### PR TITLE
Throttle stack scrolls

### DIFF
--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -46,7 +46,7 @@ function throttle(func, wait, options) {
     };
 
     return throttled;
-};
+}
 
 
 function unthrottledScroll(element, images) {
@@ -66,4 +66,4 @@ function unthrottledScroll(element, images) {
   scrollToIndex(element, newImageIdIndex);
 }
 
-export default = throttle(unthrottledScroll, 25);
+export default throttle(unthrottledScroll, 25);

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -66,4 +66,4 @@ function unthrottledScroll(element, images) {
   scrollToIndex(element, newImageIdIndex);
 }
 
-export default = throttle(unthrottledScroll, 50);
+export default = throttle(unthrottledScroll, 25);

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -1,7 +1,55 @@
 import scrollToIndex from './scrollToIndex.js';
 import { getToolState } from '../stateManagement/toolState.js';
 
-export default function (element, images) {
+// taken for underscore.js (https://github.com/jashkenas/underscore/blob/master/underscore.js#L830)
+// Returns a function, that, when invoked, will only be triggered at most once
+// during a given window of time. Normally, the throttled function will run
+// as much as it can, without ever going more than once per `wait` duration;
+// but if you'd like to disable the execution on the leading edge, pass
+// `{leading: false}`. To disable execution on the trailing edge, ditto.
+function throttle(func, wait, options) {
+    var timeout, context, args, result;
+    var previous = 0;
+    if (!options) options = {};
+
+    var later = function() {
+      previous = options.leading === false ? 0 : _.now();
+      timeout = null;
+      result = func.apply(context, args);
+      if (!timeout) context = args = null;
+    };
+
+    var throttled = function() {
+      var now = Date.now();
+      if (!previous && options.leading === false) previous = now;
+      var remaining = wait - (now - previous);
+      context = this;
+      args = arguments;
+      if (remaining <= 0 || remaining > wait) {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+        previous = now;
+        result = func.apply(context, args);
+        if (!timeout) context = args = null;
+      } else if (!timeout && options.trailing !== false) {
+        timeout = setTimeout(later, remaining);
+      }
+      return result;
+    };
+
+    throttled.cancel = function() {
+      clearTimeout(timeout);
+      previous = 0;
+      timeout = context = args = null;
+    };
+
+    return throttled;
+};
+
+
+function unthrottledScroll(element, images) {
   const toolData = getToolState(element, 'stack');
 
   if (!toolData || !toolData.data || !toolData.data.length) {
@@ -17,3 +65,5 @@ export default function (element, images) {
 
   scrollToIndex(element, newImageIdIndex);
 }
+
+export default = throttle(unthrottledScroll, 50);

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -13,14 +13,14 @@ function throttle(func, wait, options) {
     if (!options) options = {};
 
     var later = function() {
-      previous = options.leading === false ? 0 : _.now();
+      previous = options.leading === false ? 0 : new Date().getTime();
       timeout = null;
       result = func.apply(context, args);
       if (!timeout) context = args = null;
     };
 
     var throttled = function() {
-      var now = Date.now();
+      var now = new Date().getTime();
       if (!previous && options.leading === false) previous = now;
       var remaining = wait - (now - previous);
       context = this;


### PR DESCRIPTION
Using underscore's throttle function, stack scrolls are throttled so that there is no more than one scroll every 50ms. This prevents too many load requests when the user scrolls the stack.

A better solution would be to throttle only when the images are not in the cache but I am not sure how to fit that into the existing framework.