### PR TITLE
sensitivityFactor

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -50,7 +50,7 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
+function pointNearTool(element, data, coords, distance) {
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),
     end: cornerstone.pixelToCanvas(element, data.handles.end)
@@ -58,7 +58,7 @@ function pointNearTool (element, data, coords) {
 
   let distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
-  if (distanceToPoint < 5) {
+  if (distanceToPoint < distance) {
     return true;
   }
 
@@ -67,7 +67,7 @@ function pointNearTool (element, data, coords) {
 
   distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
-  return (distanceToPoint < 5);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -163,14 +163,14 @@ function onImageRendered (e, eventData) {
 const angle = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
 const angleTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -123,7 +123,7 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
+function pointNearTool(element, data, coords, distance) {
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),
     end: cornerstone.pixelToCanvas(element, data.handles.end)
@@ -132,7 +132,7 @@ function pointNearTool (element, data, coords) {
   const distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
 
-  return (distanceToPoint < 25);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -455,7 +455,7 @@ const arrowAnnotate = mouseButtonTool({
   addNewMeasurement,
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType,
   mouseDoubleClickCallback: doubleClickCallback
 });
@@ -466,7 +466,7 @@ const arrowAnnotateTouch = touchTool({
   addNewMeasurement: addNewMeasurementTouch,
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * touchTool().getConfiguration().sensitivityFactor),
   toolType,
   pressCallback
 });

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -50,7 +50,7 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 // /////// BEGIN IMAGE RENDERING ///////
-function pointNearEllipse (element, data, coords, distance) {
+function pointNearTool(element, data, coords, distance) {
   const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
@@ -76,14 +76,6 @@ function pointNearEllipse (element, data, coords, distance) {
   }
 
   return false;
-}
-
-function pointNearTool (element, data, coords) {
-  return pointNearEllipse(element, data, coords, 15);
-}
-
-function pointNearToolTouch (element, data, coords) {
-  return pointNearEllipse(element, data, coords, 25);
 }
 
 function numberWithCommas (x) {
@@ -398,14 +390,14 @@ function onImageRendered (e, eventData) {
 const ellipticalRoi = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 15 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
 const ellipticalRoiTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool: pointNearToolTouch,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -62,7 +62,7 @@ function pointInsideRect (element, data, coords) {
   return insideBox;
 }
 
-function pointNearTool (element, data, coords) {
+function pointNearTool (element, data, coords, distance) {
   const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
@@ -76,7 +76,7 @@ function pointNearTool (element, data, coords) {
   const distanceToPoint = cornerstoneMath.rect.distanceToPoint(rect, coords);
 
 
-  return (distanceToPoint < 5);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -155,7 +155,7 @@ const preventHandleOutsideImage = true;
 const highlight = mouseButtonRectangleTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * mouseButtonTool().getConfiguration().sensitivityFactor),
   pointInsideRect,
   toolType
 }, preventHandleOutsideImage);
@@ -163,7 +163,7 @@ const highlight = mouseButtonRectangleTool({
 const highlightTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * touchTool().getConfiguration().sensitivityFactor),
   pointInsideRect,
   toolType
 }, preventHandleOutsideImage);

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -44,7 +44,7 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
+function pointNearTool (element, data, coords, distance) {
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),
     end: cornerstone.pixelToCanvas(element, data.handles.end)
@@ -52,7 +52,7 @@ function pointNearTool (element, data, coords) {
   const distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
 
-  return (distanceToPoint < 25);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -220,14 +220,14 @@ function onImageRendered (e, eventData) {
 const length = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
 const lengthTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -10,7 +10,11 @@ import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 
-export default function (mouseToolInterface) {
+let globalConfiguration = {
+  sensitivityFactor: 1.0
+};
+
+function mouseButtonTool(mouseToolInterface) {
   let configuration = {};
 
     // /////// BEGIN ACTIVE TOOL ///////
@@ -301,12 +305,14 @@ export default function (mouseToolInterface) {
     cornerstone.updateImage(element);
   }
 
-  function getConfiguration () {
-    return configuration;
+  function getConfiguration() {
+    return Object.assign(configuration, globalConfiguration);
   }
 
-  function setConfiguration (config) {
-    configuration = config;
+  function setConfiguration(config) {
+    for (const p in config) {
+      if (globalConfiguration[p]) globalConfiguration[p] = config[p]; else configuration[p] = config[p];
+    }
   }
 
   const toolInterface = {
@@ -322,17 +328,19 @@ export default function (mouseToolInterface) {
   };
 
     // Expose pointNearTool if available
-  if (mouseToolInterface.pointNearTool) {
+  if (mouseToolInterface && mouseToolInterface.pointNearTool) {
     toolInterface.pointNearTool = mouseToolInterface.pointNearTool;
   }
 
-  if (mouseToolInterface.mouseDoubleClickCallback) {
+  if (mouseToolInterface && mouseToolInterface.mouseDoubleClickCallback) {
     toolInterface.mouseDoubleClickCallback = mouseToolInterface.mouseDoubleClickCallback;
   }
 
-  if (mouseToolInterface.addNewMeasurement) {
+  if (mouseToolInterface && mouseToolInterface.addNewMeasurement) {
     toolInterface.addNewMeasurement = mouseToolInterface.addNewMeasurement;
   }
 
   return toolInterface;
 }
+
+export default mouseButtonTool;

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -306,7 +306,10 @@ function mouseButtonTool(mouseToolInterface) {
   }
 
   function getConfiguration() {
-    return Object.assign(configuration, globalConfiguration);
+    let res = {};
+    Object.assign(res, globalConfiguration);
+    Object.assign(res, configuration);
+    return res;
   }
 
   function setConfiguration(config) {

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -34,11 +34,11 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 // /////// BEGIN IMAGE RENDERING ///////
-function pointNearTool (element, data, coords) {
-  const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
+function pointNearTool (element, data, coords, distance) {
+	const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
 
-  return cornerstoneMath.point.distance(endCanvas, coords) < 5;
+ return cornerstoneMath.point.distance(endCanvas, coords) < distance;
 }
 
 function onImageRendered (e, eventData) {
@@ -122,14 +122,14 @@ function onImageRendered (e, eventData) {
 const probe = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
 const probeTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -46,8 +46,8 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
-  const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
+function pointNearTool (element, data, coords, distance) {
+	const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
   const rect = {
@@ -60,7 +60,7 @@ function pointNearTool (element, data, coords) {
   const distanceToPoint = cornerstoneMath.rect.distanceToPoint(rect, coords);
 
 
-  return (distanceToPoint < 5);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -414,14 +414,14 @@ function onImageRendered (e, eventData) {
 const rectangleRoi = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
 const rectangleRoiTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 5 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -18,6 +18,9 @@ import { addToolState, removeToolState, getToolState } from '../stateManagement/
 
 const toolType = 'seedAnnotate';
 
+const mousePointNearDistance = 25 * mouseButtonTool().getConfiguration().sensitivityFactor;
+const touchNearDistance = 25 * touchTool().getConfiguration().sensitivityFactor;
+
 // Define a callback to get your text annotation
 // This could be used, e.g. to open a modal
 function getTextCallback (doneGetTextCallback) {
@@ -103,7 +106,7 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
+function pointNearTool (element, data, coords, distance) {
   if (!data.handles.end) {
     return;
   }
@@ -112,7 +115,7 @@ function pointNearTool (element, data, coords) {
   const distanceToPoint = cornerstoneMath.point.distance(realCoords, coords);
 
 
-  return (distanceToPoint < 25);
+  return (distanceToPoint < distance);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////
@@ -332,7 +335,7 @@ function doubleClickCallback (e, eventData) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (pointNearTool(element, data, coords) ||
+    if (pointNearTool(element, data, coords, mousePointNearDistance) ||
             pointInsideBoundingBox(data.handles.textBox, coords)) {
 
       data.active = true;
@@ -398,7 +401,7 @@ function pressCallback (e, eventData) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (pointNearTool(element, data, coords) ||
+    if (pointNearTool(element, data, coords, touchNearDistance) ||
           pointInsideBoundingBox(data.handles.textBox, coords)) {
       data.active = true;
       cornerstone.updateImage(element);
@@ -423,7 +426,7 @@ const seedAnnotate = mouseButtonTool({
   addNewMeasurement,
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, mousePointNearDistance),
   toolType,
   mouseDoubleClickCallback: doubleClickCallback
 });
@@ -434,7 +437,7 @@ const seedAnnotateTouch = touchTool({
   addNewMeasurement: addNewMeasurementTouch,
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, touchNearDistance),
   toolType,
   pressCallback
 });

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -57,7 +57,7 @@ function createNewMeasurement (mouseEventData) {
 }
 // /////// END ACTIVE TOOL ///////
 
-function pointNearTool (element, data, coords) {
+function pointNearTool (element, data, coords, distance) {
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),
     end: cornerstone.pixelToCanvas(element, data.handles.middle)
@@ -65,7 +65,7 @@ function pointNearTool (element, data, coords) {
 
   let distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
-  if (distanceToPoint < 25) {
+  if (distanceToPoint < distance) {
     return true;
   }
 
@@ -74,7 +74,7 @@ function pointNearTool (element, data, coords) {
 
   distanceToPoint = cornerstoneMath.lineSegment.distanceToPoint(lineSegment, coords);
 
-  return (distanceToPoint < 25);
+  return (distanceToPoint < distance);
 }
 
 function length (vector) {
@@ -376,7 +376,7 @@ const simpleAngle = mouseButtonTool({
   createNewMeasurement,
   addNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * mouseButtonTool().getConfiguration().sensitivityFactor),
   toolType
 });
 
@@ -384,7 +384,7 @@ const simpleAngleTouch = touchTool({
   createNewMeasurement,
   addNewMeasurement: addNewMeasurementTouch,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, 25 * touchTool().getConfiguration().sensitivityFactor),
   toolType
 });
 

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -11,6 +11,9 @@ import { removeToolState, getToolState } from '../stateManagement/toolState.js';
 
 const toolType = 'textMarker';
 
+const mousePointNearDistance = 10 * mouseButtonTool().getConfiguration().sensitivityFactor;
+const touchPointNearDistance = 10 * touchTool().getConfiguration().sensitivityFactor;
+
 // /////// BEGIN ACTIVE TOOL ///////
 function createNewMeasurement (mouseEventData) {
   const config = textMarker.getConfiguration();
@@ -79,7 +82,7 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 // /////// BEGIN IMAGE RENDERING ///////
-function pointNearTool (element, data, coords) {
+function pointNearTool (element, data, coords, distance) {
   if (!data.handles.end.boundingBox) {
     return;
   }
@@ -88,7 +91,7 @@ function pointNearTool (element, data, coords) {
   const insideBoundingBox = pointInsideBoundingBox(data.handles.end, coords);
 
 
-  return (distanceToPoint < 10) || insideBoundingBox;
+  return (distanceToPoint < distance) || insideBoundingBox;
 }
 
 function onImageRendered (e, eventData) {
@@ -186,7 +189,7 @@ function doubleClickCallback (e, eventData) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (pointNearTool(element, data, coords)) {
+    if (pointNearTool(element, data, coords, mousePointNearDistance)) {
       data.active = true;
       cornerstone.updateImage(element);
 
@@ -257,7 +260,7 @@ function touchPressCallback (e, eventData) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (pointNearTool(element, data, coords)) {
+    if (pointNearTool(element, data, coords, touchPointNearDistance)) {
       data.active = true;
       cornerstone.updateImage(element);
 
@@ -281,7 +284,7 @@ function touchPressCallback (e, eventData) {
 const textMarker = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, mousePointNearDistance),
   toolType,
   mouseDoubleClickCallback: doubleClickCallback
 });
@@ -289,7 +292,7 @@ const textMarker = mouseButtonTool({
 const textMarkerTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
-  pointNearTool,
+  pointNearTool: (element, data, coords) => pointNearTool(element, data, coords, touchPointNearDistance),
   toolType,
   pressCallback: touchPressCallback
 });

--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -7,6 +7,10 @@ import moveNewHandleTouch from '../manipulators/moveNewHandleTouch.js';
 import touchMoveAllHandles from '../manipulators/touchMoveAllHandles.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 
+let globalConfiguration = {
+  sensitivityFactor: 1.0
+};
+
 function deactivateAllHandles (handles) {
   Object.keys(handles).forEach(function (name) {
     const handle = handles[name];
@@ -33,6 +37,8 @@ function deactivateAllToolInstances (toolData) {
 }
 
 function touchTool (touchToolInterface) {
+  let configuration = {};
+
     // /////// BEGIN ACTIVE TOOL ///////
 
   function addNewMeasurement (touchEventData) {
@@ -351,30 +357,42 @@ function touchTool (touchToolInterface) {
     cornerstone.updateImage(element);
   }
 
-  const toolInterface = {
+  function getConfiguration() {
+    return Object.assign(configuration, globalConfiguration);
+  }
+
+  function setConfiguration(config) {
+    for (const p in config) {
+      if (globalConfiguration[p]) globalConfiguration[p] = config[p]; else configuration[p] = config[p];
+    }
+  }
+
+	const toolInterface = {
     enable,
     disable,
     activate,
     deactivate,
-    touchStartCallback: touchToolInterface.touchStartCallback || touchStartCallback,
-    touchDownActivateCallback: touchToolInterface.touchDownActivateCallback || touchDownActivateCallback,
-    tapCallback: touchToolInterface.tapCallback || tapCallback
+    getConfiguration,
+    setConfiguration,
+		touchStartCallback: (touchToolInterface && touchToolInterface.touchStartCallback) || touchStartCallback,
+		touchDownActivateCallback: (touchToolInterface && touchToolInterface.touchDownActivateCallback) || touchDownActivateCallback,
+		tapCallback: (touchToolInterface && touchToolInterface.tapCallback) || tapCallback
   };
 
     // Expose pointNearTool if available
-  if (touchToolInterface.pointNearTool) {
+	if (touchToolInterface && touchToolInterface.pointNearTool) {
     toolInterface.pointNearTool = touchToolInterface.pointNearTool;
   }
 
-  if (touchToolInterface.doubleTapCallback) {
+	if (touchToolInterface && touchToolInterface.doubleTapCallback) {
     toolInterface.doubleTapCallback = touchToolInterface.doubleTapCallback;
   }
 
-  if (touchToolInterface.pressCallback) {
+	if (touchToolInterface && touchToolInterface.pressCallback) {
     toolInterface.pressCallback = touchToolInterface.pressCallback;
   }
 
-  if (touchToolInterface.addNewMeasurement) {
+	if (touchToolInterface && touchToolInterface.addNewMeasurement) {
     toolInterface.addNewMeasurement = touchToolInterface.addNewMeasurement;
   }
 

--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -358,7 +358,10 @@ function touchTool (touchToolInterface) {
   }
 
   function getConfiguration() {
-    return Object.assign(configuration, globalConfiguration);
+    let res = {};
+    Object.assign(res, globalConfiguration);
+    Object.assign(res, configuration);
+    return res;
   }
 
   function setConfiguration(config) {


### PR DESCRIPTION
The point of this PR is accessibility. It add a 'sensitivityFactor' global configuration to touchTool and mouseButtonTool (default to 1.0) which is multiplied to the distance before being used in the pointNearTools of all tools.

This allows a single point of change to make the tools less/more sensitive to touch/mouse:

// make all tools a bit more sensitive to mouse movement/clicks (need to be nearer to select etc):
cornerstoneTools.mouseButtonTool().setConfiguration({ sensitivityFactor: 0.7 });

// make all tools a bit more sensitive to touch (need to be nearer to select etc):
cornerstoneTools.touchTool().setConfiguration({ sensitivityFactor: 0.7 });

// make all tools a bit less sensitive to mouse movement/clicks (can be further to select etc):
cornerstoneTools.mouseButtonTool().setConfiguration({ sensitivityFactor: 1.3 });

// make all tools a bit less sensitive to touch (can be further to select etc):
cornerstoneTools.touchTool().setConfiguration({ sensitivityFactor: 1.3 });

In addition:

-  mouseButtonTool.getConfiguration and touchTool.getConfiguration now return both local and global configuration object 
- mouseButtonTool.setConfiguration and touchTool.setConfiguration now override both local and global configurations with those given (instead of erasing any existing configuration).

