### PR TITLE
Add configuration and functional option to scroll a stack without skipping images

### DIFF
--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -47,12 +47,9 @@ function mouseWheelCallback (e) {
   let loop = false;
   let allowSkipping = true;
 
-  if (config && config.loop) {
-    loop = config.loop;
-  }
-
-  if (config && config.allowSkipping !== undefined) {
-    allowSkipping = config.allowSkipping;
+  if (config) {
+    loop = config.loop !== undefined ? config.loop : false;
+    allowSkipping = config.allowSkipping !== undefined ? || true;
   }
 
   scroll(eventData.element, images, loop, allowSkipping);

--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -45,12 +45,17 @@ function mouseWheelCallback (e) {
   const config = stackScroll.getConfiguration();
 
   let loop = false;
+  let allowSkipping = true;
 
   if (config && config.loop) {
     loop = config.loop;
   }
 
-  scroll(eventData.element, images, loop);
+  if (config && config.allowSkipping !== undefined) {
+    allowSkipping = config.allowSkipping;
+  }
+
+  scroll(eventData.element, images, loop, allowSkipping);
 }
 
 function dragCallback (e) {
@@ -67,6 +72,12 @@ function dragCallback (e) {
 
   const config = stackScroll.getConfiguration();
 
+  let allowSkipping = true;
+
+  if (config && config.allowSkipping !== undefined) {
+    allowSkipping = config.allowSkipping;
+  }
+
   // The Math.max here makes it easier to mouseDrag-scroll small or really large image stacks
   let pixelsPerImage = Math.max(2, element.offsetHeight / Math.max(stackData.imageIds.length, 8));
 
@@ -82,7 +93,7 @@ function dragCallback (e) {
   if (Math.abs(deltaY) >= pixelsPerImage) {
     const imageIdIndexOffset = Math.round(deltaY / pixelsPerImage);
 
-    scroll(element, imageIdIndexOffset);
+    scroll(element, imageIdIndexOffset, false, allowSkipping);
 
     options.deltaY = deltaY % pixelsPerImage;
   } else {

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -1,7 +1,37 @@
 import scrollToIndex from './scrollToIndex.js';
 import { getToolState } from '../stateManagement/toolState.js';
 
-export default function (element, images, loop = false) {
+function scrollWithoutSkipping (stackData, pendingEvent, element) {
+  if (stackData.pending[0] === pendingEvent) {
+    if (stackData.currentImageIdIndex === pendingEvent.index) {
+      stackData.pending.splice(stackData.pending.indexOf(pendingEvent), 1);
+
+      if (stackData.pending.length > 0) {
+        scrollWithoutSkipping(stackData, stackData.pending[0], element);
+      }
+
+      return;
+    }
+
+    element.addEventListener('cornerstonenewimage', function(event) {
+      const listener = this;
+      const index = stackData.imageIds.indexOf(event.detail.image.imageId);
+
+      if (index === pendingEvent.index) {
+        stackData.pending.splice(stackData.pending.indexOf(pendingEvent), 1);
+        element.removeEventListener('cornerstonenewimage', listener);
+
+        if (stackData.pending.length > 0) {
+          scrollWithoutSkipping(stackData, stackData.pending[0], element);
+        }
+      }
+    });
+
+    scrollToIndex(element, pendingEvent.index);
+  }
+}
+
+export default function (element, images, loop = false, allowSkipping = true) {
   const toolData = getToolState(element, 'stack');
 
   if (!toolData || !toolData.data || !toolData.data.length) {
@@ -9,6 +39,10 @@ export default function (element, images, loop = false) {
   }
 
   const stackData = toolData.data[0];
+
+  if (!stackData.pending) {
+    stackData.pending = [];
+  }
 
   let newImageIdIndex = stackData.currentImageIdIndex + images;
 
@@ -21,5 +55,14 @@ export default function (element, images, loop = false) {
     newImageIdIndex = Math.max(0, newImageIdIndex);
   }
 
-  scrollToIndex(element, newImageIdIndex);
+  if (allowSkipping) {
+    scrollToIndex(element, newImageIdIndex);
+  } else {
+    const pendingEvent = {
+      index : newImageIdIndex
+    };
+
+    stackData.pending.push(pendingEvent);
+    scrollWithoutSkipping(stackData, pendingEvent, element);
+  }
 }


### PR DESCRIPTION
I wanted a way to consume scroll events and prevent the stack state from progressing to the next index until the currently request index had been drawn. I *think* this covers that.