### PR TITLE
Bug when activating stackScroll before stackScrollTouchDrag at the same time. #338

### DIFF
--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -9,6 +9,7 @@ import { getToolState } from '../stateManagement/toolState.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 
 const toolType = 'stackScroll';
+const toolTypeTouchDrag = 'stackScrollTouchDrag';
 
 function mouseUpCallback (e) {
   const eventData = e.detail;
@@ -112,7 +113,7 @@ const options = {
     deltaY: 0
   }
 };
-const stackScrollTouchDrag = touchDragTool(dragCallback, toolType, options);
+const stackScrollTouchDrag = touchDragTool(dragCallback, toolTypeTouchDrag, options);
 
 function multiTouchDragCallback (e) {
   const eventData = e.detail;


### PR DESCRIPTION
Fix for Issue #338.

Both _stackScroll_  & _stackScrollTouchDrag_ were using the same _toolName_ for setting _options_. 
This was creating a condition of _options_ being overridden. 
