### PR TITLE
Added invert option to zoom with mouse drag

### DIFF
--- a/src/imageTools/zoom.js
+++ b/src/imageTools/zoom.js
@@ -234,7 +234,14 @@ function dragCallback (e) {
     return false;
   }
 
-  const ticks = eventData.deltaPoints.page.y / 100;
+  let ticks = eventData.deltaPoints.page.y / 100;
+
+  // Allow inversion of the mouse drag scroll via a configuration option
+  const config = zoom.getConfiguration();
+
+  if (config && config.invert) {
+    ticks *= -1;
+  }
 
   zoom.strategy(eventData, ticks);
 


### PR DESCRIPTION
Small change to address #296. 

Now inverting the config changes how zoom behaves on mouse drag events, in addition to mouse wheel events.