### PR TITLE
Add in viewport provider for stack navigation

### DIFF
--- a/src/util/scrollToIndex.js
+++ b/src/util/scrollToIndex.js
@@ -40,11 +40,13 @@ export default function (element, newImageIdIndex) {
       return;
     }
 
+    let enabledElement;
+
     // Check if the element is still enabled in Cornerstone,
     // If an error is thrown, stop here.
     try {
       // TODO: Add 'isElementEnabled' to Cornerstone?
-      cornerstone.getEnabledElement(element);
+      enabledElement = cornerstone.getEnabledElement(element);
     } catch(error) {
       return;
     }
@@ -53,7 +55,9 @@ export default function (element, newImageIdIndex) {
       stackRenderer.currentImageIdIndex = newImageIdIndex;
       stackRenderer.render(element, toolData.data);
     } else {
-      cornerstone.displayImage(element, image);
+      const viewportProvider = getToolState(element, 'viewportProvider');
+      const viewport = viewportProvider && viewportProvider.data && viewportProvider.data.length > 0 ? viewportProvider.data[0].getViewport(enabledElement, image, stackData) : undefined;
+      cornerstone.displayImage(element, image, viewport);
     }
 
     if (endLoadingHandler) {


### PR DESCRIPTION
**Feature**

I wanted a way to have a factory or service manage what viewports are used for display of a set of images, so that changes can be remembered within a session or presentation states can be applied at display time, and I wanted the tooling to respect that as well, and this seemed like the easiest way to do that. 

```
const viewportProvider = {
    getViewport : function(enabledElement, image, stackData) {
      //return viewport....
    }
};

// set the stack as tool state
cornerstoneTools.addStackStateManager(element, ['stack', 'viewportProvider']);
cornerstoneTools.addToolState(element, 'stack', stack);
cornerstoneTools.addToolState(element, 'viewportProvider', viewportProvider);
```

Currently `cornerstone.displayImage` is simply called with no viewport so a default one is created by cornerstone. The code as is should not break anything as if no viewport provider is registered, the `displayImage` method is called with the same parameters s before. 