### PR TITLE
Fix freehand edit first point

### DIFF
--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -170,13 +170,12 @@ function mouseMoveCallback (e) {
     data.highlight = true;
     data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
     data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
-    if (currentHandle) {
-      const lastLineIndex = data.handles[currentHandle - 1].lines.length - 1;
-      const lastLine = data.handles[currentHandle - 1].lines[lastLineIndex];
+    const neighbourIndex = currentHandle === 0 ? data.handles.length - 1 : currentHandle - 1;
+    const lastLineIndex = data.handles[neighbourIndex].lines.length - 1;
+    const lastLine = data.handles[neighbourIndex].lines[lastLineIndex];
 
-      lastLine.x = config.mouseLocation.handles.start.x;
-      lastLine.y = config.mouseLocation.handles.start.y;
-    }
+    lastLine.x = config.mouseLocation.handles.start.x;
+    lastLine.y = config.mouseLocation.handles.start.y;
   }
 
   if (config.freehand) {


### PR DESCRIPTION
This is a bug fix on freehand tool. 

**Issue:** 
Once the user modify the first point in the ***, the line between the first and the second element stays stuck in the first position. 

**Root cause:** 
After modifying the first point, we were trying to update the line in the point-index decremented by 1, but as the first its 0, we should be updating the last in the sequence instead. 

**Fix:** 
Once we update the line, we verify if the currentHandle (point index) is 0, and if it is, we use the last in the sequence instead. 

**Notes:** 
The author removed the if condition we had to check the currentHandler, I kept this because I don't see any part in the code that we remove it and its part of the default value of the configuration object. 

**Tests:** 
I have done tests on Chrome65 and it was working fine for both Freehand draw and the polygon draw.