### PR TITLE
Free hand improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,15 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [2.1.1] - 2018-03-21
+### Added
+- Added general area calculation for irregular polygons of N sides. (thanks @JamesAPetts)
+- Added textbox to show data from the area of the polygons of N sides, it does not affect 'pencil' mode (thanks @JamesAPetts)
+- The textbox-polygon tether snaps to nearest node of the polygon when moved.(thanks @JamesAPetts)
+
 ### Changed
-Overhauled and expanded the functionality of the freehandROI tool:
-- Added general area calculation for irregular polygons of N sides.
-- Finds pixels inside the freehand polygon by means of an even-odd rule algorithm, and calculates the mean and stdev based on the pixels found.
-- Displays these stats in a textbox in a similar fashion to the rectangular and ellipsoidal ROI tools. The text box is disabled for the shift-click 'pencil' mode.
-- Disallows the user to join up to any previous point besides the starting node (i.e. shape must be complete before tool deactivates).
-- Disallows the user to cross lines (using a orientation algorithm).
-- Fixed a UI bug, where upon editing the first node the line connecting the first and last nodes would not reactively update.
-- The textbox-polygon tether snaps to nearest node of the polygon when moved.
+- Disallows the user to join up to any previous point besides the starting node (i.e. shape must be complete before tool deactivates). (thanks @JamesAPetts)
+- Disallows the user to cross lines (using a orientation algorithm).(thanks @JamesAPetts)
+
+### Fixed
+- Fixed a UI bug, where upon editing the first node the line connecting the first and last nodes would not reactively update.(thanks @JamesAPetts)
 
 
 ## [2.1.0] - 2018-03-02

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2018-03-21
+### Changed
+Overhauled and expanded the functionality of the freehandROI tool:
+- Added general area calculation for irregular polygons of N sides.
+- Finds pixels inside the freehand polygon by means of an even-odd rule algorithm, and calculates the mean and stdev based on the pixels found.
+- Displays these stats in a textbox in a similar fashion to the rectangular and ellipsoidal ROI tools. The text box is disabled for the shift-click 'pencil' mode.
+- Disallows the user to join up to any previous point besides the starting node (i.e. shape must be complete before tool deactivates).
+- Disallows the user to cross lines (using a orientation algorithm).
+- Fixed a UI bug, where upon editing the first node the line connecting the first and last nodes would not reactively update.
+- The textbox-polygon tether snaps to nearest node of the polygon when moved.
+
+
 ## [2.1.0] - 2018-03-02
 ### Added
 - Added configuration and functional option to scroll a stack without skipping images (thanks @jdnarvaez)

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -348,10 +348,18 @@ function mouseHover (eventData, toolData) {
       imageNeedsUpdate = true;
     }
 
-    if ((pointNearHandleAllTools(eventData) && !data.active) || (!pointNearHandleAllTools(eventData) && data.active)) {
-      data.active = !data.active;
-      data.highlight = !data.highlight;
-      imageNeedsUpdate = true;
+    let isPointNearHandle = pointNearHandle(eventData, i);
+
+    if (isPointNearHandle === 0) {
+      // JPETTS - if returns index 0, set true as otherwise shows up falsy for condition bellow.
+      isPointNearHandle = true;
+    }
+
+    if ((isPointNearHandle && !data.active) || (!isPointNearHandle && data.active)) {
+      if (!data.lockedForEditing) {
+        data.active = !data.active;
+        imageNeedsUpdate = true;
+      }
     }
 
     if (data.textBox === true) {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -3,6 +3,13 @@ import external from '../externalModules.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
+import drawTextBox from '../util/drawTextBox.js';
+import handleActivator from '../manipulators/handleActivator.js';
+import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
+import freeHandArea from '../util/freeHandArea.js';
+import calculateFreehandStatistics from '../util/calculateFreehandStatistics.js';
+import { freeHandIntersect, freeHandIntersectEnd, freeHandIntersectModify } from '../util/freeHandIntersect.js';
+import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
@@ -19,9 +26,32 @@ let configuration = {
   },
   freehand: false,
   modifying: false,
+  movingTextBox: false,
   currentHandle: 0,
   currentTool: -1
 };
+
+function createNewMeasurement () {
+  // Create the measurement data for this tool
+  const measurementData = {
+    visible: true,
+    active: true,
+    invalidated: true,
+    handles: []
+  };
+
+  measurementData.handles.textBox = {
+    active: false,
+    hasMoved: false,
+    freehand: false,
+    movesIndependently: false,
+    drawnIndependently: true,
+    allowedOutsideImage: true,
+    hasBoundingBox: true
+  };
+
+  return measurementData;
+}
 
 // /////// BEGIN ACTIVE TOOL ///////
 function addPoint (eventData) {
@@ -47,8 +77,12 @@ function addPoint (eventData) {
 
     // If this is not the first handle
   if (data.handles.length) {
-    // Add the line from the current handle to the new handle
-    data.handles[config.currentHandle - 1].lines.push(eventData.currentPoints.image);
+    if (isValidNode(handleData, data.handles)) {
+      // Add the line from the current handle to the new handle
+      data.handles[config.currentHandle - 1].lines.push(eventData.currentPoints.image);
+    } else {
+      return false;
+    }
   }
 
   // Add the new handle
@@ -84,6 +118,13 @@ function pointNearHandle (eventData, toolIndex) {
 
     if (external.cornerstoneMath.point.distance(handleCanvas, mousePoint) < 5) {
       return i;
+    }
+  }
+
+  // Check to see if mouse in bounding box of textbox
+  if (data.handles.textBox) {
+    if (pointInsideBoundingBox(data.handles.textBox, mousePoint)) {
+      return data.handles.textBox;
     }
   }
 
@@ -132,6 +173,18 @@ function mouseUpCallback (e) {
 
   const config = freehand.getConfiguration();
 
+  if (config.movingTextBox === true) {
+    // Place textBox
+    config.movingTextBox = false;
+    // Reset the current handle
+    toolData.data[config.currentTool].invalidated = true;
+    config.currentHandle = 0;
+    config.currentTool = -1;
+    element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+
+    return;
+  }
+
   if (!eventData.event.shiftKey) {
     config.freehand = false;
   }
@@ -148,51 +201,84 @@ function mouseMoveCallback (e) {
   }
 
   const config = freehand.getConfiguration();
+  const currentTool = config.currentTool;
 
-  const data = toolData.data[config.currentTool];
+  // Tool inactive and passively watching for mouse over
+  if (currentTool < 0) {
+    const imageNeedsUpdate = mouseHover(eventData, toolData);
 
-  // Set the mouseLocation handle
-  let x = Math.max(eventData.currentPoints.image.x, 0);
+    if (!imageNeedsUpdate) {
+      return;
+    }
 
-  x = Math.min(x, eventData.image.width);
-  config.mouseLocation.handles.start.x = x;
-
-  let y = Math.max(eventData.currentPoints.image.y, 0);
-
-  y = Math.min(y, eventData.image.height);
-  config.mouseLocation.handles.start.y = y;
-
-  const currentHandle = config.currentHandle;
-
-  if (config.modifying) {
-    // Move the handle
-    data.active = true;
-    data.highlight = true;
-    data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
-    data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
-    const neighbourIndex = currentHandle === 0 ? data.handles.length - 1 : currentHandle - 1;
-    const lastLineIndex = data.handles[neighbourIndex].lines.length - 1;
-    const lastLine = data.handles[neighbourIndex].lines[lastLineIndex];
-
-    lastLine.x = config.mouseLocation.handles.start.x;
-    lastLine.y = config.mouseLocation.handles.start.y;
-  }
-
-  if (config.freehand) {
-    data.handles[currentHandle - 1].lines.push(eventData.currentPoints.image);
   } else {
-    // No snapping in freehand mode
-    const handleNearby = pointNearHandle(eventData, config.currentTool);
+    // Tool active
+    const data = toolData.data[currentTool];
+    const currentHandle = config.currentHandle;
 
-    // If there is a handle nearby to snap to
-    // (and it's not the actual mouse handle)
-    if (handleNearby !== undefined && handleNearby < (data.handles.length - 1)) {
-      config.mouseLocation.handles.start.x = data.handles[handleNearby].x;
-      config.mouseLocation.handles.start.y = data.handles[handleNearby].y;
+    // Set the mouseLocation handle
+    getMouseLocation(eventData);
+
+    if (config.modifying) {
+      // Move the handle
+      data.active = true;
+      data.highlight = true;
+      data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
+      data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
+      const neighbourIndex = currentHandle === 0 ? data.handles.length - 1 : currentHandle - 1;
+      const lastLineIndex = data.handles[neighbourIndex].lines.length - 1;
+      const lastLine = data.handles[neighbourIndex].lines[lastLineIndex];
+
+      lastLine.x = config.mouseLocation.handles.start.x;
+      lastLine.y = config.mouseLocation.handles.start.y;
+    }
+
+    if (config.freehand) { // JPETTS - Note: currently disabled
+      data.handles[currentHandle - 1].lines.push(eventData.currentPoints.image);
+    } else {
+      // No snapping in freehand mode
+      const handleNearby = pointNearHandle(eventData, config.currentTool);
+
+      // If there is a handle nearby to snap to
+      // (and it's not the actual mouse handle)
+      if (handleNearby !== undefined && !handleNearby.hasBoundingBox && handleNearby < (data.handles.length - 1)) {
+        config.mouseLocation.handles.start.x = data.handles[handleNearby].x;
+        config.mouseLocation.handles.start.y = data.handles[handleNearby].y;
+      }
     }
   }
 
   // Force onImageRendered
+  external.cornerstone.updateImage(eventData.element);
+}
+
+function mouseDragCallback (e) {
+  const eventData = e.detail;
+  const toolData = getToolState(eventData.element, toolType);
+
+  if (!toolData) {
+    return;
+  }
+
+  const config = freehand.getConfiguration();
+  const currentTool = config.currentTool;
+
+  // Check if the tool is active
+  if (currentTool >= 0) {
+    // Set the mouseLocation handle
+    getMouseLocation(eventData);
+
+    const currentHandle = config.currentHandle;
+
+    if (config.movingTextBox) {
+      // Move the textBox
+      currentHandle.hasMoved = true;
+      currentHandle.x = config.mouseLocation.handles.start.x;
+      currentHandle.y = config.mouseLocation.handles.start.y;
+    }
+  }
+
+  // Update the image
   external.cornerstone.updateImage(eventData.element);
 }
 
@@ -202,11 +288,7 @@ function startDrawing (eventData) {
   element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
   element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
 
-  const measurementData = {
-    visible: true,
-    active: true,
-    handles: []
-  };
+  const measurementData = createNewMeasurement();
 
   const config = freehand.getConfiguration();
 
@@ -221,7 +303,6 @@ function startDrawing (eventData) {
 }
 
 function endDrawing (eventData, handleNearby) {
-  const element = eventData.element;
   const toolData = getToolState(eventData.element, toolType);
 
   if (!toolData) {
@@ -235,26 +316,69 @@ function endDrawing (eventData, handleNearby) {
   data.active = false;
   data.highlight = false;
 
-  // Connect the end of the drawing to the handle nearest to the click
+  // Connect the end node to the origin node
   if (handleNearby !== undefined) {
-    // Only save x,y params from nearby handle to prevent circular reference
-    data.handles[config.currentHandle - 1].lines.push({
-      x: data.handles[handleNearby].x,
-      y: data.handles[handleNearby].y
-    });
+    data.handles[config.currentHandle - 1].lines.push(data.handles[0]);
   }
 
   if (config.modifying) {
     config.modifying = false;
+    data.invalidated = true;
   }
 
   // Reset the current handle
   config.currentHandle = 0;
   config.currentTool = -1;
 
-  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-
   external.cornerstone.updateImage(eventData.element);
+}
+
+function isValidNode (newHandle, dataHandles) {
+  return !freeHandIntersect(newHandle, dataHandles);
+}
+
+function mouseHover (eventData, toolData) {
+  // Check if user is mousing over a point
+  let imageNeedsUpdate = false;
+
+  for (let i = 0; i < toolData.data.length; i++) {
+    // Get the cursor position in canvas coordinates
+    const coords = eventData.currentPoints.canvas;
+    const data = toolData.data[i];
+
+    if (handleActivator(eventData.element, data.handles, coords) === true) {
+      imageNeedsUpdate = true;
+    }
+
+    if ((pointNearHandleAllTools(eventData) && !data.active) || (!pointNearHandleAllTools(eventData) && data.active)) {
+      data.active = !data.active;
+      data.highlight = !data.highlight;
+      imageNeedsUpdate = true;
+    }
+
+    if (data.handles.textBox === true) {
+      if (pointInsideBoundingBox(data.handles.textBox, coords)) {
+        data.active = !data.active;
+        data.highlight = !data.highlight;
+        imageNeedsUpdate = true;
+      }
+    }
+  }
+
+  return imageNeedsUpdate;
+}
+
+function getMouseLocation (eventData) {
+  // Set the mouseLocation handle
+  const config = freehand.getConfiguration();
+  let x = Math.max(eventData.currentPoints.image.x, 0);
+  let y = Math.max(eventData.currentPoints.image.y, 0);
+
+  x = Math.min(x, eventData.image.width);
+  config.mouseLocation.handles.start.x = x;
+
+  y = Math.min(y, eventData.image.height);
+  config.mouseLocation.handles.start.y = y;
 }
 
 function mouseDownCallback (e) {
@@ -264,14 +388,15 @@ function mouseDownCallback (e) {
 
   if (isMouseButtonEnabled(eventData.which, options.mouseButtonMask)) {
     const toolData = getToolState(eventData.element, toolType);
-
     let handleNearby, toolIndex;
-
     const config = freehand.getConfiguration();
     const currentTool = config.currentTool;
 
     if (config.modifying) {
-      endDrawing(eventData);
+      // Don't allow the line being modified to intersect other lines
+      if (!freeHandIntersectModify(toolData.data[currentTool].handles, config.currentHandle)) {
+        endDrawing(eventData);
+      }
 
       return;
     }
@@ -282,6 +407,16 @@ function mouseDownCallback (e) {
       if (nearby) {
         handleNearby = nearby.handleNearby;
         toolIndex = nearby.toolIndex;
+        // This means the user clicked on the textBox
+        if (handleNearby.hasBoundingBox) {
+          element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
+          element.addEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+          config.movingTextBox = true;
+          config.currentHandle = handleNearby;
+          config.currentTool = toolIndex;
+
+          return false;
+        }
         // This means the user is trying to modify a point
         if (handleNearby !== undefined) {
           element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
@@ -296,14 +431,24 @@ function mouseDownCallback (e) {
       }
     } else if (currentTool >= 0 && toolData.data[currentTool].active) {
       handleNearby = pointNearHandle(eventData, currentTool);
-      if (handleNearby !== undefined) {
+      const lastNodeID = toolData.data[currentTool].handles.length - 1;
+
+      // Snap if click registered on origin node or on last node placed
+      if ((handleNearby === 0 || handleNearby === lastNodeID) && !freeHandIntersectEnd(toolData.data[currentTool].handles)) {
         endDrawing(eventData, handleNearby);
       } else if (eventData.event.shiftKey) {
         config.freehand = true;
-      } else {
+        toolData.data[currentTool].handles.textBox.freehand = true;
+      } else if (handleNearby === undefined) {
         addPoint(eventData);
+      } else {
+        // Do not allow user to add point to previous point if not origin node.
+        return false;
       }
     }
+
+    // JPETTS Note: removed freehand shiftclick pencil mode, as it is not
+    // Useful for accurate ROI outlining and cannot easily generalise to calculate the statistics.
 
     e.preventDefault();
     e.stopPropagation();
@@ -311,6 +456,15 @@ function mouseDownCallback (e) {
 }
 
 // /////// END ACTIVE TOOL ///////
+
+function numberWithCommas (x) {
+  // http://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
+  const parts = x.toString().split('.');
+
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return parts.join('.');
+}
 
 // /////// BEGIN IMAGE RENDERING ///////
 function onImageRendered (e) {
@@ -324,7 +478,15 @@ function onImageRendered (e) {
   }
 
   const cornerstone = external.cornerstone;
+  const image = eventData.image;
+  const element = eventData.element;
   const config = freehand.getConfiguration();
+  const seriesModule = cornerstone.metaData.get('generalSeriesModule', image.imageId);
+  let modality;
+
+  if (seriesModule) {
+    modality = seriesModule.modality;
+  }
 
   // We have tool data for this element - iterate over each one and draw it
   const context = eventData.canvasContext.canvas.getContext('2d');
@@ -371,7 +533,7 @@ function onImageRendered (e) {
         const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
 
         if (j === (data.handles.length - 1)) {
-          if (data.active && !config.freehand && !config.modifying) {
+          if (!data.polyBoundingBox) {
             // If it's still being actively drawn, keep the last line to
             // The mouse location
             context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
@@ -386,11 +548,238 @@ function onImageRendered (e) {
       fill: fillColor
     };
 
-    if (data.active) {
+    if (data.active && !data.polyBoundingBox) {
       drawHandles(context, eventData, config.mouseLocation.handles, color, options);
     }
     // Draw the handles
     drawHandles(context, eventData, data.handles, color, options);
+
+    // Define variables for the area and mean/standard deviation
+    let area,
+      meanStdDev,
+      meanStdDevSUV;
+
+    // Perform a check to see if the tool has been invalidated. This is to prevent
+    // Unnecessary re-calculation of the area, mean, and standard deviation if the
+    // Image is re-rendered but the tool has not moved (e.g. during a zoom)
+    if (data.invalidated === false) {
+      // If the data is not invalidated, retrieve it from the toolData
+      meanStdDev = data.meanStdDev;
+      meanStdDevSUV = data.meanStdDevSUV;
+      area = data.area;
+    } else if (!data.active) {
+      // If the data has been invalidated, and the tool is not currently active,
+      // We need to calculate it again.
+
+      // Retrieve the bounds of the ROI in image coordinates
+      const bounds = {
+        left: data.handles[0].x,
+        right: data.handles[0].x,
+        bottom: data.handles[0].y,
+        top: data.handles[0].x
+      };
+
+      for (let i = 0; i < data.handles.length; i++) {
+        bounds.left = Math.min(bounds.left, data.handles[i].x);
+        bounds.right = Math.max(bounds.right, data.handles[i].x);
+        bounds.bottom = Math.min(bounds.bottom, data.handles[i].y);
+        bounds.top = Math.max(bounds.top, data.handles[i].y);
+      }
+
+      const polyBoundingBox = {
+        left: bounds.left,
+        top: bounds.bottom,
+        width: Math.abs(bounds.right - bounds.left),
+        height: Math.abs(bounds.top - bounds.bottom)
+      };
+
+      // Store the bounding box information for the text box
+      data.polyBoundingBox = polyBoundingBox;
+
+      // First, make sure this is not a color image, since no mean / standard
+      // Deviation will be calculated for color images.
+      if (!image.color) {
+        // Retrieve the array of pixels that the ROI bounds cover
+        const pixels = cornerstone.getPixels(element, polyBoundingBox.left, polyBoundingBox.top, polyBoundingBox.width, polyBoundingBox.height);
+
+        // Calculate the mean & standard deviation from the pixels and the object shape
+        meanStdDev = calculateFreehandStatistics(pixels, polyBoundingBox, data.handles);
+
+        if (modality === 'PT') {
+          // If the image is from a PET scan, use the DICOM tags to
+          // Calculate the SUV from the mean and standard deviation.
+
+          // Note that because we are using modality pixel values from getPixels, and
+          // The calculateSUV routine also rescales to modality pixel values, we are first
+          // Returning the values to storedPixel values before calcuating SUV with them.
+          // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+          meanStdDevSUV = {
+            mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
+            stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
+          };
+        }
+
+        // If the mean and standard deviation values are sane, store them for later retrieval
+        if (meanStdDev && !isNaN(meanStdDev.mean)) {
+          data.meanStdDev = meanStdDev;
+          data.meanStdDevSUV = meanStdDevSUV;
+        }
+      }
+
+      // Retrieve the pixel spacing values, and if they are not
+      // Real non-zero values, set them to 1
+      const columnPixelSpacing = image.columnPixelSpacing || 1;
+      const rowPixelSpacing = image.rowPixelSpacing || 1;
+      const scaling = columnPixelSpacing * rowPixelSpacing;
+
+      area = freeHandArea(data.handles, scaling);
+
+      // If the area value is sane, store it for later retrieval
+      if (!isNaN(area)) {
+        data.area = area;
+      }
+
+      // Set the invalidated flag to false so that this data won't automatically be recalculated
+      data.invalidated = false;
+    }
+
+    // Define an array to store the rows of text for the textbox
+    const textLines = [];
+
+    // If the mean and standard deviation values are present, display them
+    if (meanStdDev && meanStdDev.mean !== undefined) {
+      // If the modality is CT, add HU to denote Hounsfield Units
+      let moSuffix = '';
+
+      if (modality === 'CT') {
+        moSuffix = ' HU';
+      }
+
+      // Create a line of text to display the mean and any units that were specified (i.e. HU)
+      let meanText = `Mean: ${numberWithCommas(meanStdDev.mean.toFixed(2))}${moSuffix}`;
+      // Create a line of text to display the standard deviation and any units that were specified (i.e. HU)
+      let stdDevText = `StdDev: ${numberWithCommas(meanStdDev.stdDev.toFixed(2))}${moSuffix}`;
+
+      // If this image has SUV values to display, concatenate them to the text line
+      if (meanStdDevSUV && meanStdDevSUV.mean !== undefined) {
+        const SUVtext = ' SUV: ';
+
+        meanText += SUVtext + numberWithCommas(meanStdDevSUV.mean.toFixed(2));
+        stdDevText += SUVtext + numberWithCommas(meanStdDevSUV.stdDev.toFixed(2));
+      }
+
+      // Add these text lines to the array to be displayed in the textbox
+      textLines.push(meanText);
+      textLines.push(stdDevText);
+    }
+
+    // If the area is a sane value, display it
+    if (area) {
+      // Determine the area suffix based on the pixel spacing in the image.
+      // If pixel spacing is present, use millimeters. Otherwise, use pixels.
+      // This uses Char code 178 for a superscript 2
+      let suffix = ` mm${String.fromCharCode(178)}`;
+
+      if (!image.rowPixelSpacing || !image.columnPixelSpacing) {
+        suffix = ` pixels${String.fromCharCode(178)}`;
+      }
+
+      // Create a line of text to display the area and its units
+      const areaText = `Area: ${numberWithCommas(area.toFixed(2))}${suffix}`;
+
+      // Add this text line to the array to be displayed in the textbox
+      textLines.push(areaText);
+    }
+
+    // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
+    if (data.polyBoundingBox && !data.handles.textBox.freehand) {
+      // If the textbox has not been moved by the user, it should be displayed on the right-most
+      // Side of the tool.
+      if (!data.handles.textBox.hasMoved) {
+        // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
+        // Note that this calculates it in image coordinates
+        data.handles.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
+        data.handles.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
+      }
+
+      // Convert the textbox Image coordinates into Canvas coordinates
+      const textCoords = cornerstone.pixelToCanvas(element, data.handles.textBox);
+
+      // Set options for the textbox drawing function
+      const textOptions = {
+        centering: {
+          x: false,
+          y: true
+        }
+      };
+
+      // Draw the textbox and retrieves it's bounding box for mouse-dragging and highlighting
+      const boundingBox = drawTextBox(context, textLines, textCoords.x,
+        textCoords.y, color, textOptions);
+
+      // Store the bounding box data in the handle for mouse-dragging and highlighting
+      data.handles.textBox.boundingBox = boundingBox;
+
+      // If the textbox has moved, we would like to draw a line linking it with the tool
+      // This section decides where to draw this line to on the polyBoundingBox based on the location
+      // Of the textbox relative to it.
+      if (data.handles.textBox.hasMoved) {
+        // Draw dashed link line between tool and text
+
+        // The initial link position is at the center of the
+        // Textbox.
+        const link = {
+          start: {},
+          end: {
+            x: textCoords.x,
+            y: textCoords.y
+          }
+        };
+
+        const polyNodesCanvas = [];
+
+        // Get the nodes of the ROI in canvas coordinates
+        for (let i = 0; i < data.handles.length; i++) {
+          polyNodesCanvas.push(cornerstone.pixelToCanvas(element, data.handles[i]));
+        }
+
+        // We obtain the link starting point by finding the closest point on
+        // The polyNodesCanvas to the center of the textbox
+        link.start = external.cornerstoneMath.point.findClosestPoint(polyNodesCanvas, link.end);
+
+        // Next we calculate the corners of the textbox bounding box
+        const boundingBoxPoints = [{
+          // Top middle point of bounding box
+          x: boundingBox.left + boundingBox.width / 2,
+          y: boundingBox.top
+        }, {
+          // Left middle point of bounding box
+          x: boundingBox.left,
+          y: boundingBox.top + boundingBox.height / 2
+        }, {
+          // Bottom middle point of bounding box
+          x: boundingBox.left + boundingBox.width / 2,
+          y: boundingBox.top + boundingBox.height
+        }, {
+          // Right middle point of bounding box
+          x: boundingBox.left + boundingBox.width,
+          y: boundingBox.top + boundingBox.height / 2
+        }];
+
+        // Now we recalculate the link endpoint by identifying which corner of the bounding box
+        // Is closest to the start point we just calculated.
+        link.end = external.cornerstoneMath.point.findClosestPoint(boundingBoxPoints, link.start);
+
+        // Finally we draw the dashed linking line
+        context.beginPath();
+        context.strokeStyle = color;
+        context.lineWidth = lineWidth;
+        context.setLineDash([2, 3]);
+        context.moveTo(link.start.x, link.start.y);
+        context.lineTo(link.end.x, link.end.y);
+        context.stroke();
+      }
+    }
 
     context.restore();
   }
@@ -401,6 +790,7 @@ function enable (element) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
@@ -412,6 +802,7 @@ function disable (element) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
@@ -423,6 +814,7 @@ function activate (element, mouseButtonMask) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
@@ -436,6 +828,7 @@ function deactivate (element) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -96,6 +96,17 @@ function addPoint (eventData) {
   external.cornerstone.updateImage(eventData.element);
 }
 
+function pointNearTool (eventData, toolIndex) {
+  const isPointNearTool = pointNearHandle(eventData, toolIndex);
+
+  // JPETTS - if returns index 0, set true (fails first condition as 0 is falsy).
+  if (isPointNearTool || isPointNearTool === 0) {
+    return true;
+  }
+
+  return false;
+}
+
 function pointNearHandle (eventData, toolIndex) {
   const toolData = getToolState(eventData.element, toolType);
 
@@ -348,14 +359,7 @@ function mouseHover (eventData, toolData) {
       imageNeedsUpdate = true;
     }
 
-    let isPointNearHandle = pointNearHandle(eventData, i);
-
-    if (isPointNearHandle === 0) {
-      // JPETTS - if returns index 0, set true as otherwise shows up falsy for condition bellow.
-      isPointNearHandle = true;
-    }
-
-    if ((isPointNearHandle && !data.active) || (!isPointNearHandle && data.active)) {
+    if ((pointNearTool(eventData, i) && !data.active) || (!pointNearTool(eventData, i) && data.active)) {
       if (!data.lockedForEditing) {
         data.active = !data.active;
         imageNeedsUpdate = true;

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -37,17 +37,15 @@ function createNewMeasurement () {
     visible: true,
     active: true,
     invalidated: true,
-    handles: []
-  };
-
-  measurementData.textBox = {
-    active: false,
-    hasMoved: false,
-    freehand: false,
-    movesIndependently: false,
-    drawnIndependently: true,
-    allowedOutsideImage: true,
-    hasBoundingBox: true
+    handles: [],
+    textBox: {
+      active: false,
+      hasMoved: false,
+      movesIndependently: false,
+      drawnIndependently: true,
+      allowedOutsideImage: true,
+      hasBoundingBox: true
+    }
   };
 
   return measurementData;

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -40,7 +40,7 @@ function createNewMeasurement () {
     handles: []
   };
 
-  measurementData.handles.textBox = {
+  measurementData.textBox = {
     active: false,
     hasMoved: false,
     freehand: false,
@@ -122,9 +122,9 @@ function pointNearHandle (eventData, toolIndex) {
   }
 
   // Check to see if mouse in bounding box of textbox
-  if (data.handles.textBox) {
-    if (pointInsideBoundingBox(data.handles.textBox, mousePoint)) {
-      return data.handles.textBox;
+  if (data.textBox) {
+    if (pointInsideBoundingBox(data.textBox, mousePoint)) {
+      return data.textBox;
     }
   }
 
@@ -356,8 +356,8 @@ function mouseHover (eventData, toolData) {
       imageNeedsUpdate = true;
     }
 
-    if (data.handles.textBox === true) {
-      if (pointInsideBoundingBox(data.handles.textBox, coords)) {
+    if (data.textBox === true) {
+      if (pointInsideBoundingBox(data.textBox, coords)) {
         data.active = !data.active;
         data.highlight = !data.highlight;
         imageNeedsUpdate = true;
@@ -438,7 +438,7 @@ function mouseDownCallback (e) {
         endDrawing(eventData, handleNearby);
       } else if (eventData.event.shiftKey) {
         config.freehand = true;
-        toolData.data[currentTool].handles.textBox.freehand = true;
+        toolData.data[currentTool].textBox.freehand = true;
       } else if (handleNearby === undefined) {
         addPoint(eventData);
       } else {
@@ -692,18 +692,18 @@ function onImageRendered (e) {
     }
 
     // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
-    if (data.polyBoundingBox && !data.handles.textBox.freehand) {
+    if (data.polyBoundingBox && !data.textBox.freehand) {
       // If the textbox has not been moved by the user, it should be displayed on the right-most
       // Side of the tool.
-      if (!data.handles.textBox.hasMoved) {
+      if (!data.textBox.hasMoved) {
         // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
         // Note that this calculates it in image coordinates
-        data.handles.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
-        data.handles.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
+        data.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
+        data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
       }
 
       // Convert the textbox Image coordinates into Canvas coordinates
-      const textCoords = cornerstone.pixelToCanvas(element, data.handles.textBox);
+      const textCoords = cornerstone.pixelToCanvas(element, data.textBox);
 
       // Set options for the textbox drawing function
       const textOptions = {
@@ -718,12 +718,12 @@ function onImageRendered (e) {
         textCoords.y, color, textOptions);
 
       // Store the bounding box data in the handle for mouse-dragging and highlighting
-      data.handles.textBox.boundingBox = boundingBox;
+      data.textBox.boundingBox = boundingBox;
 
       // If the textbox has moved, we would like to draw a line linking it with the tool
       // This section decides where to draw this line to on the polyBoundingBox based on the location
       // Of the textbox relative to it.
-      if (data.handles.textBox.hasMoved) {
+      if (data.textBox.hasMoved) {
         // Draw dashed link line between tool and text
 
         // The initial link position is at the center of the

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -1,0 +1,45 @@
+import pointInFreehandROI from './pointInFreehandROI.js';
+
+export default function (sp, boundingBox, dataHandles) {
+
+  let sum = 0;
+  let sumSquared = 0;
+  let count = 0;
+  let index = 0;
+
+  for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
+    for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
+      const point = {
+        x,
+        y
+      };
+
+      if (pointInFreehandROI(dataHandles, point)) {
+        sum += sp[index];
+        sumSquared += sp[index] * sp[index];
+        count++;
+      }
+
+      index++;
+    }
+  }
+
+  if (count === 0) {
+    return {
+      count,
+      mean: 0.0,
+      variance: 0.0,
+      stdDev: 0.0
+    };
+  }
+
+  const mean = sum / count;
+  const variance = sumSquared / count - mean * mean;
+
+  return {
+    count,
+    mean,
+    variance,
+    stdDev: Math.sqrt(variance)
+  };
+}

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -1,45 +1,38 @@
 import pointInFreehandROI from './pointInFreehandROI.js';
 
-export default function (sp, boundingBox, dataHandles) {
+const statisticsObj = {
+  count: 0,
+  mean: 0.0,
+  variance: 0.0,
+  stdDev: 0.0
+};
 
+export default function (sp, boundingBox, dataHandles) {
   let sum = 0;
   let sumSquared = 0;
-  let count = 0;
   let index = 0;
 
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
-      const point = {
+      if (pointInFreehandROI(dataHandles, {
         x,
         y
-      };
-
-      if (pointInFreehandROI(dataHandles, point)) {
+      })) {
         sum += sp[index];
         sumSquared += sp[index] * sp[index];
-        count++;
+        statisticsObj.count++;
       }
-
       index++;
     }
   }
 
-  if (count === 0) {
-    return {
-      count,
-      mean: 0.0,
-      variance: 0.0,
-      stdDev: 0.0
-    };
+  if (statisticsObj.count === 0) {
+    return statisticsObj;
   }
 
-  const mean = sum / count;
-  const variance = sumSquared / count - mean * mean;
+  statisticsObj.mean = sum / statisticsObj.count;
+  statisticsObj.variance = sumSquared / statisticsObj.count - statisticsObj.mean * statisticsObj.mean;
+  statisticsObj.stdDev = Math.sqrt(statisticsObj.variance);
 
-  return {
-    count,
-    mean,
-    variance,
-    stdDev: Math.sqrt(variance)
-  };
+  return statisticsObj;
 }

--- a/src/util/freeHandArea.js
+++ b/src/util/freeHandArea.js
@@ -1,0 +1,13 @@
+export default function (dataHandles, scaling) {
+  let freeHandArea = 0;
+  let j = dataHandles.length - 1; // The last vertex is the previous one to the first
+
+  scaling = scaling || 1; // If scaling is falsy, set scaling to 1
+
+  for (let i = 0; i < dataHandles.length; i++) {
+    freeHandArea += (dataHandles[j].x + dataHandles[i].x) * (dataHandles[j].y - dataHandles[i].y);
+    j = i; // Here j is previous vertex to i
+  }
+
+  return Math.abs(freeHandArea * scaling / 2.0);
+}

--- a/src/util/freeHandIntersect.js
+++ b/src/util/freeHandIntersect.js
@@ -1,0 +1,185 @@
+// JPETTS orientation algoritm to determine if two lines cross.
+// Credit and details: geeksforgeeks.org/check-if-two-given-line-segments-intersect/
+
+function freeHandIntersect (newHandle, dataHandles) {
+  // Here (p1,p2) is the new line proposed by the user.
+  const k = dataHandles.length - 1;
+  const p1 = {
+    x: dataHandles[k].x,
+    y: dataHandles[k].y
+  };
+  const q1 = {
+    x: newHandle.x,
+    y: newHandle.y
+  };
+
+  if (doesInteresctOtherLines(dataHandles, p1, q1, k)) {
+
+    return true;
+  }
+
+  return false;
+}
+
+function freeHandIntersectEnd (dataHandles) {
+  // Check if line (dataHandles.length -1, 0) intersects with other lines.
+  const k = dataHandles.length - 1;
+  const l = 0;
+  const p1 = {
+    x: dataHandles[k].x,
+    y: dataHandles[k].y
+  };
+  const q1 = {
+    x: dataHandles[l].x,
+    y: dataHandles[l].y
+  };
+
+  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
+
+    return true;
+  }
+
+  return false;
+}
+
+function freeHandIntersectModify (dataHandles, k) {
+  // Check if line (k, k-1) intersects with other lines
+  // Where k is the id of the handle being modified.
+  let l = k - 1;
+
+  // If k is first node, previous node === final node
+  if (k === 0) {
+    l = dataHandles.length - 1;
+  }
+
+  const p1 = {
+    x: dataHandles[k].x,
+    y: dataHandles[k].y
+  };
+
+  const q1 = {
+    x: dataHandles[l].x,
+    y: dataHandles[l].y
+  };
+
+  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
+
+    return true;
+  }
+
+  // Check if line (k, k+1) intersects with other lines
+  l = k + 1;
+  // If k is last node, l === first node
+  if (k === dataHandles.length - 1) {
+    l = 0;
+  }
+
+  q1.x = dataHandles[l].x;
+  q1.y = dataHandles[l].y;
+
+  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
+
+    return true;
+  }
+
+  return false;
+}
+
+
+function doesInteresctOtherLines (dataHandles, p1, q1, k, l) {
+  let j = dataHandles.length - 1;
+
+  for (let i = 0; i < dataHandles.length; i++) {
+
+    // Ignore lines with node common to subject line
+    if (i === k || j === k || i === l || j === l) {
+      j = i;
+      continue;
+    }
+
+    const p2 = {
+      x: dataHandles[j].x,
+      y: dataHandles[j].y
+    };
+    const q2 = {
+      x: dataHandles[i].x,
+      y: dataHandles[i].y
+    };
+
+    if (doesIntersect(p1, q1, p2, q2)) {
+      return true;
+    }
+
+    j = i;
+  }
+
+  return false;
+
+}
+
+function doesIntersect (p1, q1, p2, q2) {
+  // Check orientation of points in order to determine
+  // If (p1,q1) and (p2,q2) intersect
+
+  const orient = [
+    orientation(p1, q1, p2),
+    orientation(p1, q1, q2),
+    orientation(p2, q2, p1),
+    orientation(p2, q2, q1)
+  ];
+
+  // General Case
+  if (orient[0] !== orient[1] && orient[2] !== orient[3]) {
+
+    return true;
+  }
+
+  // Special Cases
+  if (orient[0] === 0 && onSegment(p1, p2, q1)) { // If p1, q1 and p2 are colinear and p2 lies on segment p1q1
+
+    return true;
+  }
+
+  if (orient[1] === 0 && onSegment(p1, q2, q1)) { // If p1, q1 and p2 are colinear and q2 lies on segment p1q1
+
+    return true;
+  }
+
+  if (orient[2] === 0 && onSegment(p2, p1, q2)) { // If p2, q2 and p1 are colinear and p1 lies on segment p2q2
+
+    return true;
+  }
+
+  if (orient[3] === 0 && onSegment(p2, q1, q2)) { // If p2, q2 and q1 are colinear and q1 lies on segment p2q2
+
+    return true;
+  }
+
+  return false;
+}
+
+function orientation (p, q, r) {
+  const orientationValue = (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+
+  if (orientationValue === 0) {
+    return 0; // Colinear
+  }
+
+  return (orientationValue > 0) ? 1 : 2; // Clockwise or anticlockwise
+}
+
+function onSegment (p, q, r) {
+
+  if (q.x <= Math.max(p.x, r.x) && q.x >= Math.min(p.x, r.x) &&
+      q.y <= Math.max(p.y, r.y) && q.y >= Math.min(p.y, r.y)) {
+    return true;
+  }
+
+  return false;
+}
+
+export {
+  freeHandIntersect,
+  freeHandIntersectEnd,
+  freeHandIntersectModify
+};

--- a/src/util/freeHandIntersect.js
+++ b/src/util/freeHandIntersect.js
@@ -2,109 +2,64 @@
 // Credit and details: geeksforgeeks.org/check-if-two-given-line-segments-intersect/
 
 function freeHandIntersect (newHandle, dataHandles) {
-  // Here (p1,p2) is the new line proposed by the user.
-  const k = dataHandles.length - 1;
-  const p1 = {
-    x: dataHandles[k].x,
-    y: dataHandles[k].y
-  };
-  const q1 = {
-    x: newHandle.x,
-    y: newHandle.y
-  };
+  // Check if the proposed line will intersect any existent line
+  const lastHandleId = dataHandles.length - 1;
+  const lastNode = getCoords(dataHandles[lastHandleId]);
+  const newNode = getCoords(newHandle);
 
-  if (doesInteresctOtherLines(dataHandles, p1, q1, k)) {
-
-    return true;
-  }
-
-  return false;
+  return doesIntersectOtherLines(dataHandles, lastNode, newNode, [lastHandleId]);
 }
 
 function freeHandIntersectEnd (dataHandles) {
-  // Check if line (dataHandles.length -1, 0) intersects with other lines.
-  const k = dataHandles.length - 1;
-  const l = 0;
-  const p1 = {
-    x: dataHandles[k].x,
-    y: dataHandles[k].y
-  };
-  const q1 = {
-    x: dataHandles[l].x,
-    y: dataHandles[l].y
-  };
+  // Check if the last line will overlap another line.
+  const lastHandleId = dataHandles.length - 1;
+  const lastNode = getCoords(dataHandles[lastHandleId]);
+  const firstNode = getCoords(dataHandles[0]);
 
-  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
-
-    return true;
-  }
-
-  return false;
+  return doesIntersectOtherLines(dataHandles, lastNode, firstNode, [lastHandleId, 0]);
 }
 
-function freeHandIntersectModify (dataHandles, k) {
-  // Check if line (k, k-1) intersects with other lines
-  // Where k is the id of the handle being modified.
-  let l = k - 1;
+function freeHandIntersectModify (dataHandles, modifiedHandleId) {
+  // Check if the modifiedHandle's previous and next lines will intersect any other line in the polygon
+  const modifiedNode = getCoords(dataHandles[modifiedHandleId]);
 
-  // If k is first node, previous node === final node
-  if (k === 0) {
-    l = dataHandles.length - 1;
+  // Previous neightbor handle
+  let neighborHandleId = modifiedHandleId - 1;
+
+  if (modifiedHandleId === 0) {
+    neighborHandleId = dataHandles.length - 1;
   }
 
-  const p1 = {
-    x: dataHandles[k].x,
-    y: dataHandles[k].y
-  };
+  let neighborNode = getCoords(dataHandles[neighborHandleId]);
 
-  const q1 = {
-    x: dataHandles[l].x,
-    y: dataHandles[l].y
-  };
-
-  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
-
+  if (doesIntersectOtherLines(dataHandles, modifiedNode, neighborNode, [modifiedHandleId, neighborHandleId])) {
     return true;
   }
 
-  // Check if line (k, k+1) intersects with other lines
-  l = k + 1;
-  // If k is last node, l === first node
-  if (k === dataHandles.length - 1) {
-    l = 0;
+  // Next neightbor handle
+  if (modifiedHandleId === dataHandles.length - 1) {
+    neighborHandleId = 0;
+  } else {
+    neighborHandleId = modifiedHandleId + 1;
   }
 
-  q1.x = dataHandles[l].x;
-  q1.y = dataHandles[l].y;
+  neighborNode = getCoords(dataHandles[neighborHandleId]);
 
-  if (doesInteresctOtherLines(dataHandles, p1, q1, k, l)) {
-
-    return true;
-  }
-
-  return false;
+  return doesIntersectOtherLines(dataHandles, modifiedNode, neighborNode, [modifiedHandleId, neighborHandleId]);
 }
 
-
-function doesInteresctOtherLines (dataHandles, p1, q1, k, l) {
+function doesIntersectOtherLines (dataHandles, p1, q1, ignoredHandleIds) {
   let j = dataHandles.length - 1;
 
   for (let i = 0; i < dataHandles.length; i++) {
 
-    // Ignore lines with node common to subject line
-    if (i === k || j === k || i === l || j === l) {
+    if (ignoredHandleIds.indexOf(i) !== -1 || ignoredHandleIds.indexOf(j) !== -1) {
       j = i;
       continue;
     }
 
-    const p2 = {
-      x: dataHandles[j].x,
-      y: dataHandles[j].y
-    };
-    const q2 = {
-      x: dataHandles[i].x,
-      y: dataHandles[i].y
-    };
+    const p2 = getCoords(dataHandles[j]);
+    const q2 = getCoords(dataHandles[i]);
 
     if (doesIntersect(p1, q1, p2, q2)) {
       return true;
@@ -120,6 +75,7 @@ function doesInteresctOtherLines (dataHandles, p1, q1, k, l) {
 function doesIntersect (p1, q1, p2, q2) {
   // Check orientation of points in order to determine
   // If (p1,q1) and (p2,q2) intersect
+  let result = false;
 
   const orient = [
     orientation(p1, q1, p2),
@@ -130,32 +86,28 @@ function doesIntersect (p1, q1, p2, q2) {
 
   // General Case
   if (orient[0] !== orient[1] && orient[2] !== orient[3]) {
-
     return true;
   }
 
   // Special Cases
   if (orient[0] === 0 && onSegment(p1, p2, q1)) { // If p1, q1 and p2 are colinear and p2 lies on segment p1q1
-
-    return true;
+    result = true;
+  } else if (orient[1] === 0 && onSegment(p1, q2, q1)) { // If p1, q1 and p2 are colinear and q2 lies on segment p1q1
+    result = true;
+  } else if (orient[2] === 0 && onSegment(p2, p1, q2)) { // If p2, q2 and p1 are colinear and p1 lies on segment p2q2
+    result = true;
+  } else if (orient[3] === 0 && onSegment(p2, q1, q2)) { // If p2, q2 and q1 are colinear and q1 lies on segment p2q2
+    result = true;
   }
 
-  if (orient[1] === 0 && onSegment(p1, q2, q1)) { // If p1, q1 and p2 are colinear and q2 lies on segment p1q1
+  return result;
+}
 
-    return true;
-  }
-
-  if (orient[2] === 0 && onSegment(p2, p1, q2)) { // If p2, q2 and p1 are colinear and p1 lies on segment p2q2
-
-    return true;
-  }
-
-  if (orient[3] === 0 && onSegment(p2, q1, q2)) { // If p2, q2 and q1 are colinear and q1 lies on segment p2q2
-
-    return true;
-  }
-
-  return false;
+function getCoords (dataHandle) {
+  return {
+    x: dataHandle.x,
+    y: dataHandle.y
+  };
 }
 
 function orientation (p, q, r) {

--- a/src/util/pointInFreehandROI.js
+++ b/src/util/pointInFreehandROI.js
@@ -1,0 +1,66 @@
+// JPETTS - Calculates if "point" is inside the polygon defined by dataHandles by
+// Counting the number of times a ray originating from "point" crosses the
+// Edges of the polygon. Odd === inside, Even === outside.
+
+function isEnclosedY (yp, y1, y2) {
+  if ((y1 < yp && yp < y2) || (y2 < yp && yp < y1)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isLineRightOfPoint (point, lp1, lp2) {
+  // If both right of point return true
+  if (lp1.x > point.x && lp2.x > point.x) {
+    return true;
+  }
+  // Put leftmost point in lp1
+  if (lp1.x > lp2.x) {
+    const lptemp = lp1;
+
+    lp1 = lp2;
+    lp2 = lptemp;
+  }
+  const lPointY = lineSegmentAtPoint(point, lp1, lp2);
+
+  // If the lp1.x and lp2.x enclose point.x check gradient of line and see if
+  // Point is above or below the line to calculate if it inside.
+  if (Math.sign(lPointY.gradient) * point.y > lPointY.value) {
+    return true;
+  }
+
+  return false;
+}
+
+function lineSegmentAtPoint (point, lp1, lp2) {
+  const dydx = (lp2.y - lp1.y) / (lp2.x - lp1.x);
+  const fx = {
+    value: lp1.x + dydx * (point.x - lp1.x),
+    gradient: dydx
+  };
+
+  return fx;
+}
+
+export default function (dataHandles, location) {
+  // The bool "inROI" flips every time ray originating from location and
+  // Pointing to the right crosses a linesegment.
+  let inROI = false;
+
+  // Cycle round pairs of points
+  let j = dataHandles.length - 1; // The last vertex is the previous one to the first
+
+  for (let i = 0; i < dataHandles.length; i++) {
+    // Check if y values of line encapsulate location.y
+    if (isEnclosedY(location.y, dataHandles[i].y, dataHandles[j].y)) {
+      if (isLineRightOfPoint(location, dataHandles[i], dataHandles[j])) {
+        inROI = !inROI;
+      }
+    }
+
+    j = i; // Here j is previous vertex to i
+  }
+
+  return inROI;
+}

--- a/src/util/pointInFreehandROI.js
+++ b/src/util/pointInFreehandROI.js
@@ -1,7 +1,3 @@
-// JPETTS - Calculates if "point" is inside the polygon defined by dataHandles by
-// Counting the number of times a ray originating from "point" crosses the
-// Edges of the polygon. Odd === inside, Even === outside.
-
 function isEnclosedY (yp, y1, y2) {
   if ((y1 < yp && yp < y2) || (y2 < yp && yp < y1)) {
     return true;
@@ -44,6 +40,10 @@ function lineSegmentAtPoint (point, lp1, lp2) {
 }
 
 export default function (dataHandles, location) {
+  // JPETTS - Calculates if "point" is inside the polygon defined by dataHandles by
+  // Counting the number of times a ray originating from "point" crosses the
+  // Edges of the polygon. Odd === inside, Even === outside.
+
   // The bool "inROI" flips every time ray originating from location and
   // Pointing to the right crosses a linesegment.
   let inROI = false;


### PR DESCRIPTION
Improvements and new functionalities

New functionalities:
- Added general area calculation for irregular polygons of N sides.
- Added textbox to show data from the area of the polygons of N sides, it does not affect 'pencil' mode 
- The textbox-polygon tether snaps to nearest node of the polygon when moved.

Improvements:
- Disallows the user to join up to any previous point besides the starting node (i.e. shape must be complete before tool deactivates).
- Disallows the user to cross lines (using a orientation algorithm).

Tests: 
All the old functionalities and the new ones are working fine.
