### PR TITLE
Set fractionalSeconds in startTime to 0 if fractionalSeconds does not exists

### DIFF
--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -41,7 +41,7 @@ function mouseDownCallback (e) {
 
 function mouseWheelCallback (e) {
   const eventData = e.detail;
-  const images = -eventData.direction;
+  const images = eventData.direction;
 
   const config = stackScroll.getConfiguration();
 

--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -41,7 +41,7 @@ function mouseDownCallback (e) {
 
 function mouseWheelCallback (e) {
   const eventData = e.detail;
-  const images = eventData.direction;
+  const images = -eventData.direction;
 
   const config = stackScroll.getConfiguration();
 

--- a/src/util/calculateSUV.js
+++ b/src/util/calculateSUV.js
@@ -46,7 +46,7 @@ export default function (image, storedPixelValue) {
   }
 
   const acquisitionTimeInSeconds = fracToDec(seriesAcquisitionTime.fractionalSeconds || 0) + seriesAcquisitionTime.seconds + seriesAcquisitionTime.minutes * 60 + seriesAcquisitionTime.hours * 60 * 60;
-  const injectionStartTimeInSeconds = fracToDec(startTime.fractionalSeconds) + startTime.seconds + startTime.minutes * 60 + startTime.hours * 60 * 60;
+  const injectionStartTimeInSeconds = fracToDec(startTime.fractionalSeconds || 0) + startTime.seconds + startTime.minutes * 60 + startTime.hours * 60 * 60;
   const durationInSeconds = acquisitionTimeInSeconds - injectionStartTimeInSeconds;
   const correctedDose = totalDose * Math.exp(-durationInSeconds * Math.log(2) / halfLife);
   const suv = modalityPixelValue * patientWeight / correctedDose * 1000;


### PR DESCRIPTION
This PR fixes the issue [#245](https://github.com/cornerstonejs/cornerstone/issues/245) in cornerstone repository.