### PR TITLE
Prevents error on crosshairs when image has no imagePlaneModule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Improved Magnifying glass tool to display full resolution image (thanks @diego0020!)
+- [fix] Prevents crosshairs tool to throw an exception when no imagePlaneModule metadata is present (to fail gracefully)
 
 ## [2.2.0] - 2018-04-02
 ### Added

--- a/src/imageTools/crosshairs.js
+++ b/src/imageTools/crosshairs.js
@@ -28,6 +28,10 @@ function chooseLocation (e) {
   const sourceImageId = sourceEnabledElement.image.imageId;
   const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImageId);
 
+  if (!sourceImagePlane) {
+    return;
+  }
+
   // Get currentPoints from mouse cursor on selected element
   const sourceImagePoint = eventData.currentPoints.image;
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [ ] Tests for the changes have been added (for bug fixes / features)
  - [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for the crosshairs tool.


* **What is the current behavior?** (You can also link to an open issue here)
The crosshairs tool throws an exception when used with a source image that has not imagePlaneModule metadata (#385).


* **What is the new behavior (if this is a feature change)?**
A security check is made for the existence of the metadata. If it does not exist, now it doesn't do anything (simply `return`s the function).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
