### PR TITLE
fix(interaction) No tool interaction when tool is invisible

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -50,6 +50,10 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
 
   const lineSegment = {

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -122,6 +122,10 @@ function createNewMeasurement (eventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
 
   const lineSegment = {

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -50,6 +50,10 @@ function createNewMeasurement (mouseEventData) {
 
 // /////// BEGIN IMAGE RENDERING ///////
 function pointNearEllipse (element, data, coords, distance) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
   const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -120,6 +120,10 @@ function pointNearHandle (eventData, toolIndex) {
     return;
   }
 
+  if (data.visible === false) {
+    return false;
+  }
+
   const mousePoint = eventData.currentPoints.canvas;
 
   for (let i = 0; i < data.handles.length; i++) {

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -63,6 +63,10 @@ function pointInsideRect (element, data, coords) {
 }
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
   const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -44,6 +44,10 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -34,6 +34,10 @@ function createNewMeasurement (mouseEventData) {
 
 // /////// BEGIN IMAGE RENDERING ///////
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const endCanvas = external.cornerstone.pixelToCanvas(element, data.handles.end);
 
 

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -46,6 +46,10 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
   const startCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
   const endCanvas = cornerstone.pixelToCanvas(element, data.handles.end);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -105,6 +105,10 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   if (!data.handles.end) {
     return;
   }

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -57,6 +57,10 @@ function createNewMeasurement (mouseEventData) {
 // /////// END ACTIVE TOOL ///////
 
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   const cornerstone = external.cornerstone;
   const lineSegment = {
     start: cornerstone.pixelToCanvas(element, data.handles.start),

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -80,6 +80,10 @@ function createNewMeasurement (mouseEventData) {
 
 // /////// BEGIN IMAGE RENDERING ///////
 function pointNearTool (element, data, coords) {
+  if (data.visible === false) {
+    return false;
+  }
+
   if (!data.handles.end.boundingBox) {
     return;
   }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

If tool data has the `visible` flag set to false, then `pointNearTool` will return false. This is to prevent mouse interaction with the tool when the data is invisible.

* **What is the current behavior?** (You can also link to an open issue here)

#387

* **What is the new behavior (if this is a feature change)?**

Clicking on an invisible tool will not update the invisible tool.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
