### PR TITLE
Freehand Update: drag to edit, passive functionality and bug fix for statistics

### DIFF
--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -10,6 +10,7 @@ import freeHandArea from '../util/freeHandArea.js';
 import calculateFreehandStatistics from '../util/calculateFreehandStatistics.js';
 import { freeHandIntersect, freeHandIntersectEnd, freeHandIntersectModify } from '../util/freeHandIntersect.js';
 import calculateSUV from '../util/calculateSUV.js';
+import triggerEvent from '../util/triggerEvent.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
@@ -49,51 +50,6 @@ function createNewMeasurement () {
   };
 
   return measurementData;
-}
-
-// /////// BEGIN ACTIVE TOOL ///////
-function addPoint (eventData) {
-  const toolData = getToolState(eventData.element, toolType);
-
-  if (toolData === undefined) {
-    return;
-  }
-
-  const config = freehand.getConfiguration();
-
-  // Get the toolData from the last-drawn drawing
-  // (this should change when modification is added)
-  const data = toolData.data[config.currentTool];
-
-  const handleData = {
-    x: eventData.currentPoints.image.x,
-    y: eventData.currentPoints.image.y,
-    highlight: true,
-    active: true,
-    lines: []
-  };
-
-    // If this is not the first handle
-  if (data.handles.length) {
-    if (isValidNode(handleData, data.handles)) {
-      // Add the line from the current handle to the new handle
-      data.handles[config.currentHandle - 1].lines.push(eventData.currentPoints.image);
-    } else {
-      return false;
-    }
-  }
-
-  // Add the new handle
-  data.handles.push(handleData);
-
-  // Increment the current handle value
-  config.currentHandle += 1;
-
-  // Reset freehand value
-  config.freehand = false;
-
-  // Force onImageRendered to fire
-  external.cornerstone.updateImage(eventData.element);
 }
 
 function pointNearTool (eventData, toolIndex) {
@@ -164,136 +120,26 @@ function pointNearHandleAllTools (eventData) {
   }
 }
 
+// /////// BEGIN ACTIVE TOOL ///////
+
+// /////// BEGIN ACTIVE TOOL ///////
+
+function mouseDownActivateCallback (e) {
+  const eventData = e.detail;
+
+  startDrawing(eventData);
+  addPoint(eventData);
+
+  e.preventDefault();
+  e.stopPropagation();
+}
+
 // --- Drawing loop ---
 // On first click, add point
 // After first click, on mouse move, record location
 // If mouse comes close to previous point, snap to it
 // On next click, add another point -- continuously
 // On each click, if it intersects with a current point, end drawing loop
-
-function mouseUpCallback (e) {
-  const eventData = e.detail;
-  const element = eventData.element;
-
-  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-
-  // Check if drawing is finished
-  const toolData = getToolState(eventData.element, toolType);
-
-  if (toolData === undefined) {
-    return;
-  }
-
-  const config = freehand.getConfiguration();
-
-  if (config.movingTextBox === true) {
-    // Place textBox
-    config.movingTextBox = false;
-    // Reset the current handle
-    toolData.data[config.currentTool].invalidated = true;
-    config.currentHandle = 0;
-    config.currentTool = -1;
-    element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-
-    return;
-  }
-
-  if (!eventData.event.shiftKey) {
-    config.freehand = false;
-  }
-
-  external.cornerstone.updateImage(eventData.element);
-}
-
-function mouseMoveCallback (e) {
-  const eventData = e.detail;
-  const toolData = getToolState(eventData.element, toolType);
-
-  if (!toolData) {
-    return;
-  }
-
-  const config = freehand.getConfiguration();
-  const currentTool = config.currentTool;
-
-  // Tool inactive and passively watching for mouse over
-  if (currentTool < 0) {
-    const imageNeedsUpdate = mouseHover(eventData, toolData);
-
-    if (!imageNeedsUpdate) {
-      return;
-    }
-
-  } else {
-    // Tool active
-    const data = toolData.data[currentTool];
-    const currentHandle = config.currentHandle;
-
-    // Set the mouseLocation handle
-    getMouseLocation(eventData);
-
-    if (config.modifying) {
-      // Move the handle
-      data.active = true;
-      data.highlight = true;
-      data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
-      data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
-      const neighbourIndex = currentHandle === 0 ? data.handles.length - 1 : currentHandle - 1;
-      const lastLineIndex = data.handles[neighbourIndex].lines.length - 1;
-      const lastLine = data.handles[neighbourIndex].lines[lastLineIndex];
-
-      lastLine.x = config.mouseLocation.handles.start.x;
-      lastLine.y = config.mouseLocation.handles.start.y;
-    }
-
-    if (config.freehand) { // JPETTS - Note: currently disabled
-      data.handles[currentHandle - 1].lines.push(eventData.currentPoints.image);
-    } else {
-      // No snapping in freehand mode
-      const handleNearby = pointNearHandle(eventData, config.currentTool);
-
-      // If there is a handle nearby to snap to
-      // (and it's not the actual mouse handle)
-      if (handleNearby !== undefined && !handleNearby.hasBoundingBox && handleNearby < (data.handles.length - 1)) {
-        config.mouseLocation.handles.start.x = data.handles[handleNearby].x;
-        config.mouseLocation.handles.start.y = data.handles[handleNearby].y;
-      }
-    }
-  }
-
-  // Force onImageRendered
-  external.cornerstone.updateImage(eventData.element);
-}
-
-function mouseDragCallback (e) {
-  const eventData = e.detail;
-  const toolData = getToolState(eventData.element, toolType);
-
-  if (!toolData) {
-    return;
-  }
-
-  const config = freehand.getConfiguration();
-  const currentTool = config.currentTool;
-
-  // Check if the tool is active
-  if (currentTool >= 0) {
-    // Set the mouseLocation handle
-    getMouseLocation(eventData);
-
-    const currentHandle = config.currentHandle;
-
-    if (config.movingTextBox) {
-      // Move the textBox
-      currentHandle.hasMoved = true;
-      currentHandle.x = config.mouseLocation.handles.start.x;
-      currentHandle.y = config.mouseLocation.handles.start.y;
-    }
-  }
-
-  // Update the image
-  external.cornerstone.updateImage(eventData.element);
-}
 
 function startDrawing (eventData) {
   const element = eventData.element;
@@ -313,6 +159,49 @@ function startDrawing (eventData) {
   const toolData = getToolState(eventData.element, toolType);
 
   config.currentTool = toolData.data.length - 1;
+}
+
+function addPoint (eventData) {
+  const toolData = getToolState(eventData.element, toolType);
+
+  if (toolData === undefined) {
+    return;
+  }
+
+  const config = freehand.getConfiguration();
+
+  // Get the toolData from the last-drawn drawing
+  const data = toolData.data[config.currentTool];
+
+  const handleData = {
+    x: eventData.currentPoints.image.x,
+    y: eventData.currentPoints.image.y,
+    highlight: true,
+    active: true,
+    lines: []
+  };
+
+  // If this is not the first handle
+  if (data.handles.length) {
+    if (isValidNode(handleData, data.handles)) {
+      // Add the line from the current handle to the new handle
+      data.handles[config.currentHandle - 1].lines.push(eventData.currentPoints.image);
+    } else {
+      return false;
+    }
+  }
+
+  // Add the new handle
+  data.handles.push(handleData);
+
+  // Increment the current handle value
+  config.currentHandle += 1;
+
+  // Reset freehand value
+  config.freehand = false;
+
+  // Force onImageRendered to fire
+  external.cornerstone.updateImage(eventData.element);
 }
 
 function endDrawing (eventData, handleNearby) {
@@ -346,6 +235,255 @@ function endDrawing (eventData, handleNearby) {
   external.cornerstone.updateImage(eventData.element);
 }
 
+function mouseUpCallback (e) {
+  const eventData = e.detail;
+  const element = eventData.element;
+
+  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+  element.removeEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
+
+  // Check if drawing is finished
+  const toolData = getToolState(eventData.element, toolType);
+
+  if (toolData === undefined) {
+    return;
+  }
+
+  const config = freehand.getConfiguration();
+
+  if (config.movingTextBox === true) {
+    // Place textBox
+    config.movingTextBox = false;
+    // Reset the current handle
+    toolData.data[config.currentTool].invalidated = true;
+    config.currentHandle = 0;
+    config.currentTool = -1;
+    element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+
+    return;
+  }
+
+  if (!eventData.event.shiftKey) {
+    config.freehand = false;
+  }
+
+  if (config.modifying) {
+    const currentTool = config.currentTool;
+    // Don't allow the line being modified to intersect other lines
+    if (!freeHandIntersectModify(toolData.data[currentTool].handles, config.currentHandle)) {
+      endDrawing(eventData);
+    } else {
+      const currentHandle = config.currentHandle;
+      const currentHandleData = toolData.data[currentTool].handles[currentHandle];
+      let previousHandleData;
+
+      if (currentHandle === 0) {
+        const lastNodeID = toolData.data[currentTool].handles.length - 1;
+        previousHandleData = toolData.data[currentTool].handles[lastNodeID];
+      } else {
+        previousHandleData = toolData.data[currentTool].handles[currentHandle - 1];
+      }
+
+      // Snap back to previous position
+      currentHandleData.x = config.dragOrigin.x;
+      currentHandleData.y = config.dragOrigin.y;
+
+      // Reconfigure line from previous node
+      previousHandleData.lines[0] = currentHandleData;
+
+
+      endDrawing(eventData);
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  external.cornerstone.updateImage(eventData.element);
+}
+
+// /////// END ACTIVE TOOL ///////
+
+function mouseDownCallback (e) {
+  const eventData = e.detail;
+  const element = eventData.element;
+  const options = getToolOptions(toolType, element);
+
+  if (!isMouseButtonEnabled(eventData.which, options.mouseButtonMask)) {
+    e.stopPropagation();
+    e.preventDefault();
+    return;
+  }
+
+  const toolData = getToolState(eventData.element, toolType);
+  let handleNearby, toolIndex;
+  const config = freehand.getConfiguration();
+  const currentTool = config.currentTool;
+
+  if (currentTool < 0) {
+    const nearby = pointNearHandleAllTools(eventData);
+
+    if (nearby) {
+      handleNearby = nearby.handleNearby;
+      toolIndex = nearby.toolIndex;
+      // This means the user clicked on the textBox
+      if (handleNearby.hasBoundingBox) {
+        element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
+        element.addEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+        config.movingTextBox = true;
+        config.currentHandle = handleNearby;
+        config.currentTool = toolIndex;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        return;
+      }
+      // This means the user is trying to modify a point
+      if (handleNearby !== undefined) {
+
+        element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+
+        config.dragOrigin = {
+          x: toolData.data[toolIndex].handles[handleNearby].x,
+          y: toolData.data[toolIndex].handles[handleNearby].y
+        }
+
+        // Begin drag edit - call mouseUpCallback at end of drag or straight away if just a click.
+
+        element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
+        element.addEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
+        element.addEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+
+        config.modifying = true;
+        config.currentHandle = handleNearby;
+        config.currentTool = toolIndex;
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+  } else if (currentTool >= 0 && toolData.data[currentTool].active) {
+    handleNearby = pointNearHandle(eventData, currentTool);
+    const lastNodeID = toolData.data[currentTool].handles.length - 1;
+
+    // This means the user is trying to add a point
+    if (handleNearby === undefined) {
+      e.stopPropagation();
+      e.preventDefault();
+      addPoint(eventData);
+
+      return;
+
+    } else if (toolData.data[currentTool].handles.length >= 3) {
+      // Snap if click registered on origin node or on last node placed
+      if ((handleNearby === 0 || handleNearby === lastNodeID) && !freeHandIntersectEnd(toolData.data[currentTool].handles)) {
+        endDrawing(eventData, handleNearby);
+      } else if (eventData.event.shiftKey) {
+        config.freehand = true;
+        toolData.data[currentTool].textBox.freehand = true;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    return;
+  }
+
+}
+
+function mouseMoveCallback (e) {
+  const eventData = e.detail;
+  const toolData = getToolState(eventData.element, toolType);
+
+  if (!toolData) {
+    return;
+  }
+
+  const config = freehand.getConfiguration();
+  const currentTool = config.currentTool;
+
+  // Tool inactive and passively watching for mouse over
+  if (currentTool < 0) {
+    const imageNeedsUpdate = mouseHover(eventData, toolData);
+
+    if (!imageNeedsUpdate) {
+      return;
+    }
+
+  } else {
+    // Tool active
+    const data = toolData.data[currentTool];
+    const currentHandle = config.currentHandle;
+
+    // Set the mouseLocation handle
+    getMouseLocation(eventData);
+
+    if (config.freehand) { // JPETTS - Note: currently disabled
+      data.handles[currentHandle - 1].lines.push(eventData.currentPoints.image);
+    } else {
+      // No snapping in freehand mode
+      const handleNearby = pointNearHandle(eventData, config.currentTool);
+
+      // If there is a handle nearby to snap to
+      // (and it's not the actual mouse handle)
+      if (handleNearby !== undefined && !handleNearby.hasBoundingBox && handleNearby < (data.handles.length - 1)) {
+        config.mouseLocation.handles.start.x = data.handles[handleNearby].x;
+        config.mouseLocation.handles.start.y = data.handles[handleNearby].y;
+      }
+    }
+  }
+
+  // Force onImageRendered
+  external.cornerstone.updateImage(eventData.element);
+}
+
+function mouseDragCallback (e) {
+  const eventData = e.detail;
+  const toolData = getToolState(eventData.element, toolType);
+
+  if (!toolData) {
+    return;
+  }
+
+  const config = freehand.getConfiguration();
+  const currentTool = config.currentTool;
+  const data = toolData.data[currentTool];
+  const currentHandle = config.currentHandle;
+
+  // Set the mouseLocation handle
+  getMouseLocation(eventData);
+
+  // Check if the tool is active
+  if (currentTool >= 0) {
+    if (config.movingTextBox) {
+      // Move the textBox
+      currentHandle.hasMoved = true;
+      currentHandle.x = config.mouseLocation.handles.start.x;
+      currentHandle.y = config.mouseLocation.handles.start.y;
+    }
+
+    if (config.modifying) {
+      // Move the handle
+      data.active = true;
+      data.highlight = true;
+      data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
+      data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
+      if (currentHandle) {
+        const lastLineIndex = data.handles[currentHandle - 1].lines.length - 1;
+        const lastLine = data.handles[currentHandle - 1].lines[lastLineIndex];
+
+        lastLine.x = config.mouseLocation.handles.start.x;
+        lastLine.y = config.mouseLocation.handles.start.y;
+      }
+    }
+  }
+
+  // Update the image
+  external.cornerstone.updateImage(eventData.element);
+}
+
 function isValidNode (newHandle, dataHandles) {
   return !freeHandIntersect(newHandle, dataHandles);
 }
@@ -364,10 +502,8 @@ function mouseHover (eventData, toolData) {
     }
 
     if ((pointNearTool(eventData, i) && !data.active) || (!pointNearTool(eventData, i) && data.active)) {
-      if (!data.lockedForEditing) {
-        data.active = !data.active;
-        imageNeedsUpdate = true;
-      }
+      data.active = !data.active;
+      imageNeedsUpdate = true;
     }
 
     if (data.textBox === true) {
@@ -395,81 +531,9 @@ function getMouseLocation (eventData) {
   config.mouseLocation.handles.start.y = y;
 }
 
-function mouseDownCallback (e) {
-  const eventData = e.detail;
-  const element = eventData.element;
-  const options = getToolOptions(toolType, element);
 
-  if (isMouseButtonEnabled(eventData.which, options.mouseButtonMask)) {
-    const toolData = getToolState(eventData.element, toolType);
-    let handleNearby, toolIndex;
-    const config = freehand.getConfiguration();
-    const currentTool = config.currentTool;
 
-    if (config.modifying) {
-      // Don't allow the line being modified to intersect other lines
-      if (!freeHandIntersectModify(toolData.data[currentTool].handles, config.currentHandle)) {
-        endDrawing(eventData);
-      }
 
-      return;
-    }
-
-    if (currentTool < 0) {
-      const nearby = pointNearHandleAllTools(eventData);
-
-      if (nearby) {
-        handleNearby = nearby.handleNearby;
-        toolIndex = nearby.toolIndex;
-        // This means the user clicked on the textBox
-        if (handleNearby.hasBoundingBox) {
-          element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-          element.addEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-          config.movingTextBox = true;
-          config.currentHandle = handleNearby;
-          config.currentTool = toolIndex;
-
-          return false;
-        }
-        // This means the user is trying to modify a point
-        if (handleNearby !== undefined) {
-          element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-          element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-          config.modifying = true;
-          config.currentHandle = handleNearby;
-          config.currentTool = toolIndex;
-        }
-      } else {
-        startDrawing(eventData);
-        addPoint(eventData);
-      }
-    } else if (currentTool >= 0 && toolData.data[currentTool].active) {
-      handleNearby = pointNearHandle(eventData, currentTool);
-      const lastNodeID = toolData.data[currentTool].handles.length - 1;
-
-      // Snap if click registered on origin node or on last node placed
-      if ((handleNearby === 0 || handleNearby === lastNodeID) && !freeHandIntersectEnd(toolData.data[currentTool].handles)) {
-        endDrawing(eventData, handleNearby);
-      } else if (eventData.event.shiftKey) {
-        config.freehand = true;
-        toolData.data[currentTool].textBox.freehand = true;
-      } else if (handleNearby === undefined) {
-        addPoint(eventData);
-      } else {
-        // Do not allow user to add point to previous point if not origin node.
-        return false;
-      }
-    }
-
-    // JPETTS Note: removed freehand shiftclick pencil mode, as it is not
-    // Useful for accurate ROI outlining and cannot easily generalise to calculate the statistics.
-
-    e.preventDefault();
-    e.stopPropagation();
-  }
-}
-
-// /////// END ACTIVE TOOL ///////
 
 function numberWithCommas (x) {
   // http://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
@@ -806,9 +870,10 @@ function onImageRendered (e) {
 // /////// END IMAGE RENDERING ///////
 function enable (element) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
@@ -818,9 +883,10 @@ function enable (element) {
 // Disables the reference line tool for the given element
 function disable (element) {
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
@@ -828,28 +894,44 @@ function disable (element) {
 // Visible and interactive
 function activate (element, mouseButtonMask) {
   setToolOptions(toolType, element, { mouseButtonMask });
-
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
 
   external.cornerstone.updateImage(element);
 }
 
 // Visible, but not interactive
-function deactivate (element) {
+function deactivate (element, mouseButtonMask) {
+  setToolOptions(toolType, element, { mouseButtonMask });
+
+  const eventType = EVENTS.TOOL_DEACTIVATED;
+  const statusChangeEventData = {
+    mouseButtonMask,
+    toolType,
+    type: eventType
+  };
+
+  triggerEvent(element, eventType, statusChangeEventData);
+
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
 
   external.cornerstone.updateImage(element);
 }

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -270,16 +270,16 @@ function mouseUpCallback (e) {
 
   if (config.modifying) {
     const currentTool = config.currentTool;
+
     // Don't allow the line being modified to intersect other lines
-    if (!freeHandIntersectModify(toolData.data[currentTool].handles, config.currentHandle)) {
-      endDrawing(eventData);
-    } else {
+    if (freeHandIntersectModify(toolData.data[currentTool].handles, config.currentHandle)) {
       const currentHandle = config.currentHandle;
       const currentHandleData = toolData.data[currentTool].handles[currentHandle];
       let previousHandleData;
 
       if (currentHandle === 0) {
         const lastNodeID = toolData.data[currentTool].handles.length - 1;
+
         previousHandleData = toolData.data[currentTool].handles[lastNodeID];
       } else {
         previousHandleData = toolData.data[currentTool].handles[currentHandle - 1];
@@ -292,10 +292,10 @@ function mouseUpCallback (e) {
       // Reconfigure line from previous node
       previousHandleData.lines[0] = currentHandleData;
 
-
       endDrawing(eventData);
     }
 
+    endDrawing(eventData);
     e.preventDefault();
     e.stopPropagation();
   }
@@ -313,6 +313,7 @@ function mouseDownCallback (e) {
   if (!isMouseButtonEnabled(eventData.which, options.mouseButtonMask)) {
     e.stopPropagation();
     e.preventDefault();
+
     return;
   }
 
@@ -348,7 +349,7 @@ function mouseDownCallback (e) {
         config.dragOrigin = {
           x: toolData.data[toolIndex].handles[handleNearby].x,
           y: toolData.data[toolIndex].handles[handleNearby].y
-        }
+        };
 
         // Begin drag edit - call mouseUpCallback at end of drag or straight away if just a click.
 
@@ -530,10 +531,6 @@ function getMouseLocation (eventData) {
   y = Math.min(y, eventData.image.height);
   config.mouseLocation.handles.start.y = y;
 }
-
-
-
-
 
 function numberWithCommas (x) {
   // http://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -458,40 +458,49 @@ function mouseDragCallback (e) {
   }
 
   const config = freehand.getConfiguration();
-  const currentTool = config.currentTool;
-  const data = toolData.data[currentTool];
+  const data = toolData.data[config.currentTool];
   const currentHandle = config.currentHandle;
 
   // Set the mouseLocation handle
   getMouseLocation(eventData);
 
   // Check if the tool is active
-  if (currentTool >= 0) {
+  if (config.currentTool >= 0) {
     if (config.movingTextBox) {
-      // Move the textBox
-      currentHandle.hasMoved = true;
-      currentHandle.x = config.mouseLocation.handles.start.x;
-      currentHandle.y = config.mouseLocation.handles.start.y;
+      dragTextBox(currentHandle);
     }
 
     if (config.modifying) {
-      // Move the handle
-      data.active = true;
-      data.highlight = true;
-      data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
-      data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
-      if (currentHandle) {
-        const lastLineIndex = data.handles[currentHandle - 1].lines.length - 1;
-        const lastLine = data.handles[currentHandle - 1].lines[lastLineIndex];
-
-        lastLine.x = config.mouseLocation.handles.start.x;
-        lastLine.y = config.mouseLocation.handles.start.y;
-      }
+      dragHandle(currentHandle, data);
     }
   }
 
   // Update the image
   external.cornerstone.updateImage(eventData.element);
+}
+
+function dragTextBox (currentHandle) {
+  const config = freehand.getConfiguration();
+
+  currentHandle.hasMoved = true;
+  currentHandle.x = config.mouseLocation.handles.start.x;
+  currentHandle.y = config.mouseLocation.handles.start.y;
+}
+
+function dragHandle (currentHandle, data) {
+  const config = freehand.getConfiguration();
+
+  data.active = true;
+  data.highlight = true;
+  data.handles[currentHandle].x = config.mouseLocation.handles.start.x;
+  data.handles[currentHandle].y = config.mouseLocation.handles.start.y;
+  if (currentHandle) {
+    const lastLineIndex = data.handles[currentHandle - 1].lines.length - 1;
+    const lastLine = data.handles[currentHandle - 1].lines[lastLineIndex];
+
+    lastLine.x = config.mouseLocation.handles.start.x;
+    lastLine.y = config.mouseLocation.handles.start.y;
+  }
 }
 
 function isValidNode (newHandle, dataHandles) {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -245,6 +245,8 @@ function mouseUpCallback (e) {
   element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
 
+  element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+
   if (toolData === undefined) {
     return;
   }

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -466,17 +466,23 @@ function mouseDragCallback (e) {
 
   // Check if the tool is active
   if (config.currentTool >= 0) {
-    if (config.movingTextBox) {
-      dragTextBox(currentHandle);
-    }
-
-    if (config.modifying) {
-      dragHandle(currentHandle, data);
-    }
+    dragHandle(currentHandle, data);
   }
 
   // Update the image
   external.cornerstone.updateImage(eventData.element);
+}
+
+function dragHandle (currentHandle, data) {
+  const config = freehand.getConfiguration();
+
+  if (config.movingTextBox) {
+    dragTextBox(currentHandle);
+  }
+
+  if (config.modifying) {
+    dragNode(currentHandle, data);
+  }
 }
 
 function dragTextBox (currentHandle) {
@@ -487,7 +493,7 @@ function dragTextBox (currentHandle) {
   currentHandle.y = config.mouseLocation.handles.start.y;
 }
 
-function dragHandle (currentHandle, data) {
+function dragNode (currentHandle, data) {
   const config = freehand.getConfiguration();
 
   data.active = true;
@@ -884,12 +890,7 @@ function onImageRendered (e) {
 
 // /////// END IMAGE RENDERING ///////
 function enable (element) {
-  element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
-  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  removeEventListeners(element);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
@@ -897,24 +898,15 @@ function enable (element) {
 
 // Disables the reference line tool for the given element
 function disable (element) {
-  element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
-  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  removeEventListeners(element);
   external.cornerstone.updateImage(element);
 }
 
 // Visible and interactive
 function activate (element, mouseButtonMask) {
   setToolOptions(toolType, element, { mouseButtonMask });
-  element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
-  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+
+  removeEventListeners(element);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
   element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
@@ -937,18 +929,23 @@ function deactivate (element, mouseButtonMask) {
 
   triggerEvent(element, eventType, statusChangeEventData);
 
-  element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
-  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
-  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
-  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
-  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  removeEventListeners(element);
 
   element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
   element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
 
   external.cornerstone.updateImage(element);
+}
+
+
+function removeEventListeners (element) {
+  element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
+  element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
+  element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
+  element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
+  element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
 }
 
 function getConfiguration () {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -291,8 +291,6 @@ function mouseUpCallback (e) {
 
       // Reconfigure line from previous node
       previousHandleData.lines[0] = currentHandleData;
-
-      endDrawing(eventData);
     }
 
     endDrawing(eventData);

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -33,14 +33,24 @@ function getSum (sp, boundingBox, dataHandles) {
 
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
-      if (pointInFreehandROI(dataHandles, x, y)) {
-        sum.value += sp[index];
-        sum.squared += sp[index] * sp[index];
-        sum.count++;
-      }
+      const point = {
+        x,
+        y
+      };
+
+      sumPointIfInFreehandROI(dataHandles, point, sum, sp[index]);
       index++;
     }
   }
 
   return sum;
+}
+
+
+function sumPointIfInFreehandROI (dataHandles, point, sum, pixelValue) {
+  if (pointInFreehandROI(dataHandles, point)) {
+    sum.value += pixelValue;
+    sum.squared += pixelValue * pixelValue;
+    sum.count++;
+  }
 }

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -30,13 +30,10 @@ function getSum (sp, boundingBox, dataHandles) {
     count: 0
   };
   let index = 0;
-  
+
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
-      if (pointInFreehandROI(dataHandles, {
-        x,
-        y
-      })) {
+      if (pointInFreehandROI(dataHandles, x, y)) {
         sum.value += sp[index];
         sum.squared += sp[index] * sp[index];
         sum.count++;

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -9,31 +9,41 @@ export default function (sp, boundingBox, dataHandles) {
     stdDev: 0.0
   };
 
-  let sum = 0;
-  let sumSquared = 0;
-  let index = 0;
+  const sum = getSum(sp, boundingBox, dataHandles);
 
+  if (sum.count === 0) {
+    return statisticsObj;
+  }
+
+  statisticsObj.count = sum.count;
+  statisticsObj.mean = sum.value / sum.count;
+  statisticsObj.variance = sum.squared / sum.count - statisticsObj.mean * statisticsObj.mean;
+  statisticsObj.stdDev = Math.sqrt(statisticsObj.variance);
+
+  return statisticsObj;
+}
+
+function getSum (sp, boundingBox, dataHandles) {
+  const sum = {
+    value: 0,
+    squared: 0,
+    count: 0
+  };
+  let index = 0;
+  
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
       if (pointInFreehandROI(dataHandles, {
         x,
         y
       })) {
-        sum += sp[index];
-        sumSquared += sp[index] * sp[index];
-        statisticsObj.count++;
+        sum.value += sp[index];
+        sum.squared += sp[index] * sp[index];
+        sum.count++;
       }
       index++;
     }
   }
 
-  if (statisticsObj.count === 0) {
-    return statisticsObj;
-  }
-
-  statisticsObj.mean = sum / statisticsObj.count;
-  statisticsObj.variance = sumSquared / statisticsObj.count - statisticsObj.mean * statisticsObj.mean;
-  statisticsObj.stdDev = Math.sqrt(statisticsObj.variance);
-
-  return statisticsObj;
+  return sum;
 }

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -1,16 +1,19 @@
 import pointInFreehandROI from './pointInFreehandROI.js';
 
-const statisticsObj = {
-  count: 0,
-  mean: 0.0,
-  variance: 0.0,
-  stdDev: 0.0
-};
-
 export default function (sp, boundingBox, dataHandles) {
+
+  const statisticsObj = {
+    count: 0,
+    mean: 0.0,
+    variance: 0.0,
+    stdDev: 0.0
+  };
+
   let sum = 0;
   let sumSquared = 0;
   let index = 0;
+
+
 
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {

--- a/src/util/calculateFreehandStatistics.js
+++ b/src/util/calculateFreehandStatistics.js
@@ -13,8 +13,6 @@ export default function (sp, boundingBox, dataHandles) {
   let sumSquared = 0;
   let index = 0;
 
-
-
   for (let y = boundingBox.top; y < boundingBox.top + boundingBox.height; y++) {
     for (let x = boundingBox.left; x < boundingBox.left + boundingBox.width; x++) {
       if (pointInFreehandROI(dataHandles, {

--- a/src/util/pointInFreehandROI.js
+++ b/src/util/pointInFreehandROI.js
@@ -61,15 +61,21 @@ export function getPointInFreehandROI (dataHandles, location) {
   let j = dataHandles.length - 1; // The last vertex is the previous one to the first
 
   for (let i = 0; i < dataHandles.length; i++) {
-    // Check if y values of line encapsulate location.y
-    if (isEnclosedY(location.y, dataHandles[i].y, dataHandles[j].y)) {
-      if (isLineRightOfPoint(location, dataHandles[i], dataHandles[j])) {
-        inROI = !inROI;
-      }
+    if (rayFromPointCrosssesLine(location, dataHandles[i], dataHandles[j])) {
+      inROI = !inROI;
     }
 
     j = i; // Here j is previous vertex to i
   }
 
   return inROI;
+}
+
+function rayFromPointCrosssesLine (point, handleI, handleJ) {
+  if (isEnclosedY(point.y, handleI.y, handleJ.y) && isLineRightOfPoint(point, handleI, handleJ)) {
+
+    return true;
+  }
+
+  return false;
 }

--- a/src/util/pointInFreehandROI.js
+++ b/src/util/pointInFreehandROI.js
@@ -39,16 +39,7 @@ function lineSegmentAtPoint (point, lp1, lp2) {
   return fx;
 }
 
-export default function (dataHandles, px, py) {
-  const location = {
-    x: px,
-    y: py
-  };
-
-  return getPointInFreehandROI(dataHandles, location);
-}
-
-export function getPointInFreehandROI (dataHandles, location) {
+export default function (dataHandles, location) {
   // JPETTS - Calculates if "point" is inside the polygon defined by dataHandles by
   // Counting the number of times a ray originating from "point" crosses the
   // Edges of the polygon. Odd === inside, Even === outside.

--- a/src/util/pointInFreehandROI.js
+++ b/src/util/pointInFreehandROI.js
@@ -39,7 +39,16 @@ function lineSegmentAtPoint (point, lp1, lp2) {
   return fx;
 }
 
-export default function (dataHandles, location) {
+export default function (dataHandles, px, py) {
+  const location = {
+    x: px,
+    y: py
+  };
+
+  return getPointInFreehandROI(dataHandles, location);
+}
+
+export function getPointInFreehandROI (dataHandles, location) {
   // JPETTS - Calculates if "point" is inside the polygon defined by dataHandles by
   // Counting the number of times a ray originating from "point" crosses the
   // Edges of the polygon. Odd === inside, Even === outside.


### PR DESCRIPTION
New features:
-- Refactored the create functionality into the MOUSE_DOWN_ACTIVATE event, such that the passive functionality could be improved. The tool is now editable whilst the freehand tool is in deactivate mode (i.e. whilst another tool is being used).
-- Editing nodes of the polygon now works based on drag-release rather than click-move-click, as this feels more intuitive.
-- If a drag edit would create a non-simple polygon, the node snaps back to its previous position.

Bug fixes:
-- My statistic features where re-factored by another user when I submitted my last pull request, and a bug was introduced (currently in master branch), whereby statisticsObj.count was global and recalculation due editing the polygon would lead to shrinking erroneous results. This is now fixed.