### PR TITLE
Feature: Add a .color attribute to the tool data

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -17,6 +17,7 @@ function createNewMeasurement (mouseEventData) {
   const angleData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x - 20,
@@ -91,8 +92,6 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  // Activation color
-  let color;
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();
   const config = angle.getConfiguration();
@@ -115,11 +114,7 @@ function onImageRendered (e) {
     }
 
     // Differentiate the color of activation tool
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    } else {
-      color = toolColors.getToolColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     // Draw the line
     context.beginPath();

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -94,6 +94,7 @@ function createNewMeasurement (eventData) {
   const measurementData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       start: {
         x: eventData.currentPoints.image.x,
@@ -159,7 +160,6 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  let color;
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();
   const config = arrowAnnotate.getConfiguration();
@@ -179,11 +179,7 @@ function onImageRendered (e) {
       continue;
     }
 
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    } else {
-      color = toolColors.getToolColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     // Draw the arrow
     const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -21,6 +21,7 @@ function createNewMeasurement (mouseEventData) {
     visible: true,
     active: true,
     invalidated: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x,
@@ -154,7 +155,7 @@ function onImageRendered (e) {
     }
 
     // Check which color the rendered tool should be
-    const color = toolColors.getColorIfActive(data.active);
+    const color = toolColors.getColorIfActive(data);
 
     // Convert Image coordinates to Canvas coordinates given the element
     const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -39,6 +39,7 @@ function createNewMeasurement () {
     visible: true,
     active: true,
     invalidated: true,
+    color: undefined,
     handles: [],
     textBox: {
       active: false,
@@ -595,9 +596,8 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  let color;
   const lineWidth = toolStyle.getToolWidth();
-  let fillColor = toolColors.getFillColor();
+  let fillColor;
 
   for (let i = 0; i < toolData.data.length; i++) {
     context.save();
@@ -608,11 +608,11 @@ function onImageRendered (e) {
       continue;
     }
 
+    const color = toolColors.getColorIfActive(data);
+
     if (data.active) {
-      color = toolColors.getActiveColor();
       fillColor = toolColors.getFillColor();
     } else {
-      color = toolColors.getToolColor();
       fillColor = toolColors.getToolColor();
     }
 

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -21,6 +21,7 @@ function createNewMeasurement (mouseEventData) {
   const measurementData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x,
@@ -102,7 +103,6 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  let color;
   const lineWidth = toolStyle.getToolWidth();
 
   context.save();
@@ -117,11 +117,7 @@ function onImageRendered (e) {
     return;
   }
 
-  if (data.active) {
-    color = toolColors.getActiveColor();
-  } else {
-    color = toolColors.getToolColor();
-  }
+  const color = toolColors.getColorIfActive(data);
 
   const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
   const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -16,6 +16,7 @@ function createNewMeasurement (mouseEventData) {
   const measurementData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x,
@@ -108,7 +109,7 @@ function onImageRendered (e) {
       continue;
     }
 
-    const color = toolColors.getColorIfActive(data.active);
+    const color = toolColors.getColorIfActive(data);
 
     // Get the handle positions in canvas coordinates
     const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -17,6 +17,7 @@ function createNewMeasurement (mouseEventData) {
   const measurementData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       end: {
         x: mouseEventData.currentPoints.image.x,
@@ -60,7 +61,6 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  let color;
   const font = textStyle.getFont();
   const fontHeight = textStyle.getFontSize();
 
@@ -72,11 +72,7 @@ function onImageRendered (e) {
       continue;
     }
 
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    } else {
-      color = toolColors.getToolColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     // Draw the handles
     drawHandles(context, eventData, data.handles, color);

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -18,6 +18,7 @@ function createNewMeasurement (mouseEventData) {
     visible: true,
     active: true,
     invalidated: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x,
@@ -170,7 +171,7 @@ function onImageRendered (e) {
     }
 
     // Check which color the rendered tool should be
-    const color = toolColors.getColorIfActive(data.active);
+    const color = toolColors.getColorIfActive(data);
 
     // Convert Image coordinates to Canvas coordinates given the element
     const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -82,6 +82,7 @@ function createNewMeasurement (mouseEventData) {
   const measurementData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       end: {
         x: mouseEventData.currentPoints.image.x,
@@ -142,7 +143,6 @@ function onImageRendered (e) {
   // We need the canvas width
   const canvasWidth = eventData.canvasContext.canvas.width;
 
-  let color;
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();
   const config = seedAnnotate.getConfiguration();
@@ -162,11 +162,7 @@ function onImageRendered (e) {
       continue;
     }
 
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    } else {
-      color = toolColors.getToolColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     // Draw
     const handleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -23,6 +23,7 @@ function createNewMeasurement (mouseEventData) {
   const angleData = {
     visible: true,
     active: true,
+    color: undefined,
     handles: {
       start: {
         x: mouseEventData.currentPoints.image.x,
@@ -104,8 +105,6 @@ function onImageRendered (e) {
 
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  // Activation color
-  let color;
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();
   const config = simpleAngle.getConfiguration();
@@ -126,11 +125,7 @@ function onImageRendered (e) {
     }
 
     // Differentiate the color of activation tool
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    } else {
-      color = toolColors.getToolColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
     const handleMiddleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.middle);

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -24,6 +24,7 @@ function createNewMeasurement (mouseEventData) {
     visible: true,
     active: true,
     text: config.current,
+    color: undefined,
     handles: {
       end: {
         x: mouseEventData.currentPoints.image.x,
@@ -119,11 +120,7 @@ function onImageRendered (e) {
       continue;
     }
 
-    let color = toolColors.getToolColor();
-
-    if (data.active) {
-      color = toolColors.getActiveColor();
-    }
+    const color = toolColors.getColorIfActive(data);
 
     context.save();
 

--- a/src/stateManagement/toolColors.js
+++ b/src/stateManagement/toolColors.js
@@ -27,8 +27,12 @@ function getActiveColor () {
   return activeColor;
 }
 
-function getColorIfActive (active) {
-  return active ? activeColor : defaultColor;
+function getColorIfActive (data) {
+  if (data.color) {
+    return data.color;
+  }
+
+  return data.active ? activeColor : defaultColor;
 }
 
 const toolColors = {


### PR DESCRIPTION
This change adds a `.color` attribute to the tool data for those tools which currently have a `.active` attribute. If `.active` is true and `.color` is defined, then the tool data will be displayed using the custom color. If `.active` is true and `.color` is undefined then the tool data will be displayed using the default active color (`activeColor`). If `.active` is false, then the default tool color (`white`) will be used.

This is my first contribution to the project, so please advise if this change is not appropriate or could be achieved in a better way.

This PR partially address the backlog item from `README.md`: 

> Config object that allows tool appearance to be customized (e.g. line color, text color, handle size, shape, etc)
