### PR TITLE
Add a drawLinkedTextBox function

### DIFF
--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -3,7 +3,6 @@ import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
-import drawTextBox from '../util/drawTextBox.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import textStyle from '../stateManagement/textStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
@@ -14,7 +13,7 @@ import moveNewHandleTouch from '../manipulators/moveNewHandleTouch.js';
 import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 
@@ -218,9 +217,9 @@ function onImageRendered (e) {
         distance = -distance;
       }
 
-      let textCoords;
-
       if (!data.handles.textBox.hasMoved) {
+        let textCoords;
+
         if (config.arrowFirst) {
           textCoords = {
             x: handleEndCanvas.x - textWidth / 2 + distance,
@@ -245,26 +244,19 @@ function onImageRendered (e) {
         data.handles.textBox.y = coords.y;
       }
 
-      textCoords = cornerstone.pixelToCanvas(eventData.element, data.handles.textBox);
-
-      const boundingBox = drawTextBox(context, data.text, textCoords.x, textCoords.y, color);
-
-      data.handles.textBox.boundingBox = boundingBox;
-
-      if (data.handles.textBox.hasMoved) {
-        // Draw dashed link line between tool and text
-        const midpointCanvas = {
-          x: (handleStartCanvas.x + handleEndCanvas.x) / 2,
-          y: (handleStartCanvas.y + handleEndCanvas.y) / 2
-        };
-
-        const linkAnchorPoints = [handleStartCanvas, handleEndCanvas, midpointCanvas];
-
-        drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-      }
+      drawLinkedTextBox(context, eventData.element, data.handles.textBox, data.text,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
     }
-
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    const midpoint = {
+      x: (handles.start.x + handles.end.x) / 2,
+      y: (handles.start.y + handles.end.y) / 2
+    };
+
+    return [handles.start, midpoint, handles.end];
   }
 }
 // ---- Touch tool ----

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -4,12 +4,11 @@ import touchTool from './touchTool.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
-import drawTextBox from '../util/drawTextBox.js';
 import drawEllipse from '../util/drawEllipse.js';
 import pointInEllipse from '../util/pointInEllipse.js';
 import calculateEllipseStatistics from '../util/calculateEllipseStatistics.js';
 import calculateSUV from '../util/calculateSUV.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getToolState } from '../stateManagement/toolState.js';
 
 const toolType = 'ellipticalRoi';
@@ -317,53 +316,35 @@ function onImageRendered (e) {
       data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
     }
 
-    // Convert the textbox Image coordinates into Canvas coordinates
-    const textCoords = cornerstone.pixelToCanvas(element, data.handles.textBox);
-
-    // Set options for the textbox drawing function
-    const options = {
-      centering: {
-        x: false,
-        y: true
-      }
-    };
-
-    // Draw the textbox and retrieves it's bounding box for mouse-dragging and highlighting
-    const boundingBox = drawTextBox(context, textLines, textCoords.x,
-      textCoords.y, color, options);
-
-    // Store the bounding box data in the handle for mouse-dragging and highlighting
-    data.handles.textBox.boundingBox = boundingBox;
-
-    // If the textbox has moved, we would like to draw a line linking it with the tool
-    // This section decides where to draw this line to on the Ellipse based on the location
-    // Of the textbox relative to the ellipse.
-    if (data.handles.textBox.hasMoved) {
-      // Draw dashed link line between tool and text
-
-      // First we calculate the ellipse points (top, left, right, and bottom)
-      const linkAnchorPoints = [{
-        // Top middle point of ellipse
-        x: leftCanvas + widthCanvas / 2,
-        y: topCanvas
-      }, {
-        // Left middle point of ellipse
-        x: leftCanvas,
-        y: topCanvas + heightCanvas / 2
-      }, {
-        // Bottom middle point of ellipse
-        x: leftCanvas + widthCanvas / 2,
-        y: topCanvas + heightCanvas
-      }, {
-        // Right middle point of ellipse
-        x: leftCanvas + widthCanvas,
-        y: topCanvas + heightCanvas / 2
-      }];
-
-      drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-    }
-
+    drawLinkedTextBox(context, element, data.handles.textBox, textLines,
+      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    // Retrieve the bounds of the ellipse (left, top, width, and height)
+    const left = Math.min(handles.start.x, handles.end.x);
+    const top = Math.min(handles.start.y, handles.end.y);
+    const width = Math.abs(handles.start.x - handles.end.x);
+    const height = Math.abs(handles.start.y - handles.end.y);
+
+    return [{
+      // Top middle point of ellipse
+      x: left + width / 2,
+      y: top
+    }, {
+      // Left middle point of ellipse
+      x: left,
+      y: top + height / 2
+    }, {
+      // Bottom middle point of ellipse
+      x: left + width / 2,
+      y: top + height
+    }, {
+      // Right middle point of ellipse
+      x: left + width,
+      y: top + height / 2
+    }];
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -3,7 +3,6 @@ import external from '../externalModules.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
-import drawTextBox from '../util/drawTextBox.js';
 import handleActivator from '../manipulators/handleActivator.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import freeHandArea from '../util/freeHandArea.js';
@@ -12,7 +11,7 @@ import { freeHandIntersect, freeHandIntersectEnd, freeHandIntersectModify } from
 import calculateSUV from '../util/calculateSUV.js';
 import triggerEvent from '../util/triggerEvent.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 
@@ -808,42 +807,14 @@ function onImageRendered (e) {
         data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
       }
 
-      // Convert the textbox Image coordinates into Canvas coordinates
-      const textCoords = cornerstone.pixelToCanvas(element, data.textBox);
-
-      // Set options for the textbox drawing function
-      const textOptions = {
-        centering: {
-          x: false,
-          y: true
-        }
-      };
-
-      // Draw the textbox and retrieves it's bounding box for mouse-dragging and highlighting
-      const boundingBox = drawTextBox(context, textLines, textCoords.x,
-        textCoords.y, color, textOptions);
-
-      // Store the bounding box data in the handle for mouse-dragging and highlighting
-      data.textBox.boundingBox = boundingBox;
-
-      // If the textbox has moved, we would like to draw a line linking it with the tool
-      // This section decides where to draw this line to on the polyBoundingBox based on the location
-      // Of the textbox relative to it.
-      if (data.textBox.hasMoved) {
-        // Draw dashed link line between tool and text
-
-        // Get the nodes of the ROI in canvas coordinates
-        const linkAnchorPoints = [];
-
-        for (let i = 0; i < data.handles.length; i++) {
-          linkAnchorPoints.push(cornerstone.pixelToCanvas(element, data.handles[i]));
-        }
-
-        drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-      }
+      drawLinkedTextBox(context, element, data.textBox, textLines,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
     }
-
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    return handles;
   }
 }
 

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -1,8 +1,7 @@
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
-import drawTextBox from '../util/drawTextBox.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
@@ -169,37 +168,22 @@ function onImageRendered (e) {
       data.handles.textBox.y = coords.y;
     }
 
-    const textCoords = cornerstone.pixelToCanvas(eventData.element, data.handles.textBox);
-
     // Move the textbox slightly to the right and upwards
     // So that it sits beside the length tool handle
-    textCoords.x += 10;
+    const xOffset = 10;
 
-    const options = {
-      centering: {
-        x: false,
-        y: true
-      }
+    drawLinkedTextBox(context, element, data.handles.textBox, text,
+      data.handles, textBoxAnchorPoints, color, lineWidth, xOffset, true);
+    context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    const midpoint = {
+      x: (handles.start.x + handles.end.x) / 2,
+      y: (handles.start.y + handles.end.y) / 2
     };
 
-    // Draw the textbox
-    const boundingBox = drawTextBox(context, text, textCoords.x, textCoords.y, color, options);
-
-    data.handles.textBox.boundingBox = boundingBox;
-
-    if (data.handles.textBox.hasMoved) {
-      // Draw dashed link line between ellipse and text
-      const midpointCanvas = {
-        x: (handleStartCanvas.x + handleEndCanvas.x) / 2,
-        y: (handleStartCanvas.y + handleEndCanvas.y) / 2
-      };
-
-      const linkAnchorPoints = [handleStartCanvas, handleEndCanvas, midpointCanvas];
-
-      drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-    }
-
-    context.restore();
+    return [handles.start, midpoint, handles.end];
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -4,10 +4,9 @@ import touchTool from './touchTool.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
-import drawTextBox from '../util/drawTextBox.js';
 import calculateSUV from '../util/calculateSUV.js';
-import drawLink from '../util/drawLink.js';
 import { getToolState } from '../stateManagement/toolState.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 
 const toolType = 'rectangleRoi';
 
@@ -333,53 +332,35 @@ function onImageRendered (e) {
       data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
     }
 
-    // Convert the textbox Image coordinates into Canvas coordinates
-    const textCoords = cornerstone.pixelToCanvas(element, data.handles.textBox);
-
-    // Set options for the textbox drawing function
-    const options = {
-      centering: {
-        x: false,
-        y: true
-      }
-    };
-
-    // Draw the textbox and retrieves it's bounding box for mouse-dragging and highlighting
-    const boundingBox = drawTextBox(context, textLines, textCoords.x,
-      textCoords.y, color, options);
-
-    // Store the bounding box data in the handle for mouse-dragging and highlighting
-    data.handles.textBox.boundingBox = boundingBox;
-
-    // If the textbox has moved, we would like to draw a line linking it with the tool
-    // This section decides where to draw this line to on the Ellipse based on the location
-    // Of the textbox relative to the ellipse.
-    if (data.handles.textBox.hasMoved) {
-      // Draw dashed link line between tool and text
-
-      // First we calculate the ellipse points (top, left, right, and bottom)
-      const linkAnchorPoints = [{
-        // Top middle point of ellipse
-        x: leftCanvas + widthCanvas / 2,
-        y: topCanvas
-      }, {
-        // Left middle point of ellipse
-        x: leftCanvas,
-        y: topCanvas + heightCanvas / 2
-      }, {
-        // Bottom middle point of ellipse
-        x: leftCanvas + widthCanvas / 2,
-        y: topCanvas + heightCanvas
-      }, {
-        // Right middle point of ellipse
-        x: leftCanvas + widthCanvas,
-        y: topCanvas + heightCanvas / 2
-      }];
-
-      drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-    }
-
+    drawLinkedTextBox(context, element, data.handles.textBox, textLines,
+      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    // Retrieve the bounds of the ellipse (left, top, width, and height)
+    const left = Math.min(handles.start.x, handles.end.x);
+    const top = Math.min(handles.start.y, handles.end.y);
+    const width = Math.abs(handles.start.x - handles.end.x);
+    const height = Math.abs(handles.start.y - handles.end.y);
+
+    return [{
+      // Top middle point of ellipse
+      x: left + width / 2,
+      y: top
+    }, {
+      // Left middle point of ellipse
+      x: left,
+      y: top + height / 2
+    }, {
+      // Bottom middle point of ellipse
+      x: left + width / 2,
+      y: top + height
+    }, {
+      // Right middle point of ellipse
+      x: left + width,
+      y: top + height / 2
+    }];
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -3,7 +3,6 @@ import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
-import drawTextBox from '../util/drawTextBox.js';
 import textStyle from '../stateManagement/textStyle.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
@@ -13,7 +12,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import drawCircle from '../util/drawCircle.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 
@@ -223,19 +222,14 @@ function onImageRendered (e) {
         data.handles.textBox.y = coords.y;
       }
 
-      textCoords = cornerstone.pixelToCanvas(eventData.element, data.handles.textBox);
-
-      const boundingBox = drawTextBox(context, textPlusCoords, textCoords.x, textCoords.y, color);
-
-      data.handles.textBox.boundingBox = boundingBox;
-
-      if (data.handles.textBox.hasMoved) {
-        // Draw dashed link line between tool and text
-        drawLink([], handleCanvas, boundingBox, context, color, lineWidth);
-      }
+      drawLinkedTextBox(context, eventData.element, data.handles.textBox, textPlusCoords,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
     }
-
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    return [handles.end];
   }
 }
 // ---- Touch tool ----

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -1,9 +1,8 @@
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
-import drawTextBox from '../util/drawTextBox.js';
 import roundToDecimal from '../util/roundToDecimal.js';
-import drawLink from '../util/drawLink.js';
+import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import textStyle from '../stateManagement/textStyle.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
@@ -198,9 +197,7 @@ function onImageRendered (e) {
 
       let textCoords;
 
-      if (data.handles.textBox.hasMoved) {
-        textCoords = cornerstone.pixelToCanvas(eventData.element, data.handles.textBox);
-      } else {
+      if (!data.handles.textBox.hasMoved) {
         textCoords = {
           x: handleMiddleCanvas.x,
           y: handleMiddleCanvas.y
@@ -225,26 +222,14 @@ function onImageRendered (e) {
         data.handles.textBox.y = coords.y;
       }
 
-      const options = {
-        centering: {
-          x: false,
-          y: true
-        }
-      };
-
-      const boundingBox = drawTextBox(context, text, textCoords.x, textCoords.y, color, options);
-
-      data.handles.textBox.boundingBox = boundingBox;
-
-      if (data.handles.textBox.hasMoved) {
-        // Draw dashed link line between tool and text
-        const linkAnchorPoints = [handleStartCanvas, handleEndCanvas, handleMiddleCanvas];
-
-        drawLink(linkAnchorPoints, textCoords, boundingBox, context, color, lineWidth);
-      }
+      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
     }
-
     context.restore();
+  }
+
+  function textBoxAnchorPoints (handles) {
+    return [handles.start, handles.middle, handles.end];
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/util/drawLinkedTextBox.js
+++ b/src/util/drawLinkedTextBox.js
@@ -1,0 +1,32 @@
+import drawTextBox from './drawTextBox.js';
+import drawLink from './drawLink.js';
+
+
+export default function (context, element, textBox, text,
+  handles, textBoxAnchorPoints, color, lineWidth, xOffset, yCenter) {
+  const cornerstone = external.cornerstone;
+
+  // Convert the textbox Image coordinates into Canvas coordinates
+  const textCoords = cornerstone.pixelToCanvas(element, textBox);
+
+  if (xOffset) {
+    textCoords.x += xOffset;
+  }
+
+  const options = {
+    centering: {
+      x: false,
+      y: yCenter
+    }
+  };
+
+  // Draw the text box
+  textBox.boundingBox = drawTextBox(context, text, textCoords.x, textCoords.y, color, options);
+  if (textBox.hasMoved) {
+    // Identify the possible anchor points for the tool -> text line
+    const linkAnchorPoints = textBoxAnchorPoints(handles).map((h) => cornerstone.pixelToCanvas(element, h));
+
+    // Draw dashed link line between tool and text
+    drawLink(linkAnchorPoints, textCoords, textBox.boundingBox, context, color, lineWidth);
+  }
+}


### PR DESCRIPTION
The new `drawLinkedTextBox` consolidates common code for drawing a text box which is linked to an image tool.

This PR also introduces the `textBoxAnchorPoints` function to each appropriate image tool, which abstracts out the code for computing possible anchor points for the link to the text box.