### PR TITLE
Add a textBoxText function to all tools which use drawLinkedTextBox

### DIFF
--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -190,12 +190,14 @@ function onImageRendered (e) {
       drawHandles(context, eventData, data.handles, color, handleOptions);
     }
 
+    const text = textBoxText(data);
+
     // Draw the text
-    if (data.text && data.text !== '') {
+    if (text && text !== '') {
       context.font = font;
 
       // Calculate the text coordinates.
-      const textWidth = context.measureText(data.text).width + 10;
+      const textWidth = context.measureText(text).width + 10;
       const textHeight = textStyle.getFontSize() + 10;
 
       let distance = Math.max(textWidth, textHeight) / 2 + 5;
@@ -231,10 +233,14 @@ function onImageRendered (e) {
         data.handles.textBox.y = coords.y;
       }
 
-      drawLinkedTextBox(context, eventData.element, data.handles.textBox, data.text,
+      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
         data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
     }
     context.restore();
+  }
+
+  function textBoxText (data) {
+    return data.text;
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -260,6 +260,25 @@ function onImageRendered (e) {
       data.invalidated = false;
     }
 
+    // If the textbox has not been moved by the user, it should be displayed on the right-most
+    // Side of the tool.
+    if (!data.handles.textBox.hasMoved) {
+      // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
+      // Note that this calculates it in image coordinates
+      data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
+      data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
+    }
+
+    const text = textBoxText(data);
+
+    drawLinkedTextBox(context, element, data.handles.textBox, text,
+      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
+    context.restore();
+  }
+
+  function textBoxText (data) {
+    const { meanStdDev, meanStdDevSUV, area } = data;
+
     // Define an array to store the rows of text for the textbox
     const textLines = [];
 
@@ -308,18 +327,7 @@ function onImageRendered (e) {
       textLines.push(areaText);
     }
 
-    // If the textbox has not been moved by the user, it should be displayed on the right-most
-    // Side of the tool.
-    if (!data.handles.textBox.hasMoved) {
-      // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
-      // Note that this calculates it in image coordinates
-      data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
-      data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
-    }
-
-    drawLinkedTextBox(context, element, data.handles.textBox, textLines,
-      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    context.restore();
+    return textLines;
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -745,6 +745,27 @@ function onImageRendered (e) {
       data.invalidated = false;
     }
 
+    // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
+    if (data.polyBoundingBox && !data.textBox.freehand) {
+      // If the textbox has not been moved by the user, it should be displayed on the right-most
+      // Side of the tool.
+      if (!data.textBox.hasMoved) {
+        // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
+        // Note that this calculates it in image coordinates
+        data.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
+        data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
+      }
+
+      const text = textBoxText(data);
+
+      drawLinkedTextBox(context, element, data.textBox, text,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
+    }
+    context.restore();
+  }
+
+  function textBoxText (data) {
+    const { meanStdDev, meanStdDevSUV, area } = data;
     // Define an array to store the rows of text for the textbox
     const textLines = [];
 
@@ -792,22 +813,6 @@ function onImageRendered (e) {
       // Add this text line to the array to be displayed in the textbox
       textLines.push(areaText);
     }
-
-    // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
-    if (data.polyBoundingBox && !data.textBox.freehand) {
-      // If the textbox has not been moved by the user, it should be displayed on the right-most
-      // Side of the tool.
-      if (!data.textBox.hasMoved) {
-        // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
-        // Note that this calculates it in image coordinates
-        data.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
-        data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
-      }
-
-      drawLinkedTextBox(context, element, data.textBox, textLines,
-        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    }
-    context.restore();
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -135,16 +135,6 @@ function onImageRendered (e) {
     // Store the length inside the tool for outside access
     data.length = length;
 
-    // Set the length text suffix depending on whether or not pixelSpacing is available
-    let suffix = ' mm';
-
-    if (!rowPixelSpacing || !colPixelSpacing) {
-      suffix = ' pixels';
-    }
-
-    // Store the length measurement text
-    const text = `${length.toFixed(2)}${suffix}`;
-
     if (!data.handles.textBox.hasMoved) {
       const coords = {
         x: Math.max(data.handles.start.x, data.handles.end.x)
@@ -166,9 +156,22 @@ function onImageRendered (e) {
     // So that it sits beside the length tool handle
     const xOffset = 10;
 
+    const text = textBoxText(data, rowPixelSpacing, colPixelSpacing);
+
     drawLinkedTextBox(context, element, data.handles.textBox, text,
       data.handles, textBoxAnchorPoints, color, lineWidth, xOffset, true);
     context.restore();
+  }
+
+  function textBoxText (data, rowPixelSpacing, colPixelSpacing) {
+    // Set the length text suffix depending on whether or not pixelSpacing is available
+    let suffix = ' mm';
+
+    if (!rowPixelSpacing || !colPixelSpacing) {
+      suffix = ' pixels';
+    }
+
+    return `${data.length.toFixed(2)}${suffix}`;
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -276,6 +276,24 @@ function onImageRendered (e) {
       data.invalidated = false;
     }
 
+    const text = textBoxText(data);
+
+    // If the textbox has not been moved by the user, it should be displayed on the right-most
+    // Side of the tool.
+    if (!data.handles.textBox.hasMoved) {
+      // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
+      // Note that this calculates it in image coordinates
+      data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
+      data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
+    }
+
+    drawLinkedTextBox(context, element, data.handles.textBox, text,
+      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
+    context.restore();
+  }
+
+  function textBoxText (data) {
+    const { meanStdDev, meanStdDevSUV, area } = data;
     // Define an array to store the rows of text for the textbox
     const textLines = [];
 
@@ -324,18 +342,7 @@ function onImageRendered (e) {
       textLines.push(areaText);
     }
 
-    // If the textbox has not been moved by the user, it should be displayed on the right-most
-    // Side of the tool.
-    if (!data.handles.textBox.hasMoved) {
-      // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
-      // Note that this calculates it in image coordinates
-      data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
-      data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
-    }
-
-    drawLinkedTextBox(context, element, data.handles.textBox, textLines,
-      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    context.restore();
+    return textLines;
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -179,19 +179,12 @@ function onImageRendered (e) {
 
     // Draw the text
     if (data.text && data.text !== '') {
+      const text = textBoxText(data);
+
       context.font = font;
 
-      let textPlusCoords = '';
-
-      if (config.showCoordinates) {
-        textPlusCoords = `${data.text} x: ${Math.round(data.handles.end.x)
-        } y: ${Math.round(data.handles.end.y)}`;
-      } else {
-        textPlusCoords = data.text;
-      }
-
       // Calculate the text coordinates.
-      const textWidth = context.measureText(textPlusCoords).width + 10;
+      const textWidth = context.measureText(text).width + 10;
       const textHeight = textStyle.getFontSize() + 10;
 
       let distance = Math.max(textWidth, textHeight) / 2 + 5;
@@ -218,10 +211,23 @@ function onImageRendered (e) {
         data.handles.textBox.y = coords.y;
       }
 
-      drawLinkedTextBox(context, eventData.element, data.handles.textBox, textPlusCoords,
+      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
         data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
     }
     context.restore();
+  }
+
+  function textBoxText (data) {
+    let textPlusCoords = '';
+
+    if (config.showCoordinates) {
+      textPlusCoords = `${data.text} x: ${Math.round(data.handles.end.x)
+      } y: ${Math.round(data.handles.end.y)}`;
+    } else {
+      textPlusCoords = data.text;
+    }
+
+    return textPlusCoords;
   }
 
   function textBoxAnchorPoints (handles) {

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -137,11 +137,6 @@ function onImageRendered (e) {
     // Default to isotropic pixel size, update suffix to reflect this
     const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
     const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
-    let suffix = '';
-
-    if (!eventData.image.rowPixelSpacing || !eventData.image.columnPixelSpacing) {
-      suffix = ' (isotropic)';
-    }
 
     const sideA = {
       x: (Math.ceil(data.handles.middle.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
@@ -167,11 +162,10 @@ function onImageRendered (e) {
 
     angle *= (180 / Math.PI);
 
-    const rAngle = roundToDecimal(angle, 2);
+    data.rAngle = roundToDecimal(angle, 2);
 
-    if (rAngle) {
-      const str = '00B0'; // Degrees symbol
-      const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16)) + suffix;
+    if (data.rAngle) {
+      const text = textBoxText(data, eventData.image.rowPixelSpacing, eventData.image.columnPixelSpacing);
 
       const distance = 15;
 
@@ -206,6 +200,13 @@ function onImageRendered (e) {
         data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
     }
     context.restore();
+  }
+
+  function textBoxText (data, rowPixelSpacing, columnPixelSpacing) {
+    const suffix = (!rowPixelSpacing || !columnPixelSpacing) ? ' (isotropic)' : '';
+    const str = '00B0'; // Degrees symbol
+
+    return data.rAngle.toString() + String.fromCharCode(parseInt(str, 16)) + suffix;
   }
 
   function textBoxAnchorPoints (handles) {


### PR DESCRIPTION
Moving the code for generating the text box text into a separate function for each tool reduces the complexity of the `onImageRendered` function and also makes the common patterns across tools more obvious.

My aim with this collection of refactorings is to have the `onImageRendered` for each tool follow the same template, with the tool-specific details factored out into separate functions (like `textBoxText`).

The motivation here is to make it simpler to maintain our own custom tools.