### PR TITLE
[2/N] Use the getNewContext() function from drawing.js

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -9,6 +9,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -72,9 +73,7 @@ function onImageRendered (e) {
   }
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -17,6 +17,7 @@ import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 import lineSegDistance from '../util/lineSegDistance.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'arrowAnnotate';
 
@@ -146,9 +147,7 @@ function onImageRendered (e) {
   const cornerstone = external.cornerstone;
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -9,6 +9,7 @@ import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { getToolOptions } from '../toolOptions.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'dragProbe';
 
@@ -18,9 +19,7 @@ function defaultStrategy (eventData) {
   const cornerstone = external.cornerstone;
   const enabledElement = cornerstone.getEnabledElement(eventData.element);
 
-  const context = enabledElement.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(enabledElement.canvas);
 
   const color = toolColors.getActiveColor();
   const font = textStyle.getFont();
@@ -86,9 +85,7 @@ function minimalStrategy (eventData) {
   const enabledElement = cornerstone.getEnabledElement(element);
   const image = enabledElement.image;
 
-  const context = enabledElement.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(enabledElement.canvas);
 
   const color = toolColors.getActiveColor();
   const font = textStyle.getFont();

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -9,7 +9,7 @@ import calculateEllipseStatistics from '../util/calculateEllipseStatistics.js';
 import calculateSUV from '../util/calculateSUV.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { drawEllipse } from '../util/drawing.js';
+import { drawEllipse, getNewContext } from '../util/drawing.js';
 
 const toolType = 'ellipticalRoi';
 
@@ -115,7 +115,6 @@ function onImageRendered (e) {
   const element = eventData.element;
   const lineWidth = toolStyle.getToolWidth();
   const config = ellipticalRoi.getConfiguration();
-  const context = eventData.canvasContext.canvas.getContext('2d');
   const seriesModule = cornerstone.metaData.get('generalSeriesModule', image.imageId);
   const imagePlane = cornerstone.metaData.get('imagePlaneModule', image.imageId);
   let modality;
@@ -134,7 +133,7 @@ function onImageRendered (e) {
     modality = seriesModule.modality;
   }
 
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   // If we have tool data for this element - iterate over each set and draw it
   for (let i = 0; i < toolData.data.length; i++) {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -22,6 +22,7 @@ import freeHandArea from '../util/freehand/freeHandArea.js';
 import calculateFreehandStatistics from '../util/freehand/calculateFreehandStatistics.js';
 import freeHandIntersect from '../util/freehand/freeHandIntersect.js';
 import { FreehandHandleData } from '../util/freehand/FreehandHandleData.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'freehand';
 let configuration = {
@@ -789,9 +790,7 @@ function onImageRendered (e) {
   }
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
   let fillColor;

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -5,6 +5,7 @@ import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'highlight';
 
@@ -99,9 +100,7 @@ function onImageRendered (e) {
 
   const cornerstone = external.cornerstone;
   // We have tool data for this elemen
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
 

--- a/src/imageTools/imageStats.js
+++ b/src/imageTools/imageStats.js
@@ -1,14 +1,13 @@
 import displayTool from './displayTool.js';
 import drawTextBox from '../util/drawTextBox.js';
+import { getNewContext } from '../util/drawing.js';
 
 function onImageRendered (e) {
   const eventData = e.detail;
   const image = eventData.image;
   const stats = image.stats;
 
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const textLines = [];
 

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -7,6 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'length';
 
@@ -66,10 +67,8 @@ function onImageRendered (e) {
 
   const cornerstone = external.cornerstone;
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
+  const context = getNewContext(eventData.canvasContext.canvas);
   const { image, element } = eventData;
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
 
   const lineWidth = toolStyle.getToolWidth();
   const config = length.getConfiguration();

--- a/src/imageTools/magnify.js
+++ b/src/imageTools/magnify.js
@@ -4,6 +4,7 @@ import { getBrowserInfo } from '../util/getMaxSimultaneousRequests.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import { clipToBox } from '../util/clip.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'magnify';
 
@@ -111,13 +112,7 @@ function drawMagnificationTool (eventData) {
   // The 'not' magnifyTool class here is necessary because cornerstone places
   // No classes of it's own on the canvas we want to select
   const canvas = element.querySelector('canvas:not(.magnifyTool)');
-  const context = canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
-
-  const zoomCtx = magnifyCanvas.getContext('2d');
-
-  zoomCtx.setTransform(1, 0, 0, 1, 0, 0);
+  const zoomCtx = getNewContext(magnifyCanvas);
 
   const getSize = magnifySize;
 

--- a/src/imageTools/orientationMarkers.js
+++ b/src/imageTools/orientationMarkers.js
@@ -3,6 +3,7 @@ import orientation from '../orientation/index.js';
 import displayTool from './displayTool.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawTextBox from '../util/drawTextBox.js';
+import { getNewContext } from '../util/drawing.js';
 
 function getOrientationMarkers (element) {
   const cornerstone = external.cornerstone;
@@ -76,9 +77,7 @@ function onImageRendered (e) {
 
   const coords = getOrientationMarkerPositions(element, markers);
 
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const color = toolColors.getToolColor();
 

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -8,6 +8,7 @@ import drawTextBox from '../util/drawTextBox.js';
 import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'probe';
 
@@ -57,9 +58,7 @@ function onImageRendered (e) {
 
   const cornerstone = external.cornerstone;
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const font = textStyle.getFont();
   const fontHeight = textStyle.getFontSize();

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -7,6 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'rectangleRoi';
 
@@ -131,7 +132,6 @@ function onImageRendered (e) {
   const element = eventData.element;
   const lineWidth = toolStyle.getToolWidth();
   const config = rectangleRoi.getConfiguration();
-  const context = eventData.canvasContext.canvas.getContext('2d');
   const seriesModule = cornerstone.metaData.get('generalSeriesModule', image.imageId);
   const imagePlane = cornerstone.metaData.get('imagePlaneModule', image.imageId);
   let modality;
@@ -150,7 +150,7 @@ function onImageRendered (e) {
     modality = seriesModule.modality;
   }
 
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   // If we have tool data for this element - iterate over each set and draw it
   for (let i = 0; i < toolData.data.length; i++) {

--- a/src/imageTools/scaleOverlayTool.js
+++ b/src/imageTools/scaleOverlayTool.js
@@ -1,6 +1,7 @@
 import displayTool from './displayTool.js';
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
+import { getNewContext } from '../util/drawing.js';
 
 const configuration = {
   color: 'white',
@@ -152,7 +153,7 @@ function computeScaleBounds (eventData, canvasSize, imageSize, horizontalReducti
 function onImageRendered (e) {
   const eventData = e.detail;
 
-  const context = eventData.canvasContext.canvas.getContext('2d');
+  const context = getNewContext(eventData.canvasContext.canvas);
   const { image, viewport } = eventData;
   const cornerstone = external.cornerstone;
 
@@ -224,7 +225,6 @@ function onImageRendered (e) {
     }
   }, configuration);
 
-  context.setTransform(1, 0, 0, 1, 0, 0);
   context.save();
 
   drawScalebars(context, imageAttributes);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -14,7 +14,7 @@ import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
-import { drawCircle } from '../util/drawing.js';
+import { drawCircle, getNewContext } from '../util/drawing.js';
 
 const toolType = 'seedAnnotate';
 
@@ -135,9 +135,7 @@ function onImageRendered (e) {
   const enabledElement = eventData.enabledElement;
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   // We need the canvas width
   const canvasWidth = eventData.canvasContext.canvas.width;

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -13,6 +13,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
+import { getNewContext } from '../util/drawing.js';
 
 
 const toolType = 'simpleAngle';
@@ -85,9 +86,7 @@ function onImageRendered (e) {
   const enabledElement = eventData.enabledElement;
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -8,6 +8,7 @@ import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import drawTextBox from '../util/drawTextBox.js';
 import { removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
+import { getNewContext } from '../util/drawing.js';
 
 const toolType = 'textMarker';
 
@@ -107,9 +108,7 @@ function onImageRendered (e) {
   }
 
   // We have tool data for this element - iterate over each one and draw it
-  const context = eventData.canvasContext.canvas.getContext('2d');
-
-  context.setTransform(1, 0, 0, 1, 0, 0);
+  const context = getNewContext(eventData.canvasContext.canvas);
 
   const config = textMarker.getConfiguration();
 

--- a/src/stackTools/scrollIndicator.js
+++ b/src/stackTools/scrollIndicator.js
@@ -1,5 +1,6 @@
 import displayTool from '../imageTools/displayTool.js';
 import { getToolState } from '../stateManagement/toolState.js';
+import { getNewContext } from '../util/drawing.js';
 
 /*
 Display scroll progress bar across bottom of image.
@@ -22,9 +23,8 @@ function onImageRendered (e) {
     return false;
   }
 
-  const context = eventData.enabledElement.canvas.getContext('2d');
+  const context = getNewContext(eventData.enabledElement.canvas);
 
-  context.setTransform(1, 0, 0, 1, 0, 0);
   context.save();
 
   const config = scrollIndicator.getConfiguration();

--- a/src/util/drawing.js
+++ b/src/util/drawing.js
@@ -6,12 +6,12 @@ import { toolStyle, textStyle } from '../index.js';
  * @typedef {(String|CanvasGradient|CanvasPattern)} FillStyle
  */
 
- /**
+/**
  * A {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle|color, gradient or pattern} to use for the lines around shapes.
  * @typedef {(String|CanvasGradient|CanvasPattern)} StrokeStyle
  */
 
- /**
+/**
  * @callback ContextFn
  * @param {CanvasRenderingContext2D} context
  */


### PR DESCRIPTION
This PR uses the `getNewContext()` function in all places where we need a `context` object.

There is one exception, in [`referenceLinesTool.js`](https://github.com/cornerstonejs/cornerstoneTools/blob/3e587198a6d1038cb3c1a240d1e6906cf2214536/src/referenceLines/referenceLinesTool.js#L25). This function does not follow the pattern of creating a `context` and immediately settings the identity transform. Refactoring this particular use case will be left for a future task, and may involve modifying either the behaviour of this tool.

See #405 for full discussion