### PR TITLE
[3/N] Use the draw() function from drawing.js

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -9,7 +9,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -81,69 +81,68 @@ function onImageRendered (e) {
   const cornerstone = external.cornerstone;
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
-    // Configurable shadow
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    // Differentiate the color of activation tool
-    const color = toolColors.getColorIfActive(data);
+    draw(context, (context) => {
+      // Configurable shadow
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
+      }
 
-    // Draw the line
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
+      // Differentiate the color of activation tool
+      const color = toolColors.getColorIfActive(data);
 
-    let handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-    let handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
+      // Draw the line
+      context.beginPath();
+      context.strokeStyle = color;
+      context.lineWidth = lineWidth;
 
-    context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-    context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      let handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
+      let handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-    handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
-    handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
+      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
 
-    context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-    context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-    context.stroke();
+      handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
+      handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
 
-    // Draw the handles
-    drawHandles(context, eventData, data.handles);
+      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      context.stroke();
 
-    // Draw the text
-    context.fillStyle = color;
+      // Draw the handles
+      drawHandles(context, eventData, data.handles);
 
-    // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
-    // Where lines cross to measure angle. For now it will show smallest angle.
-    const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * eventData.image.columnPixelSpacing;
-    const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * eventData.image.rowPixelSpacing;
-    const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * eventData.image.columnPixelSpacing;
-    const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * eventData.image.rowPixelSpacing;
+      // Draw the text
+      context.fillStyle = color;
 
-    let angle = Math.acos(Math.abs(((dx1 * dx2) + (dy1 * dy2)) / (Math.sqrt((dx1 * dx1) + (dy1 * dy1)) * Math.sqrt((dx2 * dx2) + (dy2 * dy2)))));
+      // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
+      // Where lines cross to measure angle. For now it will show smallest angle.
+      const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * eventData.image.columnPixelSpacing;
+      const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * eventData.image.rowPixelSpacing;
+      const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * eventData.image.columnPixelSpacing;
+      const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * eventData.image.rowPixelSpacing;
 
-    angle *= (180 / Math.PI);
+      let angle = Math.acos(Math.abs(((dx1 * dx2) + (dy1 * dy2)) / (Math.sqrt((dx1 * dx1) + (dy1 * dy1)) * Math.sqrt((dx2 * dx2) + (dy2 * dy2)))));
 
-    const rAngle = roundToDecimal(angle, 2);
-    const str = '00B0'; // Degrees symbol
-    const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16));
+      angle *= (180 / Math.PI);
 
-    const textX = (handleStartCanvas.x + handleEndCanvas.x) / 2;
-    const textY = (handleStartCanvas.y + handleEndCanvas.y) / 2;
+      const rAngle = roundToDecimal(angle, 2);
+      const str = '00B0'; // Degrees symbol
+      const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16));
 
-    context.font = font;
-    drawTextBox(context, text, textX, textY, color);
-    context.restore();
+      const textX = (handleStartCanvas.x + handleEndCanvas.x) / 2;
+      const textY = (handleStartCanvas.y + handleEndCanvas.y) / 2;
+
+      context.font = font;
+      drawTextBox(context, text, textX, textY, color);
+    });
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -17,7 +17,7 @@ import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'arrowAnnotate';
 
@@ -154,88 +154,87 @@ function onImageRendered (e) {
   const config = arrowAnnotate.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    const color = toolColors.getColorIfActive(data);
-
-    // Draw the arrow
-    const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-    const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
-
-    // Config.arrowFirst = false;
-    if (config.arrowFirst) {
-      drawArrow(context, handleEndCanvas, handleStartCanvas, color, lineWidth);
-    } else {
-      drawArrow(context, handleStartCanvas, handleEndCanvas, color, lineWidth);
-    }
-
-    const handleOptions = {
-      drawHandlesIfActive: (config && config.drawHandlesOnHover)
-    };
-
-    if (config.drawHandles) {
-      drawHandles(context, eventData, data.handles, color, handleOptions);
-    }
-
-    const text = textBoxText(data);
-
-    // Draw the text
-    if (text && text !== '') {
-      context.font = font;
-
-      // Calculate the text coordinates.
-      const textWidth = context.measureText(text).width + 10;
-      const textHeight = textStyle.getFontSize() + 10;
-
-      let distance = Math.max(textWidth, textHeight) / 2 + 5;
-
-      if (handleEndCanvas.x < handleStartCanvas.x) {
-        distance = -distance;
+    draw(context, (context) => {
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
       }
 
-      if (!data.handles.textBox.hasMoved) {
-        let textCoords;
+      const color = toolColors.getColorIfActive(data);
 
-        if (config.arrowFirst) {
-          textCoords = {
-            x: handleEndCanvas.x - textWidth / 2 + distance,
-            y: handleEndCanvas.y - textHeight / 2
-          };
-        } else {
-          // If the arrow is at the End position, the text should
-          // Be placed near the Start position
-          textCoords = {
-            x: handleStartCanvas.x - textWidth / 2 - distance,
-            y: handleStartCanvas.y - textHeight / 2
-          };
+      // Draw the arrow
+      const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
+      const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
+
+      // Config.arrowFirst = false;
+      if (config.arrowFirst) {
+        drawArrow(context, handleEndCanvas, handleStartCanvas, color, lineWidth);
+      } else {
+        drawArrow(context, handleStartCanvas, handleEndCanvas, color, lineWidth);
+      }
+
+      const handleOptions = {
+        drawHandlesIfActive: (config && config.drawHandlesOnHover)
+      };
+
+      if (config.drawHandles) {
+        drawHandles(context, eventData, data.handles, color, handleOptions);
+      }
+
+      const text = textBoxText(data);
+
+      // Draw the text
+      if (text && text !== '') {
+        context.font = font;
+
+        // Calculate the text coordinates.
+        const textWidth = context.measureText(text).width + 10;
+        const textHeight = textStyle.getFontSize() + 10;
+
+        let distance = Math.max(textWidth, textHeight) / 2 + 5;
+
+        if (handleEndCanvas.x < handleStartCanvas.x) {
+          distance = -distance;
         }
 
-        const transform = cornerstone.internal.getTransform(enabledElement);
+        if (!data.handles.textBox.hasMoved) {
+          let textCoords;
 
-        transform.invert();
+          if (config.arrowFirst) {
+            textCoords = {
+              x: handleEndCanvas.x - textWidth / 2 + distance,
+              y: handleEndCanvas.y - textHeight / 2
+            };
+          } else {
+            // If the arrow is at the End position, the text should
+            // Be placed near the Start position
+            textCoords = {
+              x: handleStartCanvas.x - textWidth / 2 - distance,
+              y: handleStartCanvas.y - textHeight / 2
+            };
+          }
 
-        const coords = transform.transformPoint(textCoords.x, textCoords.y);
+          const transform = cornerstone.internal.getTransform(enabledElement);
 
-        data.handles.textBox.x = coords.x;
-        data.handles.textBox.y = coords.y;
+          transform.invert();
+
+          const coords = transform.transformPoint(textCoords.x, textCoords.y);
+
+          data.handles.textBox.x = coords.x;
+          data.handles.textBox.y = coords.y;
+        }
+
+        drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
+          data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
       }
-
-      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
-        data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
-    }
-    context.restore();
+    });
   }
 
   function textBoxText (data) {

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -22,7 +22,7 @@ import freeHandArea from '../util/freehand/freeHandArea.js';
 import calculateFreehandStatistics from '../util/freehand/calculateFreehandStatistics.js';
 import freeHandIntersect from '../util/freehand/freeHandIntersect.js';
 import { FreehandHandleData } from '../util/freehand/FreehandHandleData.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'freehand';
 let configuration = {
@@ -793,196 +793,195 @@ function onImageRendered (e) {
   const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
-  let fillColor;
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    let color = toolColors.getColorIfActive(data);
+    draw(context, (context) => {
+      let color = toolColors.getColorIfActive(data);
+      let fillColor;
 
-    if (data.active) {
-      if (data.handles.invalidHandlePlacement) {
-        color = config.invalidColor;
-        fillColor = config.invalidColor;
-      } else {
-        color = toolColors.getColorIfActive(data);
-        fillColor = toolColors.getFillColor();
-      }
-
-    } else {
-      fillColor = toolColors.getToolColor();
-    }
-
-    let handleStart;
-
-    if (data.handles.length) {
-      for (let j = 0; j < data.handles.length; j++) {
-        // Draw a line between handle j and j+1
-        handleStart = data.handles[j];
-        const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, handleStart);
-
-        context.beginPath();
-        context.strokeStyle = color;
-        context.lineWidth = lineWidth;
-        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-
-        for (let k = 0; k < data.handles[j].lines.length; k++) {
-          const lineCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles[j].lines[k]);
-
-          context.lineTo(lineCanvas.x, lineCanvas.y);
-          context.stroke();
+      if (data.active) {
+        if (data.handles.invalidHandlePlacement) {
+          color = config.invalidColor;
+          fillColor = config.invalidColor;
+        } else {
+          color = toolColors.getColorIfActive(data);
+          fillColor = toolColors.getFillColor();
         }
 
-        const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
+      } else {
+        fillColor = toolColors.getToolColor();
+      }
 
-        if (j === (data.handles.length - 1)) {
-          if (!data.polyBoundingBox) {
-            // If it's still being actively drawn, keep the last line to
-            // The mouse location
-            context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
+      let handleStart;
+
+      if (data.handles.length) {
+        for (let j = 0; j < data.handles.length; j++) {
+          // Draw a line between handle j and j+1
+          handleStart = data.handles[j];
+          const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, handleStart);
+
+          context.beginPath();
+          context.strokeStyle = color;
+          context.lineWidth = lineWidth;
+          context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+
+          for (let k = 0; k < data.handles[j].lines.length; k++) {
+            const lineCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles[j].lines[k]);
+
+            context.lineTo(lineCanvas.x, lineCanvas.y);
             context.stroke();
+          }
+
+          const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
+
+          if (j === (data.handles.length - 1)) {
+            if (!data.polyBoundingBox) {
+              // If it's still being actively drawn, keep the last line to
+              // The mouse location
+              context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
+              context.stroke();
+            }
           }
         }
       }
-    }
 
-    // Draw handles
+      // Draw handles
 
-    const options = {
-      fill: fillColor
-    };
-
-    if (config.alwaysShowHandles || config.keyDown.ctrl || data.active && data.polyBoundingBox) {
-      // Render all handles
-      options.handleRadius = config.activeHandleRadius;
-      drawHandles(context, eventData, data.handles, color, options);
-    }
-
-    if (data.canComplete) {
-      // Draw large handle at the origin if can complete drawing
-      options.handleRadius = config.completeHandleRadius;
-      drawHandles(context, eventData, [data.handles[0]], color, options);
-    }
-
-    if (data.active && !data.polyBoundingBox) {
-      // Draw handle at origin and at mouse if actively drawing
-      options.handleRadius = config.activeHandleRadius;
-      drawHandles(context, eventData, config.mouseLocation.handles, color, options);
-      drawHandles(context, eventData, [data.handles[0]], color, options);
-    }
-
-    // Define variables for the area and mean/standard deviation
-    let area,
-      meanStdDev,
-      meanStdDevSUV;
-
-    // Perform a check to see if the tool has been invalidated. This is to prevent
-    // Unnecessary re-calculation of the area, mean, and standard deviation if the
-    // Image is re-rendered but the tool has not moved (e.g. during a zoom)
-    if (data.invalidated === false) {
-      // If the data is not invalidated, retrieve it from the toolData
-      meanStdDev = data.meanStdDev;
-      meanStdDevSUV = data.meanStdDevSUV;
-      area = data.area;
-    } else if (!data.active) {
-      // If the data has been invalidated, and the tool is not currently active,
-      // We need to calculate it again.
-
-      // Retrieve the bounds of the ROI in image coordinates
-      const bounds = {
-        left: data.handles[0].x,
-        right: data.handles[0].x,
-        bottom: data.handles[0].y,
-        top: data.handles[0].x
+      const options = {
+        fill: fillColor
       };
 
-      for (let i = 0; i < data.handles.length; i++) {
-        bounds.left = Math.min(bounds.left, data.handles[i].x);
-        bounds.right = Math.max(bounds.right, data.handles[i].x);
-        bounds.bottom = Math.min(bounds.bottom, data.handles[i].y);
-        bounds.top = Math.max(bounds.top, data.handles[i].y);
+      if (config.alwaysShowHandles || config.keyDown.ctrl || data.active && data.polyBoundingBox) {
+        // Render all handles
+        options.handleRadius = config.activeHandleRadius;
+        drawHandles(context, eventData, data.handles, color, options);
       }
 
-      const polyBoundingBox = {
-        left: bounds.left,
-        top: bounds.bottom,
-        width: Math.abs(bounds.right - bounds.left),
-        height: Math.abs(bounds.top - bounds.bottom)
-      };
+      if (data.canComplete) {
+        // Draw large handle at the origin if can complete drawing
+        options.handleRadius = config.completeHandleRadius;
+        drawHandles(context, eventData, [data.handles[0]], color, options);
+      }
 
-      // Store the bounding box information for the text box
-      data.polyBoundingBox = polyBoundingBox;
+      if (data.active && !data.polyBoundingBox) {
+        // Draw handle at origin and at mouse if actively drawing
+        options.handleRadius = config.activeHandleRadius;
+        drawHandles(context, eventData, config.mouseLocation.handles, color, options);
+        drawHandles(context, eventData, [data.handles[0]], color, options);
+      }
 
-      // First, make sure this is not a color image, since no mean / standard
-      // Deviation will be calculated for color images.
-      if (!image.color) {
-        // Retrieve the array of pixels that the ROI bounds cover
-        const pixels = cornerstone.getPixels(element, polyBoundingBox.left, polyBoundingBox.top, polyBoundingBox.width, polyBoundingBox.height);
+      // Define variables for the area and mean/standard deviation
+      let area,
+        meanStdDev,
+        meanStdDevSUV;
 
-        // Calculate the mean & standard deviation from the pixels and the object shape
-        meanStdDev = calculateFreehandStatistics(pixels, polyBoundingBox, data.handles);
+      // Perform a check to see if the tool has been invalidated. This is to prevent
+      // Unnecessary re-calculation of the area, mean, and standard deviation if the
+      // Image is re-rendered but the tool has not moved (e.g. during a zoom)
+      if (data.invalidated === false) {
+        // If the data is not invalidated, retrieve it from the toolData
+        meanStdDev = data.meanStdDev;
+        meanStdDevSUV = data.meanStdDevSUV;
+        area = data.area;
+      } else if (!data.active) {
+        // If the data has been invalidated, and the tool is not currently active,
+        // We need to calculate it again.
 
-        if (modality === 'PT') {
-          // If the image is from a PET scan, use the DICOM tags to
-          // Calculate the SUV from the mean and standard deviation.
+        // Retrieve the bounds of the ROI in image coordinates
+        const bounds = {
+          left: data.handles[0].x,
+          right: data.handles[0].x,
+          bottom: data.handles[0].y,
+          top: data.handles[0].x
+        };
 
-          // Note that because we are using modality pixel values from getPixels, and
-          // The calculateSUV routine also rescales to modality pixel values, we are first
-          // Returning the values to storedPixel values before calcuating SUV with them.
-          // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
-          meanStdDevSUV = {
-            mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
-            stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
-          };
+        for (let i = 0; i < data.handles.length; i++) {
+          bounds.left = Math.min(bounds.left, data.handles[i].x);
+          bounds.right = Math.max(bounds.right, data.handles[i].x);
+          bounds.bottom = Math.min(bounds.bottom, data.handles[i].y);
+          bounds.top = Math.max(bounds.top, data.handles[i].y);
         }
 
-        // If the mean and standard deviation values are sane, store them for later retrieval
-        if (meanStdDev && !isNaN(meanStdDev.mean)) {
-          data.meanStdDev = meanStdDev;
-          data.meanStdDevSUV = meanStdDevSUV;
+        const polyBoundingBox = {
+          left: bounds.left,
+          top: bounds.bottom,
+          width: Math.abs(bounds.right - bounds.left),
+          height: Math.abs(bounds.top - bounds.bottom)
+        };
+
+        // Store the bounding box information for the text box
+        data.polyBoundingBox = polyBoundingBox;
+
+        // First, make sure this is not a color image, since no mean / standard
+        // Deviation will be calculated for color images.
+        if (!image.color) {
+          // Retrieve the array of pixels that the ROI bounds cover
+          const pixels = cornerstone.getPixels(element, polyBoundingBox.left, polyBoundingBox.top, polyBoundingBox.width, polyBoundingBox.height);
+
+          // Calculate the mean & standard deviation from the pixels and the object shape
+          meanStdDev = calculateFreehandStatistics(pixels, polyBoundingBox, data.handles);
+
+          if (modality === 'PT') {
+            // If the image is from a PET scan, use the DICOM tags to
+            // Calculate the SUV from the mean and standard deviation.
+
+            // Note that because we are using modality pixel values from getPixels, and
+            // The calculateSUV routine also rescales to modality pixel values, we are first
+            // Returning the values to storedPixel values before calcuating SUV with them.
+            // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+            meanStdDevSUV = {
+              mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
+              stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
+            };
+          }
+
+          // If the mean and standard deviation values are sane, store them for later retrieval
+          if (meanStdDev && !isNaN(meanStdDev.mean)) {
+            data.meanStdDev = meanStdDev;
+            data.meanStdDevSUV = meanStdDevSUV;
+          }
         }
+
+        // Retrieve the pixel spacing values, and if they are not
+        // Real non-zero values, set them to 1
+        const columnPixelSpacing = image.columnPixelSpacing || 1;
+        const rowPixelSpacing = image.rowPixelSpacing || 1;
+        const scaling = columnPixelSpacing * rowPixelSpacing;
+
+        area = freeHandArea(data.handles, scaling);
+
+        // If the area value is sane, store it for later retrieval
+        if (!isNaN(area)) {
+          data.area = area;
+        }
+
+        // Set the invalidated flag to false so that this data won't automatically be recalculated
+        data.invalidated = false;
       }
 
-      // Retrieve the pixel spacing values, and if they are not
-      // Real non-zero values, set them to 1
-      const columnPixelSpacing = image.columnPixelSpacing || 1;
-      const rowPixelSpacing = image.rowPixelSpacing || 1;
-      const scaling = columnPixelSpacing * rowPixelSpacing;
+      // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
+      if (data.polyBoundingBox && !data.textBox.freehand) {
+        // If the textbox has not been moved by the user, it should be displayed on the right-most
+        // Side of the tool.
+        if (!data.textBox.hasMoved) {
+          // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
+          // Note that this calculates it in image coordinates
+          data.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
+          data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
+        }
 
-      area = freeHandArea(data.handles, scaling);
+        const text = textBoxText(data);
 
-      // If the area value is sane, store it for later retrieval
-      if (!isNaN(area)) {
-        data.area = area;
+        drawLinkedTextBox(context, element, data.textBox, text,
+          data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
       }
-
-      // Set the invalidated flag to false so that this data won't automatically be recalculated
-      data.invalidated = false;
-    }
-
-    // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
-    if (data.polyBoundingBox && !data.textBox.freehand) {
-      // If the textbox has not been moved by the user, it should be displayed on the right-most
-      // Side of the tool.
-      if (!data.textBox.hasMoved) {
-        // Find the rightmost side of the polyBoundingBox at its vertical center, and place the textbox here
-        // Note that this calculates it in image coordinates
-        data.textBox.x = data.polyBoundingBox.left + data.polyBoundingBox.width;
-        data.textBox.y = data.polyBoundingBox.top + data.polyBoundingBox.height / 2;
-      }
-
-      const text = textBoxText(data);
-
-      drawLinkedTextBox(context, element, data.textBox, text,
-        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    }
-    context.restore();
+    });
   }
 
   function textBoxText (data) {

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -5,7 +5,7 @@ import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'highlight';
 
@@ -104,8 +104,6 @@ function onImageRendered (e) {
 
   const lineWidth = toolStyle.getToolWidth();
 
-  context.save();
-
   const data = toolData.data[0];
 
   if (data.visible === false) {
@@ -116,43 +114,44 @@ function onImageRendered (e) {
     return;
   }
 
-  const color = toolColors.getColorIfActive(data);
+  draw(context, (context) => {
+    const color = toolColors.getColorIfActive(data);
 
-  const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-  const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
+    const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
+    const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-  const rect = {
-    left: Math.min(handleStartCanvas.x, handleEndCanvas.x),
-    top: Math.min(handleStartCanvas.y, handleEndCanvas.y),
-    width: Math.abs(handleStartCanvas.x - handleEndCanvas.x),
-    height: Math.abs(handleStartCanvas.y - handleEndCanvas.y)
-  };
+    const rect = {
+      left: Math.min(handleStartCanvas.x, handleEndCanvas.x),
+      top: Math.min(handleStartCanvas.y, handleEndCanvas.y),
+      width: Math.abs(handleStartCanvas.x - handleEndCanvas.x),
+      height: Math.abs(handleStartCanvas.y - handleEndCanvas.y)
+    };
 
-    // Draw dark fill outside the rectangle
-  context.beginPath();
-  context.strokeStyle = 'transparent';
+      // Draw dark fill outside the rectangle
+    context.beginPath();
+    context.strokeStyle = 'transparent';
 
-  context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
+    context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
 
-  context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
-  context.stroke();
-  context.fillStyle = 'rgba(0,0,0,0.7)';
-  context.fill();
-  context.closePath();
+    context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
+    context.stroke();
+    context.fillStyle = 'rgba(0,0,0,0.7)';
+    context.fill();
+    context.closePath();
 
-  // Draw dashed stroke rectangle
-  context.beginPath();
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.setLineDash([4]);
-  context.strokeRect(rect.left, rect.top, rect.width, rect.height);
+    // Draw dashed stroke rectangle
+    context.beginPath();
+    context.strokeStyle = color;
+    context.lineWidth = lineWidth;
+    context.setLineDash([4]);
+    context.strokeRect(rect.left, rect.top, rect.width, rect.height);
 
-  // Strange fix, but restore doesn't seem to reset the line dashes?
-  context.setLineDash([]);
+    // Strange fix, but restore doesn't seem to reset the line dashes?
+    context.setLineDash([]);
 
-  // Draw the handles last, so they will be on top of the overlay
-  drawHandles(context, eventData, data.handles, color);
-  context.restore();
+    // Draw the handles last, so they will be on top of the overlay
+    drawHandles(context, eventData, data.handles, color);
+  });
 }
 // /////// END IMAGE RENDERING ///////
 

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -7,7 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'length';
 
@@ -85,81 +85,80 @@ function onImageRendered (e) {
   }
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
-    // Configurable shadow
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    const color = toolColors.getColorIfActive(data);
-
-    // Get the handle positions in canvas coordinates
-    const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
-    const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
-
-    // Draw the measurement line
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-    context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-    context.stroke();
-
-    // Draw the handles
-    const handleOptions = {
-      drawHandlesIfActive: (config && config.drawHandlesOnHover)
-    };
-
-    drawHandles(context, eventData, data.handles, color, handleOptions);
-
-    // Draw the text
-    context.fillStyle = color;
-
-    // Set rowPixelSpacing and columnPixelSpacing to 1 if they are undefined (or zero)
-    const dx = (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1);
-    const dy = (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1);
-
-    // Calculate the length, and create the text variable with the millimeters or pixels suffix
-    const length = Math.sqrt(dx * dx + dy * dy);
-
-    // Store the length inside the tool for outside access
-    data.length = length;
-
-    if (!data.handles.textBox.hasMoved) {
-      const coords = {
-        x: Math.max(data.handles.start.x, data.handles.end.x)
-      };
-
-      // Depending on which handle has the largest x-value,
-      // Set the y-value for the text box
-      if (coords.x === data.handles.start.x) {
-        coords.y = data.handles.start.y;
-      } else {
-        coords.y = data.handles.end.y;
+    draw(context, (context) => {
+      // Configurable shadow
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
       }
 
-      data.handles.textBox.x = coords.x;
-      data.handles.textBox.y = coords.y;
-    }
+      const color = toolColors.getColorIfActive(data);
 
-    // Move the textbox slightly to the right and upwards
-    // So that it sits beside the length tool handle
-    const xOffset = 10;
+      // Get the handle positions in canvas coordinates
+      const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
+      const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
-    const text = textBoxText(data, rowPixelSpacing, colPixelSpacing);
+      // Draw the measurement line
+      context.beginPath();
+      context.strokeStyle = color;
+      context.lineWidth = lineWidth;
+      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      context.stroke();
 
-    drawLinkedTextBox(context, element, data.handles.textBox, text,
-      data.handles, textBoxAnchorPoints, color, lineWidth, xOffset, true);
-    context.restore();
+      // Draw the handles
+      const handleOptions = {
+        drawHandlesIfActive: (config && config.drawHandlesOnHover)
+      };
+
+      drawHandles(context, eventData, data.handles, color, handleOptions);
+
+      // Draw the text
+      context.fillStyle = color;
+
+      // Set rowPixelSpacing and columnPixelSpacing to 1 if they are undefined (or zero)
+      const dx = (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1);
+      const dy = (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1);
+
+      // Calculate the length, and create the text variable with the millimeters or pixels suffix
+      const length = Math.sqrt(dx * dx + dy * dy);
+
+      // Store the length inside the tool for outside access
+      data.length = length;
+
+      if (!data.handles.textBox.hasMoved) {
+        const coords = {
+          x: Math.max(data.handles.start.x, data.handles.end.x)
+        };
+
+        // Depending on which handle has the largest x-value,
+        // Set the y-value for the text box
+        if (coords.x === data.handles.start.x) {
+          coords.y = data.handles.start.y;
+        } else {
+          coords.y = data.handles.end.y;
+        }
+
+        data.handles.textBox.x = coords.x;
+        data.handles.textBox.y = coords.y;
+      }
+
+      // Move the textbox slightly to the right and upwards
+      // So that it sits beside the length tool handle
+      const xOffset = 10;
+
+      const text = textBoxText(data, rowPixelSpacing, colPixelSpacing);
+
+      drawLinkedTextBox(context, element, data.handles.textBox, text,
+        data.handles, textBoxAnchorPoints, color, lineWidth, xOffset, true);
+    });
   }
 
   function textBoxText (data, rowPixelSpacing, colPixelSpacing) {

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -8,7 +8,7 @@ import drawTextBox from '../util/drawTextBox.js';
 import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'probe';
 
@@ -64,60 +64,59 @@ function onImageRendered (e) {
   const fontHeight = textStyle.getFontSize();
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    const color = toolColors.getColorIfActive(data);
+    draw(context, (context) => {
 
-    // Draw the handles
-    drawHandles(context, eventData, data.handles, color);
+      const color = toolColors.getColorIfActive(data);
 
-    const x = Math.round(data.handles.end.x);
-    const y = Math.round(data.handles.end.y);
-    let storedPixels;
+      // Draw the handles
+      drawHandles(context, eventData, data.handles, color);
 
-    let text,
-      str;
+      const x = Math.round(data.handles.end.x);
+      const y = Math.round(data.handles.end.y);
+      let storedPixels;
 
-    if (x < 0 || y < 0 || x >= eventData.image.columns || y >= eventData.image.rows) {
-      return;
-    }
+      let text,
+        str;
 
-    if (eventData.image.color) {
-      text = `${x}, ${y}`;
-      storedPixels = getRGBPixels(eventData.element, x, y, 1, 1);
-      str = `R: ${storedPixels[0]} G: ${storedPixels[1]} B: ${storedPixels[2]}`;
-    } else {
-      storedPixels = cornerstone.getStoredPixels(eventData.element, x, y, 1, 1);
-      const sp = storedPixels[0];
-      const mo = sp * eventData.image.slope + eventData.image.intercept;
-      const suv = calculateSUV(eventData.image, sp);
+      if (x >= 0 && y >= 0 && x < eventData.image.columns && y < eventData.image.rows) {
+        if (eventData.image.color) {
+          text = `${x}, ${y}`;
+          storedPixels = getRGBPixels(eventData.element, x, y, 1, 1);
+          str = `R: ${storedPixels[0]} G: ${storedPixels[1]} B: ${storedPixels[2]}`;
+        } else {
+          storedPixels = cornerstone.getStoredPixels(eventData.element, x, y, 1, 1);
+          const sp = storedPixels[0];
+          const mo = sp * eventData.image.slope + eventData.image.intercept;
+          const suv = calculateSUV(eventData.image, sp);
 
-      // Draw text
-      text = `${x}, ${y}`;
-      str = `SP: ${sp} MO: ${parseFloat(mo.toFixed(3))}`;
-      if (suv) {
-        str += ` SUV: ${parseFloat(suv.toFixed(3))}`;
+          // Draw text
+          text = `${x}, ${y}`;
+          str = `SP: ${sp} MO: ${parseFloat(mo.toFixed(3))}`;
+          if (suv) {
+            str += ` SUV: ${parseFloat(suv.toFixed(3))}`;
+          }
+        }
+
+        const coords = {
+          // Translate the x/y away from the cursor
+          x: data.handles.end.x + 3,
+          y: data.handles.end.y - 3
+        };
+        const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
+
+        context.font = font;
+        context.fillStyle = color;
+
+        drawTextBox(context, str, textCoords.x, textCoords.y + fontHeight + 5, color);
+        drawTextBox(context, text, textCoords.x, textCoords.y, color);
       }
-    }
-
-    const coords = {
-      // Translate the x/y away from the cursor
-      x: data.handles.end.x + 3,
-      y: data.handles.end.y - 3
-    };
-    const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
-
-    context.font = font;
-    context.fillStyle = color;
-
-    drawTextBox(context, str, textCoords.x, textCoords.y + fontHeight + 5, color);
-    drawTextBox(context, text, textCoords.x, textCoords.y, color);
-    context.restore();
+    });
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -7,7 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'rectangleRoi';
 
@@ -154,142 +154,141 @@ function onImageRendered (e) {
 
   // If we have tool data for this element - iterate over each set and draw it
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    // Apply any shadow settings defined in the tool configuration
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
+    draw(context, (context) => {
+      // Apply any shadow settings defined in the tool configuration
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
+      }
 
-    // Check which color the rendered tool should be
-    const color = toolColors.getColorIfActive(data);
+      // Check which color the rendered tool should be
+      const color = toolColors.getColorIfActive(data);
 
-    // Convert Image coordinates to Canvas coordinates given the element
-    const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
-    const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
+      // Convert Image coordinates to Canvas coordinates given the element
+      const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
+      const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
-    // Retrieve the bounds of the ellipse (left, top, width, and height)
-    // In Canvas coordinates
-    const leftCanvas = Math.min(handleStartCanvas.x, handleEndCanvas.x);
-    const topCanvas = Math.min(handleStartCanvas.y, handleEndCanvas.y);
-    const widthCanvas = Math.abs(handleStartCanvas.x - handleEndCanvas.x);
-    const heightCanvas = Math.abs(handleStartCanvas.y - handleEndCanvas.y);
+      // Retrieve the bounds of the ellipse (left, top, width, and height)
+      // In Canvas coordinates
+      const leftCanvas = Math.min(handleStartCanvas.x, handleEndCanvas.x);
+      const topCanvas = Math.min(handleStartCanvas.y, handleEndCanvas.y);
+      const widthCanvas = Math.abs(handleStartCanvas.x - handleEndCanvas.x);
+      const heightCanvas = Math.abs(handleStartCanvas.y - handleEndCanvas.y);
 
-    // Draw the rectangle on the canvas
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.rect(leftCanvas, topCanvas, widthCanvas, heightCanvas);
-    context.stroke();
+      // Draw the rectangle on the canvas
+      context.beginPath();
+      context.strokeStyle = color;
+      context.lineWidth = lineWidth;
+      context.rect(leftCanvas, topCanvas, widthCanvas, heightCanvas);
+      context.stroke();
 
-    // If the tool configuration specifies to only draw the handles on hover / active,
-    // Follow this logic
-    if (config && config.drawHandlesOnHover) {
-      // Draw the handles if the tool is active
-      if (data.active === true) {
-        drawHandles(context, eventData, data.handles, color);
+      // If the tool configuration specifies to only draw the handles on hover / active,
+      // Follow this logic
+      if (config && config.drawHandlesOnHover) {
+        // Draw the handles if the tool is active
+        if (data.active === true) {
+          drawHandles(context, eventData, data.handles, color);
+        } else {
+          // If the tool is inactive, draw the handles only if each specific handle is being
+          // Hovered over
+          const handleOptions = {
+            drawHandlesIfActive: true
+          };
+
+          drawHandles(context, eventData, data.handles, color, handleOptions);
+        }
       } else {
-        // If the tool is inactive, draw the handles only if each specific handle is being
-        // Hovered over
-        const handleOptions = {
-          drawHandlesIfActive: true
+        // If the tool has no configuration settings, always draw the handles
+        drawHandles(context, eventData, data.handles, color);
+      }
+
+      // Define variables for the area and mean/standard deviation
+      let area,
+        meanStdDev,
+        meanStdDevSUV;
+
+      // Perform a check to see if the tool has been invalidated. This is to prevent
+      // Unnecessary re-calculation of the area, mean, and standard deviation if the
+      // Image is re-rendered but the tool has not moved (e.g. during a zoom)
+      if (data.invalidated === false) {
+        // If the data is not invalidated, retrieve it from the toolData
+        meanStdDev = data.meanStdDev;
+        meanStdDevSUV = data.meanStdDevSUV;
+        area = data.area;
+      } else {
+        // If the data has been invalidated, we need to calculate it again
+
+        // Retrieve the bounds of the ellipse in image coordinates
+        const ellipse = {
+          left: Math.min(data.handles.start.x, data.handles.end.x),
+          top: Math.min(data.handles.start.y, data.handles.end.y),
+          width: Math.abs(data.handles.start.x - data.handles.end.x),
+          height: Math.abs(data.handles.start.y - data.handles.end.y)
         };
 
-        drawHandles(context, eventData, data.handles, color, handleOptions);
-      }
-    } else {
-      // If the tool has no configuration settings, always draw the handles
-      drawHandles(context, eventData, data.handles, color);
-    }
+        // First, make sure this is not a color image, since no mean / standard
+        // Deviation will be calculated for color images.
+        if (!image.color) {
+          // Retrieve the array of pixels that the ellipse bounds cover
+          const pixels = cornerstone.getPixels(element, ellipse.left, ellipse.top, ellipse.width, ellipse.height);
 
-    // Define variables for the area and mean/standard deviation
-    let area,
-      meanStdDev,
-      meanStdDevSUV;
+          // Calculate the mean & standard deviation from the pixels and the ellipse details
+          meanStdDev = calculateMeanStdDev(pixels, ellipse);
 
-    // Perform a check to see if the tool has been invalidated. This is to prevent
-    // Unnecessary re-calculation of the area, mean, and standard deviation if the
-    // Image is re-rendered but the tool has not moved (e.g. during a zoom)
-    if (data.invalidated === false) {
-      // If the data is not invalidated, retrieve it from the toolData
-      meanStdDev = data.meanStdDev;
-      meanStdDevSUV = data.meanStdDevSUV;
-      area = data.area;
-    } else {
-      // If the data has been invalidated, we need to calculate it again
+          if (modality === 'PT') {
+            // If the image is from a PET scan, use the DICOM tags to
+            // Calculate the SUV from the mean and standard deviation.
 
-      // Retrieve the bounds of the ellipse in image coordinates
-      const ellipse = {
-        left: Math.min(data.handles.start.x, data.handles.end.x),
-        top: Math.min(data.handles.start.y, data.handles.end.y),
-        width: Math.abs(data.handles.start.x - data.handles.end.x),
-        height: Math.abs(data.handles.start.y - data.handles.end.y)
-      };
+            // Note that because we are using modality pixel values from getPixels, and
+            // The calculateSUV routine also rescales to modality pixel values, we are first
+            // Returning the values to storedPixel values before calcuating SUV with them.
+            // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+            meanStdDevSUV = {
+              mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
+              stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
+            };
+          }
 
-      // First, make sure this is not a color image, since no mean / standard
-      // Deviation will be calculated for color images.
-      if (!image.color) {
-        // Retrieve the array of pixels that the ellipse bounds cover
-        const pixels = cornerstone.getPixels(element, ellipse.left, ellipse.top, ellipse.width, ellipse.height);
-
-        // Calculate the mean & standard deviation from the pixels and the ellipse details
-        meanStdDev = calculateMeanStdDev(pixels, ellipse);
-
-        if (modality === 'PT') {
-          // If the image is from a PET scan, use the DICOM tags to
-          // Calculate the SUV from the mean and standard deviation.
-
-          // Note that because we are using modality pixel values from getPixels, and
-          // The calculateSUV routine also rescales to modality pixel values, we are first
-          // Returning the values to storedPixel values before calcuating SUV with them.
-          // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
-          meanStdDevSUV = {
-            mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
-            stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
-          };
+          // If the mean and standard deviation values are sane, store them for later retrieval
+          if (meanStdDev && !isNaN(meanStdDev.mean)) {
+            data.meanStdDev = meanStdDev;
+            data.meanStdDevSUV = meanStdDevSUV;
+          }
         }
 
-        // If the mean and standard deviation values are sane, store them for later retrieval
-        if (meanStdDev && !isNaN(meanStdDev.mean)) {
-          data.meanStdDev = meanStdDev;
-          data.meanStdDevSUV = meanStdDevSUV;
+        // Calculate the image area from the ellipse dimensions and pixel spacing
+        area = (ellipse.width * (colPixelSpacing || 1)) * (ellipse.height * (rowPixelSpacing || 1));
+
+        // If the area value is sane, store it for later retrieval
+        if (!isNaN(area)) {
+          data.area = area;
         }
+
+        // Set the invalidated flag to false so that this data won't automatically be recalculated
+        data.invalidated = false;
       }
 
-      // Calculate the image area from the ellipse dimensions and pixel spacing
-      area = (ellipse.width * (colPixelSpacing || 1)) * (ellipse.height * (rowPixelSpacing || 1));
+      const text = textBoxText(data);
 
-      // If the area value is sane, store it for later retrieval
-      if (!isNaN(area)) {
-        data.area = area;
+      // If the textbox has not been moved by the user, it should be displayed on the right-most
+      // Side of the tool.
+      if (!data.handles.textBox.hasMoved) {
+        // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
+        // Note that this calculates it in image coordinates
+        data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
+        data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
       }
 
-      // Set the invalidated flag to false so that this data won't automatically be recalculated
-      data.invalidated = false;
-    }
-
-    const text = textBoxText(data);
-
-    // If the textbox has not been moved by the user, it should be displayed on the right-most
-    // Side of the tool.
-    if (!data.handles.textBox.hasMoved) {
-      // Find the rightmost side of the ellipse at its vertical center, and place the textbox here
-      // Note that this calculates it in image coordinates
-      data.handles.textBox.x = Math.max(data.handles.start.x, data.handles.end.x);
-      data.handles.textBox.y = (data.handles.start.y + data.handles.end.y) / 2;
-    }
-
-    drawLinkedTextBox(context, element, data.handles.textBox, text,
-      data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    context.restore();
+      drawLinkedTextBox(context, element, data.handles.textBox, text,
+        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
+    });
   }
 
   function textBoxText (data) {

--- a/src/imageTools/scaleOverlayTool.js
+++ b/src/imageTools/scaleOverlayTool.js
@@ -1,7 +1,7 @@
 import displayTool from './displayTool.js';
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const configuration = {
   color: 'white',
@@ -225,10 +225,9 @@ function onImageRendered (e) {
     }
   }, configuration);
 
-  context.save();
-
-  drawScalebars(context, imageAttributes);
-  context.restore();
+  draw(context, (context) => {
+    drawScalebars(context, imageAttributes);
+  });
 }
 // /////// END IMAGE RENDERING ///////
 

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -14,7 +14,7 @@ import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
-import { drawCircle, getNewContext } from '../util/drawing.js';
+import { drawCircle, getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'seedAnnotate';
 
@@ -145,76 +145,75 @@ function onImageRendered (e) {
   const config = seedAnnotate.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    const color = toolColors.getColorIfActive(data);
-
-    // Draw
-    const handleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
-
-    // Draw the circle always at the end of the handle
-    const handleRadius = 6;
-
-    drawCircle(context, eventData.element, data.handles.end, handleRadius, { color });
-
-    const handleOptions = {
-      drawHandlesIfActive: (config && config.drawHandlesOnHover)
-    };
-
-    if (config.drawHandles) {
-      drawHandles(context, eventData, handleCanvas, color, handleOptions);
-    }
-
-    // Draw the text
-    if (data.text && data.text !== '') {
-      const text = textBoxText(data);
-
-      context.font = font;
-
-      // Calculate the text coordinates.
-      const textWidth = context.measureText(text).width + 10;
-      const textHeight = textStyle.getFontSize() + 10;
-
-      let distance = Math.max(textWidth, textHeight) / 2 + 5;
-
-      if (handleCanvas.x > (canvasWidth / 2)) {
-        distance = -distance;
+    draw(context, (context) => {
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
       }
 
-      let textCoords;
+      const color = toolColors.getColorIfActive(data);
 
-      if (!data.handles.textBox.hasMoved) {
-        textCoords = {
-          x: handleCanvas.x - textWidth / 2 + distance,
-          y: handleCanvas.y - textHeight / 2
-        };
+      // Draw
+      const handleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-        const transform = cornerstone.internal.getTransform(enabledElement);
+      // Draw the circle always at the end of the handle
+      const handleRadius = 6;
 
-        transform.invert();
+      drawCircle(context, eventData.element, data.handles.end, handleRadius, { color });
 
-        const coords = transform.transformPoint(textCoords.x, textCoords.y);
+      const handleOptions = {
+        drawHandlesIfActive: (config && config.drawHandlesOnHover)
+      };
 
-        data.handles.textBox.x = coords.x;
-        data.handles.textBox.y = coords.y;
+      if (config.drawHandles) {
+        drawHandles(context, eventData, handleCanvas, color, handleOptions);
       }
 
-      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
-        data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
-    }
-    context.restore();
+      // Draw the text
+      if (data.text && data.text !== '') {
+        const text = textBoxText(data);
+
+        context.font = font;
+
+        // Calculate the text coordinates.
+        const textWidth = context.measureText(text).width + 10;
+        const textHeight = textStyle.getFontSize() + 10;
+
+        let distance = Math.max(textWidth, textHeight) / 2 + 5;
+
+        if (handleCanvas.x > (canvasWidth / 2)) {
+          distance = -distance;
+        }
+
+        let textCoords;
+
+        if (!data.handles.textBox.hasMoved) {
+          textCoords = {
+            x: handleCanvas.x - textWidth / 2 + distance,
+            y: handleCanvas.y - textHeight / 2
+          };
+
+          const transform = cornerstone.internal.getTransform(enabledElement);
+
+          transform.invert();
+
+          const coords = transform.transformPoint(textCoords.x, textCoords.y);
+
+          data.handles.textBox.x = coords.x;
+          data.handles.textBox.y = coords.y;
+        }
+
+        drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
+          data.handles, textBoxAnchorPoints, color, lineWidth, 0, false);
+      }
+    });
   }
 
   function textBoxText (data) {

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -13,7 +13,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 
 const toolType = 'simpleAngle';
@@ -93,112 +93,111 @@ function onImageRendered (e) {
   const config = simpleAngle.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
     const data = toolData.data[i];
 
     if (data.visible === false) {
       continue;
     }
 
-    // Differentiate the color of activation tool
-    const color = toolColors.getColorIfActive(data);
-
-    const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-    const handleMiddleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.middle);
-    const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
-
-    // Draw the line
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-    context.lineTo(handleMiddleCanvas.x, handleMiddleCanvas.y);
-    context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-    context.stroke();
-
-    // Draw the handles
-    const handleOptions = {
-      drawHandlesIfActive: (config && config.drawHandlesOnHover)
-    };
-
-    drawHandles(context, eventData, data.handles, color, handleOptions);
-
-    // Draw the text
-    context.fillStyle = color;
-
-    // Default to isotropic pixel size, update suffix to reflect this
-    const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
-    const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
-
-    const sideA = {
-      x: (Math.ceil(data.handles.middle.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
-      y: (Math.ceil(data.handles.middle.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
-    };
-
-    const sideB = {
-      x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.middle.x)) * columnPixelSpacing,
-      y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.middle.y)) * rowPixelSpacing
-    };
-
-    const sideC = {
-      x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
-      y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
-    };
-
-    const sideALength = length(sideA);
-    const sideBLength = length(sideB);
-    const sideCLength = length(sideC);
-
-    // Cosine law
-    let angle = Math.acos((Math.pow(sideALength, 2) + Math.pow(sideBLength, 2) - Math.pow(sideCLength, 2)) / (2 * sideALength * sideBLength));
-
-    angle *= (180 / Math.PI);
-
-    data.rAngle = roundToDecimal(angle, 2);
-
-    if (data.rAngle) {
-      const text = textBoxText(data, eventData.image.rowPixelSpacing, eventData.image.columnPixelSpacing);
-
-      const distance = 15;
-
-      let textCoords;
-
-      if (!data.handles.textBox.hasMoved) {
-        textCoords = {
-          x: handleMiddleCanvas.x,
-          y: handleMiddleCanvas.y
-        };
-
-        context.font = font;
-        const textWidth = context.measureText(text).width;
-
-        if (handleMiddleCanvas.x < handleStartCanvas.x) {
-          textCoords.x -= distance + textWidth + 10;
-        } else {
-          textCoords.x += distance;
-        }
-
-        const transform = cornerstone.internal.getTransform(enabledElement);
-
-        transform.invert();
-
-        const coords = transform.transformPoint(textCoords.x, textCoords.y);
-
-        data.handles.textBox.x = coords.x;
-        data.handles.textBox.y = coords.y;
+    draw(context, (context) => {
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
       }
 
-      drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
-        data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
-    }
-    context.restore();
+      // Differentiate the color of activation tool
+      const color = toolColors.getColorIfActive(data);
+
+      const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
+      const handleMiddleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.middle);
+      const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
+
+      // Draw the line
+      context.beginPath();
+      context.strokeStyle = color;
+      context.lineWidth = lineWidth;
+      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+      context.lineTo(handleMiddleCanvas.x, handleMiddleCanvas.y);
+      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      context.stroke();
+
+      // Draw the handles
+      const handleOptions = {
+        drawHandlesIfActive: (config && config.drawHandlesOnHover)
+      };
+
+      drawHandles(context, eventData, data.handles, color, handleOptions);
+
+      // Draw the text
+      context.fillStyle = color;
+
+      // Default to isotropic pixel size, update suffix to reflect this
+      const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
+      const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
+
+      const sideA = {
+        x: (Math.ceil(data.handles.middle.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
+        y: (Math.ceil(data.handles.middle.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
+      };
+
+      const sideB = {
+        x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.middle.x)) * columnPixelSpacing,
+        y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.middle.y)) * rowPixelSpacing
+      };
+
+      const sideC = {
+        x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
+        y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
+      };
+
+      const sideALength = length(sideA);
+      const sideBLength = length(sideB);
+      const sideCLength = length(sideC);
+
+      // Cosine law
+      let angle = Math.acos((Math.pow(sideALength, 2) + Math.pow(sideBLength, 2) - Math.pow(sideCLength, 2)) / (2 * sideALength * sideBLength));
+
+      angle *= (180 / Math.PI);
+
+      data.rAngle = roundToDecimal(angle, 2);
+
+      if (data.rAngle) {
+        const text = textBoxText(data, eventData.image.rowPixelSpacing, eventData.image.columnPixelSpacing);
+
+        const distance = 15;
+
+        let textCoords;
+
+        if (!data.handles.textBox.hasMoved) {
+          textCoords = {
+            x: handleMiddleCanvas.x,
+            y: handleMiddleCanvas.y
+          };
+
+          context.font = font;
+          const textWidth = context.measureText(text).width;
+
+          if (handleMiddleCanvas.x < handleStartCanvas.x) {
+            textCoords.x -= distance + textWidth + 10;
+          } else {
+            textCoords.x += distance;
+          }
+
+          const transform = cornerstone.internal.getTransform(enabledElement);
+
+          transform.invert();
+
+          const coords = transform.transformPoint(textCoords.x, textCoords.y);
+
+          data.handles.textBox.x = coords.x;
+          data.handles.textBox.y = coords.y;
+        }
+
+        drawLinkedTextBox(context, eventData.element, data.handles.textBox, text,
+          data.handles, textBoxAnchorPoints, color, lineWidth, 0, true);
+      }
+    });
   }
 
   function textBoxText (data, rowPixelSpacing, columnPixelSpacing) {

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -8,7 +8,7 @@ import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import drawTextBox from '../util/drawTextBox.js';
 import { removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 const toolType = 'textMarker';
 
@@ -121,32 +121,30 @@ function onImageRendered (e) {
 
     const color = toolColors.getColorIfActive(data);
 
-    context.save();
-
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
-    // Draw text
-    context.fillStyle = color;
-    const measureText = context.measureText(data.text);
-
-    data.textWidth = measureText.width + 10;
-
-    const textCoords = external.cornerstone.pixelToCanvas(eventData.element, data.handles.end);
-
-    const options = {
-      centering: {
-        x: true,
-        y: true
+    draw(context, (context) => {
+      if (config && config.shadow) {
+        context.shadowColor = config.shadowColor || '#000000';
+        context.shadowOffsetX = config.shadowOffsetX || 1;
+        context.shadowOffsetY = config.shadowOffsetY || 1;
       }
-    };
 
-    data.handles.end.boundingBox = drawTextBox(context, data.text, textCoords.x, textCoords.y - 10, color, options);
+      // Draw text
+      context.fillStyle = color;
+      const measureText = context.measureText(data.text);
 
-    context.restore();
+      data.textWidth = measureText.width + 10;
+
+      const textCoords = external.cornerstone.pixelToCanvas(eventData.element, data.handles.end);
+
+      const options = {
+        centering: {
+          x: true,
+          y: true
+        }
+      };
+
+      data.handles.end.boundingBox = drawTextBox(context, data.text, textCoords.x, textCoords.y - 10, color, options);
+    });
   }
 }
 

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -7,6 +7,7 @@ import getLuminance from '../util/getLuminance.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import clip from '../util/clip.js';
+import { draw } from '../util/drawing.js';
 
 const toolType = 'wwwcRegion';
 
@@ -249,21 +250,19 @@ function onImageRendered (e) {
   const config = wwwcRegion.getConfiguration();
 
   // Draw the rectangle
-  context.save();
+  draw(context, (context) => {
+    if (config && config.shadow) {
+      context.shadowColor = config.shadowColor || '#000000';
+      context.shadowOffsetX = config.shadowOffsetX || 1;
+      context.shadowOffsetY = config.shadowOffsetY || 1;
+    }
 
-  if (config && config.shadow) {
-    context.shadowColor = config.shadowColor || '#000000';
-    context.shadowOffsetX = config.shadowOffsetX || 1;
-    context.shadowOffsetY = config.shadowOffsetY || 1;
-  }
-
-  context.beginPath();
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.rect(left, top, width, height);
-  context.stroke();
-
-  context.restore();
+    context.beginPath();
+    context.strokeStyle = color;
+    context.lineWidth = lineWidth;
+    context.rect(left, top, width, height);
+    context.stroke();
+  });
 }
 
 // --- Mouse tool enable / disable --- ///

--- a/src/paintingTools/drawBrush.js
+++ b/src/paintingTools/drawBrush.js
@@ -1,4 +1,5 @@
 import external from '../externalModules.js';
+import { draw } from '../util/drawing.js';
 
 function drawBrushPixels (pointerArray, storedPixels, brushPixelValue, columns) {
   const getPixelIndex = (x, y) => (y * columns) + x;
@@ -10,7 +11,7 @@ function drawBrushPixels (pointerArray, storedPixels, brushPixelValue, columns) 
   });
 }
 
-function drawBrushOnCanvas (pointerArray, canvasContext, color, element) {
+function drawBrushOnCanvas (pointerArray, context, color, element) {
   const canvasPtTL = external.cornerstone.pixelToCanvas(element, { x: 0,
     y: 0 });
   const canvasPtBR = external.cornerstone.pixelToCanvas(element, { x: 1,
@@ -18,19 +19,18 @@ function drawBrushOnCanvas (pointerArray, canvasContext, color, element) {
   const sizeX = canvasPtBR.x - canvasPtTL.x;
   const sizeY = canvasPtBR.y - canvasPtTL.y;
 
-  canvasContext.save();
-  canvasContext.fillStyle = color;
+  draw(context, (context) => {
+    context.fillStyle = color;
 
-  pointerArray.forEach((point) => {
-    const canvasPt = external.cornerstone.pixelToCanvas(element, {
-      x: point[0],
-      y: point[1]
+    pointerArray.forEach((point) => {
+      const canvasPt = external.cornerstone.pixelToCanvas(element, {
+        x: point[0],
+        y: point[1]
+      });
+
+      context.fillRect(canvasPt.x, canvasPt.y, sizeX, sizeY);
     });
-
-    canvasContext.fillRect(canvasPt.x, canvasPt.y, sizeX, sizeY);
   });
-
-  canvasContext.restore();
 }
 
 export { drawBrushPixels, drawBrushOnCanvas };

--- a/src/referenceLines/renderActiveReferenceLine.js
+++ b/src/referenceLines/renderActiveReferenceLine.js
@@ -3,6 +3,7 @@ import calculateReferenceLine from './calculateReferenceLine.js';
 import toolColors from '../stateManagement/toolColors.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import convertToVector3 from '../util/convertToVector3.js';
+import { draw } from '../util/drawing.js';
 
 // Renders the active reference line
 export default function (context, eventData, targetElement, referenceElement) {
@@ -67,12 +68,12 @@ export default function (context, eventData, targetElement, referenceElement) {
   // Draw the referenceLines
   context.setTransform(1, 0, 0, 1, 0, 0);
 
-  context.save();
-  context.beginPath();
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.moveTo(refLineStartCanvas.x, refLineStartCanvas.y);
-  context.lineTo(refLineEndCanvas.x, refLineEndCanvas.y);
-  context.stroke();
-  context.restore();
+  draw(context, (context) => {
+    context.beginPath();
+    context.strokeStyle = color;
+    context.lineWidth = lineWidth;
+    context.moveTo(refLineStartCanvas.x, refLineStartCanvas.y);
+    context.lineTo(refLineEndCanvas.x, refLineEndCanvas.y);
+    context.stroke();
+  });
 }

--- a/src/stackTools/scrollIndicator.js
+++ b/src/stackTools/scrollIndicator.js
@@ -1,6 +1,6 @@
 import displayTool from '../imageTools/displayTool.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, draw } from '../util/drawing.js';
 
 /*
 Display scroll progress bar across bottom of image.
@@ -25,42 +25,38 @@ function onImageRendered (e) {
 
   const context = getNewContext(eventData.enabledElement.canvas);
 
-  context.save();
+  draw(context, (context) => {
+    const config = scrollIndicator.getConfiguration();
 
-  const config = scrollIndicator.getConfiguration();
+    // Draw indicator background
+    context.fillStyle = config.backgroundColor;
+    if (config.orientation === 'horizontal') {
+      context.fillRect(0, height - scrollBarHeight, width, scrollBarHeight);
+    } else {
+      context.fillRect(0, 0, scrollBarHeight, height);
+    }
 
-  // Draw indicator background
-  context.fillStyle = config.backgroundColor;
-  if (config.orientation === 'horizontal') {
-    context.fillRect(0, height - scrollBarHeight, width, scrollBarHeight);
-  } else {
-    context.fillRect(0, 0, scrollBarHeight, height);
-  }
+    // Get current image index
+    const stackData = getToolState(element, 'stack');
 
-  // Get current image index
-  const stackData = getToolState(element, 'stack');
+    if (stackData && stackData.data && stackData.data.length) {
+      const imageIds = stackData.data[0].imageIds;
+      const currentImageIdIndex = stackData.data[0].currentImageIdIndex;
 
-  if (!stackData || !stackData.data || !stackData.data.length) {
-    return;
-  }
+      // Draw current image cursor
+      const cursorWidth = width / imageIds.length;
+      const cursorHeight = height / imageIds.length;
+      const xPosition = cursorWidth * currentImageIdIndex;
+      const yPosition = cursorHeight * currentImageIdIndex;
 
-  const imageIds = stackData.data[0].imageIds;
-  const currentImageIdIndex = stackData.data[0].currentImageIdIndex;
-
-  // Draw current image cursor
-  const cursorWidth = width / imageIds.length;
-  const cursorHeight = height / imageIds.length;
-  const xPosition = cursorWidth * currentImageIdIndex;
-  const yPosition = cursorHeight * currentImageIdIndex;
-
-  context.fillStyle = config.fillColor;
-  if (config.orientation === 'horizontal') {
-    context.fillRect(xPosition, height - scrollBarHeight, cursorWidth, scrollBarHeight);
-  } else {
-    context.fillRect(0, yPosition, scrollBarHeight, cursorHeight);
-  }
-
-  context.restore();
+      context.fillStyle = config.fillColor;
+      if (config.orientation === 'horizontal') {
+        context.fillRect(xPosition, height - scrollBarHeight, cursorWidth, scrollBarHeight);
+      } else {
+        context.fillRect(0, yPosition, scrollBarHeight, cursorHeight);
+      }
+    }
+  });
 }
 
 const scrollIndicator = displayTool(onImageRendered);

--- a/src/timeSeriesTools/probeTool4D.js
+++ b/src/timeSeriesTools/probeTool4D.js
@@ -6,6 +6,7 @@ import MeasurementManager from '../measurementManager/measurementManager.js';
 import LineSampleMeasurement from '../measurementManager/lineSampleMeasurement.js';
 import textStyle from '../stateManagement/textStyle.js';
 import drawTextBox from '../util/drawTextBox.js';
+import { draw } from '../util/drawing.js';
 
 const toolType = 'probe4D';
 
@@ -86,29 +87,28 @@ function onImageRendered (e) {
   const font = textStyle.getFont();
 
   for (let i = 0; i < toolData.data.length; i++) {
-    context.save();
-    const data = toolData.data[i];
+    draw(context, (context) => {
+      const data = toolData.data[i];
 
-    // Draw the handles
-    context.beginPath();
-    drawHandles(context, eventData, data.handles, color);
-    context.stroke();
+      // Draw the handles
+      context.beginPath();
+      drawHandles(context, eventData, data.handles, color);
+      context.stroke();
 
-    context.font = font;
+      context.font = font;
 
-    const coords = {
-      // Translate the x/y away from the cursor
-      x: data.handles.end.x + 3,
-      y: data.handles.end.y - 3
-    };
+      const coords = {
+        // Translate the x/y away from the cursor
+        x: data.handles.end.x + 3,
+        y: data.handles.end.y - 3
+      };
 
-    const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
+      const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
 
-    context.fillStyle = color;
+      context.fillStyle = color;
 
-    drawTextBox(context, `${data.handles.end.x}, ${data.handles.end.y}`, textCoords.x, textCoords.y, color);
-
-    context.restore();
+      drawTextBox(context, `${data.handles.end.x}, ${data.handles.end.y}`, textCoords.x, textCoords.y, color);
+    });
   }
 }
 // /////// END IMAGE RENDERING ///////

--- a/src/util/drawTextBox.js
+++ b/src/util/drawTextBox.js
@@ -1,4 +1,5 @@
 import textStyle from '../stateManagement/textStyle.js';
+import { draw } from './drawing.js';
 
 export default function (context, textLines, x, y, color, options) {
   if (Object.prototype.toString.call(textLines) !== '[object Array]') {
@@ -9,11 +10,6 @@ export default function (context, textLines, x, y, color, options) {
   const font = textStyle.getFont();
   const fontSize = textStyle.getFontSize();
   const backgroundColor = textStyle.getBackgroundColor();
-
-  context.save();
-  context.font = font;
-  context.textBaseline = 'top';
-  context.strokeStyle = color;
 
   // Find the longest text width in the array of text data
   let maxWidth = 0;
@@ -26,47 +22,51 @@ export default function (context, textLines, x, y, color, options) {
     maxWidth = Math.max(maxWidth, width);
   });
 
-  // Draw the background box with padding
-  context.fillStyle = backgroundColor;
-
   // Calculate the bounding box for this text box
   const boundingBox = {
     width: maxWidth + (padding * 2),
     height: padding + textLines.length * (fontSize + padding)
   };
 
-  if (options && options.centering && options.centering.x === true) {
-    x -= boundingBox.width / 2;
-  }
+  draw(context, (context) => {
+    context.font = font;
+    context.textBaseline = 'top';
+    context.strokeStyle = color;
 
-  if (options && options.centering && options.centering.y === true) {
-    y -= boundingBox.height / 2;
-  }
+    // Draw the background box with padding
+    context.fillStyle = backgroundColor;
 
-  boundingBox.left = x;
-  boundingBox.top = y;
+    if (options && options.centering && options.centering.x === true) {
+      x -= boundingBox.width / 2;
+    }
 
-  if (options && options.debug === true) {
-    context.fillStyle = '#FF0000';
-  }
+    if (options && options.centering && options.centering.y === true) {
+      y -= boundingBox.height / 2;
+    }
 
-  context.fillRect(boundingBox.left, boundingBox.top, boundingBox.width, boundingBox.height);
+    boundingBox.left = x;
+    boundingBox.top = y;
 
-  // Draw each of the text lines on top of the background box
-  textLines.forEach(function (text, index) {
-    context.fillStyle = color;
+    if (options && options.debug === true) {
+      context.fillStyle = '#FF0000';
+    }
 
-    /* Var ypos;
-        if (index === 0) {
-            ypos = y + index * (fontSize + padding);
-        } else {
-            ypos = y + index * (fontSize + padding * 2);
-        }*/
+    context.fillRect(boundingBox.left, boundingBox.top, boundingBox.width, boundingBox.height);
 
-    context.fillText(text, x + padding, y + padding + index * (fontSize + padding));
+    // Draw each of the text lines on top of the background box
+    textLines.forEach(function (text, index) {
+      context.fillStyle = color;
+
+      /* Var ypos;
+          if (index === 0) {
+              ypos = y + index * (fontSize + padding);
+          } else {
+              ypos = y + index * (fontSize + padding * 2);
+          }*/
+
+      context.fillText(text, x + padding, y + padding + index * (fontSize + padding));
+    });
   });
-
-  context.restore();
 
   // Return the bounding box so it can be used for pointNearHandle
   return boundingBox;


### PR DESCRIPTION
This PR replaces calls to `context.save()` and `context.restore()` with calls to the `draw()` function from the `drawing.js` API.

In some cases in the existing code, there would be a `return` or `continue` statement between the calls to `context.save()` and `context.restore()`. The logic for this flow control has been shifted outside the `draw()` function to ensure that we don't have calls to `context.save()` which never call `context.restore()`.

See #405 for full discussion
