### PR TITLE
[4/N] Use the path function from drawing.js

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -9,7 +9,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -97,24 +97,21 @@ function onImageRendered (e) {
 
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);
-
-      // Draw the line
-      context.beginPath();
-      context.strokeStyle = color;
-      context.lineWidth = lineWidth;
-
       let handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
       let handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      // Draw the line
+      path(context, { color,
+        lineWidth }, (context) => {
+        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
 
-      handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
-      handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
+        handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
+        handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
 
-      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      context.stroke();
+        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      });
 
       // Draw the handles
       drawHandles(context, eventData, data.handles);

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -9,7 +9,7 @@ import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { getToolOptions } from '../toolOptions.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'dragProbe';
 
@@ -169,10 +169,9 @@ function minimalStrategy (eventData) {
       };
     }
 
-    context.beginPath();
-    context.strokeStyle = color;
-    context.arc(textCoords.x, textCoords.y, handleRadius, 0, 2 * Math.PI);
-    context.stroke();
+    path(context, { color }, (context) => {
+      context.arc(textCoords.x, textCoords.y, handleRadius, 0, 2 * Math.PI);
+    });
 
     drawTextBox(context, text, textCoords.x + translation.x, textCoords.y + translation.y, color);
   });

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -22,7 +22,7 @@ import freeHandArea from '../util/freehand/freeHandArea.js';
 import calculateFreehandStatistics from '../util/freehand/calculateFreehandStatistics.js';
 import freeHandIntersect from '../util/freehand/freeHandIntersect.js';
 import { FreehandHandleData } from '../util/freehand/FreehandHandleData.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'freehand';
 let configuration = {
@@ -826,28 +826,26 @@ function onImageRendered (e) {
           handleStart = data.handles[j];
           const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, handleStart);
 
-          context.beginPath();
-          context.strokeStyle = color;
-          context.lineWidth = lineWidth;
-          context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+          path(context, { color,
+            lineWidth }, (context) => {
+            context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
 
-          for (let k = 0; k < data.handles[j].lines.length; k++) {
-            const lineCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles[j].lines[k]);
+            for (let k = 0; k < data.handles[j].lines.length; k++) {
+              const lineCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles[j].lines[k]);
 
-            context.lineTo(lineCanvas.x, lineCanvas.y);
-            context.stroke();
-          }
-
-          const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
-
-          if (j === (data.handles.length - 1)) {
-            if (!data.polyBoundingBox) {
-              // If it's still being actively drawn, keep the last line to
-              // The mouse location
-              context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
-              context.stroke();
+              context.lineTo(lineCanvas.x, lineCanvas.y);
             }
-          }
+
+            const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
+
+            if (j === (data.handles.length - 1)) {
+              if (!data.polyBoundingBox) {
+                // If it's still being actively drawn, keep the last line to
+                // The mouse location
+                context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
+              }
+            }
+          });
         }
       }
 

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -5,7 +5,7 @@ import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'highlight';
 
@@ -115,7 +115,7 @@ function onImageRendered (e) {
   }
 
   draw(context, (context) => {
-    const color = toolColors.getColorIfActive(data);
+
 
     const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
     const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
@@ -128,26 +128,26 @@ function onImageRendered (e) {
     };
 
       // Draw dark fill outside the rectangle
-    context.beginPath();
-    context.strokeStyle = 'transparent';
 
-    context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
+    let color = 'transparent';
+    const fillStyle = 'rgba(0,0,0,0.7)';
 
-    context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
-    context.stroke();
-    context.fillStyle = 'rgba(0,0,0,0.7)';
-    context.fill();
-    context.closePath();
+    path(context, { color,
+      fillStyle }, (context) => {
+      context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
+      context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
+    });
+
+    color = toolColors.getColorIfActive(data);
 
     // Draw dashed stroke rectangle
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.setLineDash([4]);
-    context.strokeRect(rect.left, rect.top, rect.width, rect.height);
+    const lineDash = [4];
 
-    // Strange fix, but restore doesn't seem to reset the line dashes?
-    context.setLineDash([]);
+    path(context, { color,
+      lineWidth,
+      lineDash }, (context) => {
+      context.rect(rect.left, rect.top, rect.width, rect.height);
+    });
 
     // Draw the handles last, so they will be on top of the overlay
     drawHandles(context, eventData, data.handles, color);

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -7,7 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'length';
 
@@ -106,12 +106,11 @@ function onImageRendered (e) {
       const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
 
       // Draw the measurement line
-      context.beginPath();
-      context.strokeStyle = color;
-      context.lineWidth = lineWidth;
-      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      context.stroke();
+      path(context, { color,
+        lineWidth }, (context) => {
+        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      });
 
       // Draw the handles
       const handleOptions = {

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -7,7 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const toolType = 'rectangleRoi';
 
@@ -183,11 +183,10 @@ function onImageRendered (e) {
       const heightCanvas = Math.abs(handleStartCanvas.y - handleEndCanvas.y);
 
       // Draw the rectangle on the canvas
-      context.beginPath();
-      context.strokeStyle = color;
-      context.lineWidth = lineWidth;
-      context.rect(leftCanvas, topCanvas, widthCanvas, heightCanvas);
-      context.stroke();
+      path(context, { color,
+        lineWidth }, (context) => {
+        context.rect(leftCanvas, topCanvas, widthCanvas, heightCanvas);
+      });
 
       // If the tool configuration specifies to only draw the handles on hover / active,
       // Follow this logic

--- a/src/imageTools/scaleOverlayTool.js
+++ b/src/imageTools/scaleOverlayTool.js
@@ -1,7 +1,7 @@
 import displayTool from './displayTool.js';
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 const configuration = {
   color: 'white',
@@ -81,14 +81,13 @@ function drawVerticalScalebar (context, imageAttributes) {
     y: imageAttributes.verticalLine.end.y
   };
 
-  context.beginPath();
-  context.strokeStyle = imageAttributes.color;
-  context.lineWidth = imageAttributes.lineWidth;
+  const { color, lineWidth } = imageAttributes;
 
-  drawLine(context, startPoint, endPoint);
-  drawVerticalScalebarIntervals(context, imageAttributes);
-
-  context.stroke();
+  path(context, { color,
+    lineWidth }, (context) => {
+    drawLine(context, startPoint, endPoint);
+    drawVerticalScalebarIntervals(context, imageAttributes);
+  });
 }
 
 function drawHorizontalScalebar (context, imageAttributes) {
@@ -108,13 +107,13 @@ function drawHorizontalScalebar (context, imageAttributes) {
 function drawScalebars (context, imageAttributes) {
   context.shadowColor = imageAttributes.shadowColor;
   context.shadowBlur = imageAttributes.shadowBlur;
-  context.strokeStyle = imageAttributes.color;
-  context.lineWidth = imageAttributes.lineWidth;
+  const { color, lineWidth } = imageAttributes;
 
-  context.beginPath();
-  drawVerticalScalebar(context, imageAttributes);
-  drawHorizontalScalebar(context, imageAttributes);
-  context.stroke();
+  path(context, { color,
+    lineWidth }, (context) => {
+    drawVerticalScalebar(context, imageAttributes);
+    drawHorizontalScalebar(context, imageAttributes);
+  });
 }
 
 // Computes the max bound for scales on the image

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -13,7 +13,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, path } from '../util/drawing.js';
 
 
 const toolType = 'simpleAngle';
@@ -114,13 +114,12 @@ function onImageRendered (e) {
       const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
       // Draw the line
-      context.beginPath();
-      context.strokeStyle = color;
-      context.lineWidth = lineWidth;
-      context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-      context.lineTo(handleMiddleCanvas.x, handleMiddleCanvas.y);
-      context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      context.stroke();
+      path(context, { color,
+        lineWidth }, (context) => {
+        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
+        context.lineTo(handleMiddleCanvas.x, handleMiddleCanvas.y);
+        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
+      });
 
       // Draw the handles
       const handleOptions = {

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -7,7 +7,7 @@ import getLuminance from '../util/getLuminance.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import clip from '../util/clip.js';
-import { draw } from '../util/drawing.js';
+import { draw, path } from '../util/drawing.js';
 
 const toolType = 'wwwcRegion';
 
@@ -257,11 +257,10 @@ function onImageRendered (e) {
       context.shadowOffsetY = config.shadowOffsetY || 1;
     }
 
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.rect(left, top, width, height);
-    context.stroke();
+    path(context, { color,
+      lineWidth }, (context) => {
+      context.rect(left, top, width, height);
+    });
   });
 }
 

--- a/src/manipulators/drawHandles.js
+++ b/src/manipulators/drawHandles.js
@@ -1,5 +1,6 @@
 import external from '../externalModules.js';
 import toolStyle from '../stateManagement/toolStyle.js';
+import { path } from '../util/drawing.js';
 
 const defaultHandleRadius = 6;
 
@@ -17,26 +18,17 @@ export default function (context, renderData, handles, color, options) {
       return;
     }
 
-    context.beginPath();
+    const lineWidth = handle.active ? toolStyle.getActiveWidth() : toolStyle.getToolWidth();
+    const fillStyle = options && options.fill;
 
-    if (handle.active) {
-      context.lineWidth = toolStyle.getActiveWidth();
-    } else {
-      context.lineWidth = toolStyle.getToolWidth();
-    }
+    path(context, { lineWidth,
+      fillStyle }, (context) => {
+      const handleCanvasCoords = external.cornerstone.pixelToCanvas(renderData.element, handle);
 
-    const handleCanvasCoords = external.cornerstone.pixelToCanvas(renderData.element, handle);
+      const handleRadius = getHandleRadius(options);
 
-    const handleRadius = getHandleRadius(options);
-
-    context.arc(handleCanvasCoords.x, handleCanvasCoords.y, handleRadius, 0, 2 * Math.PI);
-
-    if (options && options.fill) {
-      context.fillStyle = options.fill;
-      context.fill();
-    }
-
-    context.stroke();
+      context.arc(handleCanvasCoords.x, handleCanvasCoords.y, handleRadius, 0, 2 * Math.PI);
+    });
   });
 }
 

--- a/src/referenceLines/renderActiveReferenceLine.js
+++ b/src/referenceLines/renderActiveReferenceLine.js
@@ -3,7 +3,7 @@ import calculateReferenceLine from './calculateReferenceLine.js';
 import toolColors from '../stateManagement/toolColors.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import convertToVector3 from '../util/convertToVector3.js';
-import { draw } from '../util/drawing.js';
+import { draw, path } from '../util/drawing.js';
 
 // Renders the active reference line
 export default function (context, eventData, targetElement, referenceElement) {
@@ -69,11 +69,10 @@ export default function (context, eventData, targetElement, referenceElement) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   draw(context, (context) => {
-    context.beginPath();
-    context.strokeStyle = color;
-    context.lineWidth = lineWidth;
-    context.moveTo(refLineStartCanvas.x, refLineStartCanvas.y);
-    context.lineTo(refLineEndCanvas.x, refLineEndCanvas.y);
-    context.stroke();
+    path(context, { color,
+      lineWidth }, (context) => {
+      context.moveTo(refLineStartCanvas.x, refLineStartCanvas.y);
+      context.lineTo(refLineEndCanvas.x, refLineEndCanvas.y);
+    });
   });
 }

--- a/src/timeSeriesTools/probeTool4D.js
+++ b/src/timeSeriesTools/probeTool4D.js
@@ -6,7 +6,7 @@ import MeasurementManager from '../measurementManager/measurementManager.js';
 import LineSampleMeasurement from '../measurementManager/lineSampleMeasurement.js';
 import textStyle from '../stateManagement/textStyle.js';
 import drawTextBox from '../util/drawTextBox.js';
-import { draw } from '../util/drawing.js';
+import { draw, path } from '../util/drawing.js';
 
 const toolType = 'probe4D';
 
@@ -91,9 +91,9 @@ function onImageRendered (e) {
       const data = toolData.data[i];
 
       // Draw the handles
-      context.beginPath();
-      drawHandles(context, eventData, data.handles, color);
-      context.stroke();
+      path(context, {}, (context) => {
+        drawHandles(context, eventData, data.handles, color);
+      });
 
       context.font = font;
 

--- a/src/util/drawArrow.js
+++ b/src/util/drawArrow.js
@@ -1,3 +1,5 @@
+import { path } from './drawing.js';
+
 export default function (context, start, end, color, lineWidth) {
   // Variables to be used when creating the arrow
   const headLength = 10;
@@ -5,29 +7,26 @@ export default function (context, start, end, color, lineWidth) {
   const angle = Math.atan2(end.y - start.y, end.x - start.x);
 
   // Starting path of the arrow from the start square to the end square and drawing the stroke
-  context.beginPath();
-  context.moveTo(start.x, start.y);
-  context.lineTo(end.x, end.y);
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.stroke();
+  path(context, { color,
+    lineWidth }, (context) => {
+    context.moveTo(start.x, start.y);
+    context.lineTo(end.x, end.y);
+  });
 
-  // Starting a new path from the head of the arrow to one of the sides of the point
-  context.beginPath();
-  context.moveTo(end.x, end.y);
-  context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
+  const fillStyle = color;
 
-  // Path from the side point of the arrow, to the other side point
-  context.lineTo(end.x - headLength * Math.cos(angle + Math.PI / 7), end.y - headLength * Math.sin(angle + Math.PI / 7));
+  path(context, { color,
+    lineWidth,
+    fillStyle }, (context) => {
+    // Starting a new path from the head of the arrow to one of the sides of the point
+    context.moveTo(end.x, end.y);
+    context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
 
-  // Path from the side point back to the tip of the arrow, and then again to the opposite side point
-  context.lineTo(end.x, end.y);
-  context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
+    // Path from the side point of the arrow, to the other side point
+    context.lineTo(end.x - headLength * Math.cos(angle + Math.PI / 7), end.y - headLength * Math.sin(angle + Math.PI / 7));
 
-  // Draws the paths created above
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.stroke();
-  context.fillStyle = color;
-  context.fill();
+    // Path from the side point back to the tip of the arrow, and then again to the opposite side point
+    context.lineTo(end.x, end.y);
+    context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
+  });
 }

--- a/src/util/drawCircle.js
+++ b/src/util/drawCircle.js
@@ -1,12 +1,13 @@
+import { path } from './drawing.js';
+
 /**
  * @deprecated Use drawing.js:drawCircle()
  */
 export default function (context, start, color, lineWidth) {
   const handleRadius = 6;
 
-  context.beginPath();
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.arc(start.x, start.y, handleRadius, 0, 2 * Math.PI);
-  context.stroke();
+  path(context, { color,
+    lineWidth }, (context) => {
+    context.arc(start.x, start.y, handleRadius, 0, 2 * Math.PI);
+  });
 }

--- a/src/util/drawEllipse.js
+++ b/src/util/drawEllipse.js
@@ -20,6 +20,5 @@ export default function (context, x, y, w, h) {
     context.bezierCurveTo(xm + ox, y, xe, ym - oy, xe, ym);
     context.bezierCurveTo(xe, ym + oy, xm + ox, ye, xm, ye);
     context.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
-    context.closePath();
   });
 }

--- a/src/util/drawEllipse.js
+++ b/src/util/drawEllipse.js
@@ -1,3 +1,5 @@
+import { path } from './drawing.js';
+
 // http://stackoverflow.com/questions/2172798/how-to-draw-an-oval-in-html5-canvas
 
 /**
@@ -12,12 +14,12 @@ export default function (context, x, y, w, h) {
     xm = x + w / 2, // X-middle
     ym = y + h / 2; // Y-middle
 
-  context.beginPath();
-  context.moveTo(x, ym);
-  context.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
-  context.bezierCurveTo(xm + ox, y, xe, ym - oy, xe, ym);
-  context.bezierCurveTo(xe, ym + oy, xm + ox, ye, xm, ye);
-  context.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
-  context.closePath();
-  context.stroke();
+  path(context, {}, (context) => {
+    context.moveTo(x, ym);
+    context.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
+    context.bezierCurveTo(xm + ox, y, xe, ym - oy, xe, ym);
+    context.bezierCurveTo(xe, ym + oy, xm + ox, ye, xm, ye);
+    context.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
+    context.closePath();
+  });
 }

--- a/src/util/drawLink.js
+++ b/src/util/drawLink.js
@@ -1,4 +1,5 @@
 import external from '../externalModules.js';
+import { path } from './drawing.js';
 
 export default function (linkAnchorPoints, refPoint, boundingBox, context, color, lineWidth) {
   // Draw a link from "the closest anchor point to refPoint" to "the nearest midpoint on the bounding box".
@@ -29,11 +30,12 @@ export default function (linkAnchorPoints, refPoint, boundingBox, context, color
   const end = external.cornerstoneMath.point.findClosestPoint(boundingBoxPoints, start);
 
   // Finally we draw the dashed linking line
-  context.beginPath();
-  context.strokeStyle = color;
-  context.lineWidth = lineWidth;
-  context.setLineDash([2, 3]);
-  context.moveTo(start.x, start.y);
-  context.lineTo(end.x, end.y);
-  context.stroke();
+  const lineDash = [2, 3];
+
+  path(context, { color,
+    lineWidth,
+    lineDash }, (context) => {
+    context.moveTo(start.x, start.y);
+    context.lineTo(end.x, end.y);
+  });
 }


### PR DESCRIPTION
This PR replaces calls to `context.beginPath()` and `context.stroke()` with calls to the `path()` function from the drawing.js API.

See #405 for full discussion.