### PR TITLE
Cornerstone#245 Remove default 0 for fractional seconds of seriesAcquisitionTime since dicomParser handles it

### DIFF
--- a/src/util/calculateSUV.js
+++ b/src/util/calculateSUV.js
@@ -45,7 +45,7 @@ export default function (image, storedPixelValue) {
     return;
   }
 
-  const acquisitionTimeInSeconds = fracToDec(seriesAcquisitionTime.fractionalSeconds || 0) + seriesAcquisitionTime.seconds + seriesAcquisitionTime.minutes * 60 + seriesAcquisitionTime.hours * 60 * 60;
+  const acquisitionTimeInSeconds = fracToDec(seriesAcquisitionTime.fractionalSeconds) + seriesAcquisitionTime.seconds + seriesAcquisitionTime.minutes * 60 + seriesAcquisitionTime.hours * 60 * 60;
   const injectionStartTimeInSeconds = fracToDec(startTime.fractionalSeconds) + startTime.seconds + startTime.minutes * 60 + startTime.hours * 60 * 60;
   const durationInSeconds = acquisitionTimeInSeconds - injectionStartTimeInSeconds;
   const correctedDose = totalDose * Math.exp(-durationInSeconds * Math.log(2) / halfLife);


### PR DESCRIPTION
See https://github.com/cornerstonejs/cornerstone/issues/245