### PR TITLE
feat(eraser) initial implementation of eraser

### DIFF
--- a/examples/allImageTools/index.html
+++ b/examples/allImageTools/index.html
@@ -37,6 +37,7 @@
                 <a id="angle" class="list-group-item">Angle</a>
                 <a id="highlight" class="list-group-item">Highlight</a>
                 <a id="freehand" class="list-group-item">Freeform ROI</a>
+                <a id="eraser" class="list-group-item">Eraser</a>
             </ul>
             <div class="checkbox">
               <label><input type="checkbox" id="chkshadow">Apply shadow</label>
@@ -83,6 +84,7 @@
                         <li>Rectangle ROI - A rectangular ROI that shows mean, stddev and area</li>
                         <li>Highlight - Darkens the image around a rectangular ROI</li>
                         <li>Angle - Cobb angle tool</li>
+                        <li>Eraser - Erases marks from other tools</li>
                     </ul>
                 </li>
                 <li>Use the activated tool by dragging the left mouse button</li>
@@ -156,6 +158,7 @@
         cornerstoneTools.rectangleRoi.enable(element);
         cornerstoneTools.angle.enable(element);
         cornerstoneTools.highlight.enable(element);
+        cornerstoneTools.eraser.enable(element);
 
         activate("enableWindowLevelTool");
 
@@ -181,6 +184,7 @@
             cornerstoneTools.angle.deactivate(element, 1);
             cornerstoneTools.highlight.deactivate(element, 1);
             cornerstoneTools.freehand.deactivate(element, 1);
+            cornerstoneTools.eraser.deactivate(element, 1);
         }
 
         // Tool button event handlers that set the new active tool
@@ -234,6 +238,11 @@
             disableAllTools();
             cornerstoneTools.freehand.activate(element, 1);
         });
+        document.getElementById('eraser').addEventListener('click', function() {
+            activate('eraser');
+            disableAllTools();
+            cornerstoneTools.eraser.activate(element, 1);
+        })
     });
 
 

--- a/src/imageTools/eraser.js
+++ b/src/imageTools/eraser.js
@@ -1,0 +1,62 @@
+import * as cornerstoneTools from '../index.js';
+import EVENTS from '../events.js';
+import external from '../externalModules.js';
+
+const toolType = 'eraser';
+
+function eventListeners (event) {
+  return {
+    activate: function (element) {
+      element.addEventListener(event, deleteNearbyMeasurement);
+    },
+    deactivate: function (element) {
+      element.removeEventListener(event, deleteNearbyMeasurement);
+    },
+    disable: function (element) {
+      element.removeEventListener(event, deleteNearbyMeasurement);
+    },
+    enable: function (element) {
+      element.removeEventListener(event, deleteNearbyMeasurement);
+    }
+  }
+}
+
+function pointNearTool () {
+  return false;
+}
+
+function deleteNearbyMeasurement (mouseEventData) {
+  const coords = mouseEventData.detail.currentPoints.canvas;
+  const element = mouseEventData.detail.element;
+
+  Object.keys(cornerstoneTools).forEach(function (toolName) {
+    const tool = cornerstoneTools[toolName]; // eslint-disable-line import/namespace
+    const toolState = cornerstoneTools.getToolState(element, toolName);
+
+    if (toolState) {
+      toolState.data.forEach(function (data) {
+        if(tool.pointNearTool(element, data, coords)) {
+          cornerstoneTools.removeToolState(element, toolName, data);
+          external.cornerstone.updateImage(element);
+        }
+      });
+    }
+  });
+}
+
+const eraser = {
+  ...eventListeners(EVENTS.MOUSE_CLICK),
+  pointNearTool,
+  toolType
+};
+
+const eraserTouch = {
+  ...eventListeners(EVENTS.TOUCH_PRESS),
+  pointNearTool,
+  toolType
+}
+
+export {
+  eraser,
+  eraserTouch
+};

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ export { default as doubleTapZoom } from './imageTools/doubleTapZoom.js';
 export { dragProbe, dragProbeTouch } from './imageTools/dragProbe.js';
 
 export { ellipticalRoi, ellipticalRoiTouch } from './imageTools/ellipticalRoi.js';
+export { eraser, eraserTouch } from './imageTools/eraser.js';
 export { freehand } from './imageTools/freehand.js';
 
 export { highlight, highlightTouch } from './imageTools/highlight.js';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds an eraser that works on tool markings.


* **What is the current behavior?** (You can also link to an open issue here)
There isn't one. ;)


* **What is the new behavior (if this is a feature change)?**
Adding this tool will allow users to delete other tool's markings by clicking on them.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
I'm not really certain where to update docs at this point. Let me know what you'd like to see added and I'll get after it.

On the events front, I didn't inherit from mouseButtonTool because this is a lot smaller than the other tools. Also, the MOUSE_DOWN event seems to get swallowed by the first tool that catches it and so never makes it to the eraser tool. This way we can use MOUSE_CLICK which makes it to the eraser.

I imported all of cornerstoneTools so we can just iterate over everything there and operate on any tools with the pointNearTool function.

Finally, I'm not able to test on mobile but there's a good chance it will have the same issue using MOUSE_DOWN does. I imagine those events are dispatched and handled much like MOUSE_DOWN.

I'm sure there's plenty of feedback on this attempt. Happy to update to a more idiomatic approach.