### PR TITLE
[5/N] Use the setShadow function from drawing.js

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -9,7 +9,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -89,11 +89,7 @@ function onImageRendered (e) {
 
     draw(context, (context) => {
       // Configurable shadow
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -17,7 +17,7 @@ import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, setShadow } from '../util/drawing.js';
 
 const toolType = 'arrowAnnotate';
 
@@ -161,11 +161,7 @@ function onImageRendered (e) {
     }
 
     draw(context, (context) => {
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       const color = toolColors.getColorIfActive(data);
 

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -9,7 +9,7 @@ import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { getToolOptions } from '../toolOptions.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
 
 const toolType = 'dragProbe';
 
@@ -34,11 +34,7 @@ function defaultStrategy (eventData) {
   }
 
   draw(context, (context) => {
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
+    setShadow(context, config);
 
     let storedPixels;
     let text,
@@ -106,11 +102,7 @@ function minimalStrategy (eventData) {
   }
 
   draw(context, (context) => {
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
+    setShadow(context, config);
 
     const seriesModule = cornerstone.metaData.get('generalSeriesModule', image.imageId);
     let modality;

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -9,7 +9,7 @@ import calculateEllipseStatistics from '../util/calculateEllipseStatistics.js';
 import calculateSUV from '../util/calculateSUV.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { drawEllipse, getNewContext, draw } from '../util/drawing.js';
+import { drawEllipse, getNewContext, draw, setShadow } from '../util/drawing.js';
 
 const toolType = 'ellipticalRoi';
 
@@ -145,11 +145,7 @@ function onImageRendered (e) {
 
     draw(context, (context) => {
       // Apply any shadow settings defined in the tool configuration
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       // Check which color the rendered tool should be
       const color = toolColors.getColorIfActive(data);

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -7,7 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
 
 const toolType = 'length';
 
@@ -93,11 +93,7 @@ function onImageRendered (e) {
 
     draw(context, (context) => {
       // Configurable shadow
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       const color = toolColors.getColorIfActive(data);
 

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -7,7 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
 
 const toolType = 'rectangleRoi';
 
@@ -162,11 +162,7 @@ function onImageRendered (e) {
 
     draw(context, (context) => {
       // Apply any shadow settings defined in the tool configuration
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       // Check which color the rendered tool should be
       const color = toolColors.getColorIfActive(data);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -14,7 +14,7 @@ import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
-import { drawCircle, getNewContext, draw } from '../util/drawing.js';
+import { drawCircle, getNewContext, draw, setShadow } from '../util/drawing.js';
 
 const toolType = 'seedAnnotate';
 
@@ -152,11 +152,7 @@ function onImageRendered (e) {
     }
 
     draw(context, (context) => {
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       const color = toolColors.getColorIfActive(data);
 

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -13,7 +13,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
 
 
 const toolType = 'simpleAngle';
@@ -100,11 +100,7 @@ function onImageRendered (e) {
     }
 
     draw(context, (context) => {
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -8,7 +8,7 @@ import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import drawTextBox from '../util/drawTextBox.js';
 import { removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, setShadow } from '../util/drawing.js';
 
 const toolType = 'textMarker';
 
@@ -122,11 +122,7 @@ function onImageRendered (e) {
     const color = toolColors.getColorIfActive(data);
 
     draw(context, (context) => {
-      if (config && config.shadow) {
-        context.shadowColor = config.shadowColor || '#000000';
-        context.shadowOffsetX = config.shadowOffsetX || 1;
-        context.shadowOffsetY = config.shadowOffsetY || 1;
-      }
+      setShadow(context, config);
 
       // Draw text
       context.fillStyle = color;

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -7,7 +7,7 @@ import getLuminance from '../util/getLuminance.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import clip from '../util/clip.js';
-import { draw, path } from '../util/drawing.js';
+import { draw, path, setShadow } from '../util/drawing.js';
 
 const toolType = 'wwwcRegion';
 
@@ -251,12 +251,7 @@ function onImageRendered (e) {
 
   // Draw the rectangle
   draw(context, (context) => {
-    if (config && config.shadow) {
-      context.shadowColor = config.shadowColor || '#000000';
-      context.shadowOffsetX = config.shadowOffsetX || 1;
-      context.shadowOffsetY = config.shadowOffsetY || 1;
-    }
-
+    setShadow(context, config);
     path(context, { color,
       lineWidth }, (context) => {
       context.rect(left, top, width, height);


### PR DESCRIPTION
This PR replaces blocks of code setting the `context` shadow parameters with calls to the `setShadow()` function from the `drawing.js` API.

See #405 for full discussion.