### PR TITLE
[6/N] Use the drawLine, drawLines and drawJoinedLines functions from drawing.js

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -3,13 +3,12 @@ import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';
 import roundToDecimal from '../util/roundToDecimal.js';
-import toolStyle from '../stateManagement/toolStyle.js';
 import textStyle from '../stateManagement/textStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -75,7 +74,6 @@ function onImageRendered (e) {
   // We have tool data for this element - iterate over each one and draw it
   const context = getNewContext(eventData.canvasContext.canvas);
 
-  const lineWidth = toolStyle.getToolWidth();
   const font = textStyle.getFont();
   const config = angle.getConfiguration();
   const cornerstone = external.cornerstone;
@@ -93,21 +91,8 @@ function onImageRendered (e) {
 
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);
-      let handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-      let handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-      // Draw the line
-      path(context, { color,
-        lineWidth }, (context) => {
-        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-
-        handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
-        handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
-
-        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      });
+      drawJoinedLines(context, eventData.element, data.handles.end, [data.handles.start, data.handles.end2], { color });
 
       // Draw the handles
       drawHandles(context, eventData, data.handles);
@@ -129,6 +114,9 @@ function onImageRendered (e) {
       const rAngle = roundToDecimal(angle, 2);
       const str = '00B0'; // Degrees symbol
       const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16));
+
+      const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
+      const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
 
       const textX = (handleStartCanvas.x + handleEndCanvas.x) / 2;
       const textY = (handleStartCanvas.y + handleEndCanvas.y) / 2;

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -22,7 +22,7 @@ import freeHandArea from '../util/freehand/freeHandArea.js';
 import calculateFreehandStatistics from '../util/freehand/calculateFreehandStatistics.js';
 import freeHandIntersect from '../util/freehand/freeHandIntersect.js';
 import { FreehandHandleData } from '../util/freehand/FreehandHandleData.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, drawJoinedLines } from '../util/drawing.js';
 
 const toolType = 'freehand';
 let configuration = {
@@ -818,34 +818,16 @@ function onImageRendered (e) {
         fillColor = toolColors.getToolColor();
       }
 
-      let handleStart;
-
       if (data.handles.length) {
         for (let j = 0; j < data.handles.length; j++) {
-          // Draw a line between handle j and j+1
-          handleStart = data.handles[j];
-          const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, handleStart);
+          const points = [...data.handles[j].lines];
 
-          path(context, { color,
-            lineWidth }, (context) => {
-            context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-
-            for (let k = 0; k < data.handles[j].lines.length; k++) {
-              const lineCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles[j].lines[k]);
-
-              context.lineTo(lineCanvas.x, lineCanvas.y);
-            }
-
-            const mouseLocationCanvas = cornerstone.pixelToCanvas(eventData.element, config.mouseLocation.handles.start);
-
-            if (j === (data.handles.length - 1)) {
-              if (!data.polyBoundingBox) {
-                // If it's still being actively drawn, keep the last line to
-                // The mouse location
-                context.lineTo(mouseLocationCanvas.x, mouseLocationCanvas.y);
-              }
-            }
-          });
+          if (j === (data.handles.length - 1) && !data.polyBoundingBox) {
+            // If it's still being actively drawn, keep the last line to
+            // The mouse location
+            points.push(config.mouseLocation.handles.start);
+          }
+          drawJoinedLines(context, eventData.element, data.handles[j], points, { color });
         }
       }
 

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -7,7 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawLine } from '../util/drawing.js';
 
 const toolType = 'length';
 
@@ -97,16 +97,8 @@ function onImageRendered (e) {
 
       const color = toolColors.getColorIfActive(data);
 
-      // Get the handle positions in canvas coordinates
-      const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
-      const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
-
       // Draw the measurement line
-      path(context, { color,
-        lineWidth }, (context) => {
-        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      });
+      drawLine(context, element, data.handles.start, data.handles.end, { color });
 
       // Draw the handles
       const handleOptions = {

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -13,7 +13,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
 
 
 const toolType = 'simpleAngle';
@@ -107,15 +107,8 @@ function onImageRendered (e) {
 
       const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
       const handleMiddleCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.middle);
-      const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 
-      // Draw the line
-      path(context, { color,
-        lineWidth }, (context) => {
-        context.moveTo(handleStartCanvas.x, handleStartCanvas.y);
-        context.lineTo(handleMiddleCanvas.x, handleMiddleCanvas.y);
-        context.lineTo(handleEndCanvas.x, handleEndCanvas.y);
-      });
+      drawJoinedLines(context, eventData.element, data.handles.start, [data.handles.middle, data.handles.end], { color });
 
       // Draw the handles
       const handleOptions = {

--- a/src/referenceLines/renderActiveReferenceLine.js
+++ b/src/referenceLines/renderActiveReferenceLine.js
@@ -1,9 +1,8 @@
 import external from '../externalModules.js';
 import calculateReferenceLine from './calculateReferenceLine.js';
 import toolColors from '../stateManagement/toolColors.js';
-import toolStyle from '../stateManagement/toolStyle.js';
 import convertToVector3 from '../util/convertToVector3.js';
-import { draw, path } from '../util/drawing.js';
+import { draw, drawLine } from '../util/drawing.js';
 
 // Renders the active reference line
 export default function (context, eventData, targetElement, referenceElement) {
@@ -59,20 +58,12 @@ export default function (context, eventData, targetElement, referenceElement) {
     return;
   }
 
-  const refLineStartCanvas = cornerstone.pixelToCanvas(eventData.element, referenceLine.start);
-  const refLineEndCanvas = cornerstone.pixelToCanvas(eventData.element, referenceLine.end);
-
   const color = toolColors.getActiveColor();
-  const lineWidth = toolStyle.getToolWidth();
 
   // Draw the referenceLines
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   draw(context, (context) => {
-    path(context, { color,
-      lineWidth }, (context) => {
-      context.moveTo(refLineStartCanvas.x, refLineStartCanvas.y);
-      context.lineTo(refLineEndCanvas.x, refLineEndCanvas.y);
-    });
+    drawLine(context, eventData.element, referenceLine.start, referenceLine.end, { color });
   });
 }

--- a/src/util/drawArrow.js
+++ b/src/util/drawArrow.js
@@ -1,4 +1,4 @@
-import { path } from './drawing.js';
+import { drawLine, drawJoinedLines } from './drawing.js';
 
 export default function (context, start, end, color, lineWidth) {
   // Variables to be used when creating the arrow
@@ -7,26 +7,29 @@ export default function (context, start, end, color, lineWidth) {
   const angle = Math.atan2(end.y - start.y, end.x - start.x);
 
   // Starting path of the arrow from the start square to the end square and drawing the stroke
-  path(context, { color,
-    lineWidth }, (context) => {
-    context.moveTo(start.x, start.y);
-    context.lineTo(end.x, end.y);
-  });
+  let options = {
+    color,
+    lineWidth
+  };
 
-  const fillStyle = color;
-
-  path(context, { color,
+  drawLine(context, undefined, start, end, options, 'canvas');
+  options = {
+    color,
     lineWidth,
-    fillStyle }, (context) => {
-    // Starting a new path from the head of the arrow to one of the sides of the point
-    context.moveTo(end.x, end.y);
-    context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
+    fillStyle: color
+  };
 
-    // Path from the side point of the arrow, to the other side point
-    context.lineTo(end.x - headLength * Math.cos(angle + Math.PI / 7), end.y - headLength * Math.sin(angle + Math.PI / 7));
+  const points = [
+    {
+      x: end.x - headLength * Math.cos(angle - Math.PI / 7),
+      y: end.y - headLength * Math.sin(angle - Math.PI / 7)
+    },
+    {
+      x: end.x - headLength * Math.cos(angle + Math.PI / 7),
+      y: end.y - headLength * Math.sin(angle + Math.PI / 7)
+    },
+    end
+  ];
 
-    // Path from the side point back to the tip of the arrow, and then again to the opposite side point
-    context.lineTo(end.x, end.y);
-    context.lineTo(end.x - headLength * Math.cos(angle - Math.PI / 7), end.y - headLength * Math.sin(angle - Math.PI / 7));
-  });
+  drawJoinedLines(context, undefined, end, points, options, 'canvas');
 }

--- a/src/util/drawLink.js
+++ b/src/util/drawLink.js
@@ -1,5 +1,5 @@
 import external from '../externalModules.js';
-import { path } from './drawing.js';
+import { drawLine } from './drawing.js';
 
 export default function (linkAnchorPoints, refPoint, boundingBox, context, color, lineWidth) {
   // Draw a link from "the closest anchor point to refPoint" to "the nearest midpoint on the bounding box".
@@ -30,12 +30,11 @@ export default function (linkAnchorPoints, refPoint, boundingBox, context, color
   const end = external.cornerstoneMath.point.findClosestPoint(boundingBoxPoints, start);
 
   // Finally we draw the dashed linking line
-  const lineDash = [2, 3];
-
-  path(context, { color,
+  const options = {
+    color,
     lineWidth,
-    lineDash }, (context) => {
-    context.moveTo(start.x, start.y);
-    context.lineTo(end.x, end.y);
-  });
+    lineDash: [2, 3]
+  };
+
+  drawLine(context, undefined, start, end, options, 'canvas');
 }


### PR DESCRIPTION
This PR replaces calls to `path`, `moveTo` and `lineTo` with calls to `drawLine`, `drawLines`, and `drawJoinedLines` from the `drawing.js` API.

See #405 for full discussion.