### PR TITLE
[7/N] Use the fillBox and fillTextLines functions from drawing.js

### DIFF
--- a/src/imageTools/magnify.js
+++ b/src/imageTools/magnify.js
@@ -4,7 +4,7 @@ import { getBrowserInfo } from '../util/getMaxSimultaneousRequests.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import { clipToBox } from '../util/clip.js';
-import { getNewContext } from '../util/drawing.js';
+import { getNewContext, fillBox } from '../util/drawing.js';
 
 const toolType = 'magnify';
 
@@ -115,7 +115,7 @@ function drawMagnificationTool (eventData) {
   // The 'not' magnifyTool class here is necessary because cornerstone places
   // No classes of it's own on the canvas we want to select
   const canvas = element.querySelector('canvas:not(.magnifyTool)');
-  const zoomCtx = getNewContext(magnifyCanvas);
+  const context = getNewContext(magnifyCanvas);
 
   const getSize = magnifySize;
 
@@ -125,11 +125,17 @@ function drawMagnificationTool (eventData) {
   clipToBox(canvasLocation, canvas);
 
   // Clear the rectangle
-  zoomCtx.clearRect(0, 0, magnifySize, magnifySize);
-  zoomCtx.fillStyle = 'transparent';
+  context.clearRect(0, 0, magnifySize, magnifySize);
 
   // Fill it with the pixels that the mouse is clicking on
-  zoomCtx.fillRect(0, 0, magnifySize, magnifySize);
+  const boundingBox = {
+    left: 0,
+    top: 0,
+    width: magnifySize,
+    height: magnifySize
+  };
+
+  fillBox(context, boundingBox, 'transparent');
 
   const copyFrom = {
     x: canvasLocation.x * magnificationLevel - 0.5 * getSize,
@@ -146,7 +152,7 @@ function drawMagnificationTool (eventData) {
   copyFrom.x = Math.min(copyFrom.x, zoomCanvas.width);
   copyFrom.y = Math.min(copyFrom.y, zoomCanvas.height);
 
-  zoomCtx.drawImage(zoomCanvas, copyFrom.x, copyFrom.y, getSize, getSize, 0, 0, getSize, getSize);
+  context.drawImage(zoomCanvas, copyFrom.x, copyFrom.y, getSize, getSize, 0, 0, getSize, getSize);
 
   // Place the magnification tool at the same location as the pointer
   magnifyCanvas.style.top = `${canvasLocation.y - 0.5 * magnifySize}px`;

--- a/src/paintingTools/drawBrush.js
+++ b/src/paintingTools/drawBrush.js
@@ -1,5 +1,5 @@
 import external from '../externalModules.js';
-import { draw } from '../util/drawing.js';
+import { draw, fillBox } from '../util/drawing.js';
 
 function drawBrushPixels (pointerArray, storedPixels, brushPixelValue, columns) {
   const getPixelIndex = (x, y) => (y * columns) + x;
@@ -20,15 +20,19 @@ function drawBrushOnCanvas (pointerArray, context, color, element) {
   const sizeY = canvasPtBR.y - canvasPtTL.y;
 
   draw(context, (context) => {
-    context.fillStyle = color;
-
     pointerArray.forEach((point) => {
       const canvasPt = external.cornerstone.pixelToCanvas(element, {
         x: point[0],
         y: point[1]
       });
+      const boundingBox = {
+        left: canvasPt.x,
+        top: canvasPt.y,
+        width: sizeX,
+        height: sizeY
+      };
 
-      context.fillRect(canvasPt.x, canvasPt.y, sizeX, sizeY);
+      fillBox(context, boundingBox, color);
     });
   });
 }

--- a/src/stackTools/scrollIndicator.js
+++ b/src/stackTools/scrollIndicator.js
@@ -1,6 +1,6 @@
 import displayTool from '../imageTools/displayTool.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw } from '../util/drawing.js';
+import { getNewContext, draw, fillBox } from '../util/drawing.js';
 
 /*
 Display scroll progress bar across bottom of image.
@@ -29,12 +29,24 @@ function onImageRendered (e) {
     const config = scrollIndicator.getConfiguration();
 
     // Draw indicator background
-    context.fillStyle = config.backgroundColor;
+    let boundingBox;
+
     if (config.orientation === 'horizontal') {
-      context.fillRect(0, height - scrollBarHeight, width, scrollBarHeight);
+      boundingBox = {
+        left: 0,
+        top: height - scrollBarHeight,
+        width,
+        heigh: scrollBarHeight
+      };
     } else {
-      context.fillRect(0, 0, scrollBarHeight, height);
+      boundingBox = {
+        left: 0,
+        top: 0,
+        width: scrollBarHeight,
+        height
+      };
     }
+    fillBox(context, boundingBox, config.backgroundColor);
 
     // Get current image index
     const stackData = getToolState(element, 'stack');
@@ -49,12 +61,22 @@ function onImageRendered (e) {
       const xPosition = cursorWidth * currentImageIdIndex;
       const yPosition = cursorHeight * currentImageIdIndex;
 
-      context.fillStyle = config.fillColor;
       if (config.orientation === 'horizontal') {
-        context.fillRect(xPosition, height - scrollBarHeight, cursorWidth, scrollBarHeight);
+        boundingBox = {
+          left: xPosition,
+          top: height - scrollBarHeight,
+          cursorWidth,
+          scrollBarHeight
+        };
       } else {
-        context.fillRect(0, yPosition, scrollBarHeight, cursorHeight);
+        boundingBox = {
+          left: 0,
+          top: yPosition,
+          width: scrollBarHeight,
+          heigh: cursorHeight
+        };
       }
+      fillBox(context, boundingBox, config.fillColor);
     }
   });
 }

--- a/src/util/drawTextBox.js
+++ b/src/util/drawTextBox.js
@@ -1,5 +1,5 @@
 import textStyle from '../stateManagement/textStyle.js';
-import { draw } from './drawing.js';
+import { draw, fillTextLines, fillBox } from './drawing.js';
 
 export default function (context, textLines, x, y, color, options) {
   if (Object.prototype.toString.call(textLines) !== '[object Array]') {
@@ -7,7 +7,6 @@ export default function (context, textLines, x, y, color, options) {
   }
 
   const padding = 5;
-  const font = textStyle.getFont();
   const fontSize = textStyle.getFontSize();
   const backgroundColor = textStyle.getBackgroundColor();
 
@@ -29,13 +28,9 @@ export default function (context, textLines, x, y, color, options) {
   };
 
   draw(context, (context) => {
-    context.font = font;
-    context.textBaseline = 'top';
     context.strokeStyle = color;
 
     // Draw the background box with padding
-    context.fillStyle = backgroundColor;
-
     if (options && options.centering && options.centering.x === true) {
       x -= boundingBox.width / 2;
     }
@@ -47,25 +42,12 @@ export default function (context, textLines, x, y, color, options) {
     boundingBox.left = x;
     boundingBox.top = y;
 
-    if (options && options.debug === true) {
-      context.fillStyle = '#FF0000';
-    }
+    const fillStyle = (options && options.debug === true) ? '#FF0000' : backgroundColor;
 
-    context.fillRect(boundingBox.left, boundingBox.top, boundingBox.width, boundingBox.height);
+    fillBox(context, boundingBox, fillStyle);
 
     // Draw each of the text lines on top of the background box
-    textLines.forEach(function (text, index) {
-      context.fillStyle = color;
-
-      /* Var ypos;
-          if (index === 0) {
-              ypos = y + index * (fontSize + padding);
-          } else {
-              ypos = y + index * (fontSize + padding * 2);
-          }*/
-
-      context.fillText(text, x + padding, y + padding + index * (fontSize + padding));
-    });
+    fillTextLines(context, boundingBox, textLines, color, padding);
   });
 
   // Return the bounding box so it can be used for pointNearHandle


### PR DESCRIPTION
This PR replaces calls to `fillRect()` and `fillText()` with calls to the `fillBox()` and `fillTextLines()` functions from the `drawing.js` API.

See #405 for full discussion.