### PR TITLE
[8/N] Use the drawCircle function from drawing.js

### DIFF
--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -9,7 +9,7 @@ import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { getToolOptions } from '../toolOptions.js';
-import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawCircle } from '../util/drawing.js';
 
 const toolType = 'dragProbe';
 
@@ -161,10 +161,7 @@ function minimalStrategy (eventData) {
       };
     }
 
-    path(context, { color }, (context) => {
-      context.arc(textCoords.x, textCoords.y, handleRadius, 0, 2 * Math.PI);
-    });
-
+    drawCircle(context, element, textCoords, handleRadius, { color }, 'canvas');
     drawTextBox(context, text, textCoords.x + translation.x, textCoords.y + translation.y, color);
   });
 }

--- a/src/manipulators/drawHandles.js
+++ b/src/manipulators/drawHandles.js
@@ -1,12 +1,9 @@
-import external from '../externalModules.js';
 import toolStyle from '../stateManagement/toolStyle.js';
-import { path } from '../util/drawing.js';
+import { drawCircle } from '../util/drawing.js';
 
 const defaultHandleRadius = 6;
 
 export default function (context, renderData, handles, color, options) {
-  context.strokeStyle = color;
-
   Object.keys(handles).forEach(function (name) {
     const handle = handles[name];
 
@@ -18,17 +15,15 @@ export default function (context, renderData, handles, color, options) {
       return;
     }
 
-    const lineWidth = handle.active ? toolStyle.getActiveWidth() : toolStyle.getToolWidth();
-    const fillStyle = options && options.fill;
+    const handleRadius = getHandleRadius(options);
 
-    path(context, { lineWidth,
-      fillStyle }, (context) => {
-      const handleCanvasCoords = external.cornerstone.pixelToCanvas(renderData.element, handle);
+    const circleOptions = {
+      color,
+      lineWidth: handle.active ? toolStyle.getActiveWidth() : toolStyle.getToolWidth(),
+      fillStyle: options && options.fill
+    };
 
-      const handleRadius = getHandleRadius(options);
-
-      context.arc(handleCanvasCoords.x, handleCanvasCoords.y, handleRadius, 0, 2 * Math.PI);
-    });
+    drawCircle(context, renderData.element, handle, handleRadius, circleOptions);
   });
 }
 

--- a/src/util/drawCircle.js
+++ b/src/util/drawCircle.js
@@ -1,13 +1,14 @@
-import { path } from './drawing.js';
+import { drawCircle } from './drawing.js';
 
 /**
  * @deprecated Use drawing.js:drawCircle()
  */
 export default function (context, start, color, lineWidth) {
   const handleRadius = 6;
+  const options = {
+    color,
+    lineWidth
+  };
 
-  path(context, { color,
-    lineWidth }, (context) => {
-    context.arc(start.x, start.y, handleRadius, 0, 2 * Math.PI);
-  });
+  drawCircle(context, undefined, start, handleRadius, options, 'canvas');
 }


### PR DESCRIPTION
This PR replaces calls to `.arc()` with calls to the `drawCircle()` function from the drawing.js API.

See #405 for full discussion.