### PR TITLE
increment on the eraser tool, delete one piece of data at a time, hig…

### DIFF
--- a/examples/allImageTools/index.html
+++ b/examples/allImageTools/index.html
@@ -37,7 +37,7 @@
                 <a id="angle" class="list-group-item">Angle</a>
                 <a id="highlight" class="list-group-item">Highlight</a>
                 <a id="freehand" class="list-group-item">Freeform ROI</a>
-                <!-- <a id="eraser" class="list-group-item">Eraser</a> @TODO uncomment in 2.3.8 -->
+                <a id="eraser" class="list-group-item">Eraser</a>
             </ul>
             <div class="checkbox">
               <label><input type="checkbox" id="chkshadow">Apply shadow</label>
@@ -84,7 +84,7 @@
                         <li>Rectangle ROI - A rectangular ROI that shows mean, stddev and area</li>
                         <li>Highlight - Darkens the image around a rectangular ROI</li>
                         <li>Angle - Cobb angle tool</li>
-                        <!-- <li>Eraser - Erases marks from other tools</li> @TODO uncomment with 2.3.8 -->
+                        <li>Eraser - Erases marks from other tools</li>
                     </ul>
                 </li>
                 <li>Use the activated tool by dragging the left mouse button</li>
@@ -158,7 +158,7 @@
         cornerstoneTools.rectangleRoi.enable(element);
         cornerstoneTools.angle.enable(element);
         cornerstoneTools.highlight.enable(element);
-        // cornerstoneTools.eraser.enable(element); Uncomment this with release 2.3.8
+        cornerstoneTools.eraser.enable(element);
 
         activate("enableWindowLevelTool");
 
@@ -184,7 +184,7 @@
             cornerstoneTools.angle.deactivate(element, 1);
             cornerstoneTools.highlight.deactivate(element, 1);
             cornerstoneTools.freehand.deactivate(element, 1);
-            // cornerstoneTools.eraser.deactivate(element, 1); @TODO: Uncomment this with release 2.3.8
+            cornerstoneTools.eraser.deactivate(element, 1);
         }
 
         // Tool button event handlers that set the new active tool
@@ -238,25 +238,24 @@
             disableAllTools();
             cornerstoneTools.freehand.activate(element, 1);
         });
-        // @TODO: Uncomment this with release 2.3.8, the eraser tool isn't in 2.3.7
-        // document.getElementById('eraser').addEventListener('click', function() {
-        //     activate('eraser');
-        //     disableAllTools();
+        document.getElementById('eraser').addEventListener('click', function() {
+            activate('eraser');
+            disableAllTools();
 
-        //     // In order for the eraser to work, other tools must be in the 'enable'
-        //     // state. This allows eraser to receive mouse click events on other tools'
-        //     // data.
-        //     cornerstoneTools.probe.enable(element, 1);
-        //     cornerstoneTools.length.enable(element, 1);
-        //     cornerstoneTools.ellipticalRoi.enable(element, 1);
-        //     cornerstoneTools.rectangleRoi.enable(element, 1);
-        //     cornerstoneTools.angle.enable(element, 1);
-        //     cornerstoneTools.highlight.enable(element, 1);
-        //     cornerstoneTools.freehand.enable(element, 1);
-        //     cornerstoneTools.eraser.enable(element, 1);
+            // In order for the eraser to work, other tools must be in the 'enable'
+            // state. This allows eraser to receive mouse click events on other tools'
+            // data.
+            cornerstoneTools.probe.enable(element, 1);
+            cornerstoneTools.length.enable(element, 1);
+            cornerstoneTools.ellipticalRoi.enable(element, 1);
+            cornerstoneTools.rectangleRoi.enable(element, 1);
+            cornerstoneTools.angle.enable(element, 1);
+            cornerstoneTools.highlight.enable(element, 1);
+            cornerstoneTools.freehand.enable(element, 1);
+            cornerstoneTools.eraser.enable(element, 1);
 
-        //     cornerstoneTools.eraser.activate(element, 1);
-        // });
+            cornerstoneTools.eraser.activate(element, 1);
+        });
     });
 
 

--- a/src/imageTools/eraser.js
+++ b/src/imageTools/eraser.js
@@ -1,31 +1,117 @@
 import * as cornerstoneTools from '../index.js';
 import external from '../externalModules.js';
-import simpleMouseButtonTool from './simpleMouseButtonTool.js';
+import EVENTS from '../events.js';
+import { setToolOptions } from '../toolOptions.js';
 import simpleTouchTool from './simpleTouchTool.js';
 
 const toolType = 'eraser';
+let configuration = {
+  supportedTools: {}
+};
 
-function deleteNearbyMeasurement (mouseEventData) {
-  const coords = mouseEventData.detail.currentPoints.canvas;
-  const element = mouseEventData.detail.element;
-
+function populateSupportedTools () {
+  configuration.supportedTools = {};
   Object.keys(cornerstoneTools).forEach(function (toolName) {
     const tool = cornerstoneTools[toolName]; // eslint-disable-line import/namespace
-    const toolState = cornerstoneTools.getToolState(element, toolName);
 
-    if (toolState) {
-      toolState.data.forEach(function (data) {
-        if(typeof tool.pointNearTool === 'function' &&
-          tool.pointNearTool(element, data, coords)) {
-          cornerstoneTools.removeToolState(element, toolName, data);
-          external.cornerstone.updateImage(element);
-        }
-      });
+    if (typeof tool.pointNearTool === 'function') {
+      configuration.supportedTools[toolName] = tool;
     }
   });
 }
 
-const eraser = simpleMouseButtonTool(deleteNearbyMeasurement, toolType);
+function deleteNearbyMeasurement (mouseEventData) {
+  const coords = mouseEventData.detail.currentPoints.canvas;
+  const element = mouseEventData.detail.element;
+  let foundDataToDelete = false;
+  let imageNeedsUpdate = false;
+
+  Object.entries(configuration.supportedTools).forEach(function ([toolName, tool]) {
+    const toolState = cornerstoneTools.getToolState(element, toolName);
+
+    if (toolState) {
+      toolState.data.forEach(function (data) {
+        if (!foundDataToDelete && tool.pointNearTool(element, data, coords)) {
+          cornerstoneTools.removeToolState(element, toolName, data);
+          foundDataToDelete = true;
+          imageNeedsUpdate = true;
+        }
+      });
+    }
+  });
+
+  if (imageNeedsUpdate) {
+    external.cornerstone.updateImage(element);
+  }
+}
+
+function highlightNearbyMeasurement (mouseEventData) {
+  const coords = mouseEventData.detail.currentPoints.canvas;
+  const element = mouseEventData.detail.element;
+  let imageNeedsUpdate = false;
+  let foundFirstActive = false;
+
+  Object.entries(configuration.supportedTools).forEach(function ([toolName, tool]) {
+    const toolState = cornerstoneTools.getToolState(element, toolName);
+
+    if (toolState) {
+      toolState.data.forEach(function (data) {
+        if (data.active) {
+          data.active = false;
+          imageNeedsUpdate = true;
+        }
+
+        if (!foundFirstActive && tool.pointNearTool(element, data, coords)) {
+          data.active = true;
+          imageNeedsUpdate = true;
+          foundFirstActive = true;
+        }
+      });
+    }
+  });
+
+  if (imageNeedsUpdate) {
+    external.cornerstone.updateImage(element);
+  }
+}
+
+const eraser = {
+  activate (element, mouseButtonMask, options = {}) {
+    options.mouseButtonMask = mouseButtonMask;
+    setToolOptions(toolType, element, options);
+
+    element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, deleteNearbyMeasurement);
+    element.removeEventListener(EVENTS.MOUSE_MOVE, highlightNearbyMeasurement);
+
+    element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, deleteNearbyMeasurement);
+    element.addEventListener(EVENTS.MOUSE_MOVE, highlightNearbyMeasurement);
+
+    populateSupportedTools();
+  },
+
+  disable (element) {
+    element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, deleteNearbyMeasurement);
+    element.removeEventListener(EVENTS.MOUSE_MOVE, highlightNearbyMeasurement);
+  },
+
+  enable (element) {
+    element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, deleteNearbyMeasurement);
+    element.removeEventListener(EVENTS.MOUSE_MOVE, highlightNearbyMeasurement);
+  },
+
+  deactivate (element) {
+    element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, deleteNearbyMeasurement);
+    element.removeEventListener(EVENTS.MOUSE_MOVE, highlightNearbyMeasurement);
+  },
+
+  getConfiguration () {
+    return configuration;
+  },
+
+  setConfiguration (config) {
+    configuration = config;
+  }
+};
 const eraserTouch = simpleTouchTool(deleteNearbyMeasurement, toolType);
 
 export {


### PR DESCRIPTION
…hlight only the data which will be deleted

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Tool data is not highlighted on mouseover when the eraser is active and multiple pieces of data can be deleted with a single click.


* **What is the new behavior (if this is a feature change)?**
Tool data is highlighted on mouseover. When the mouse button is clicked the highlighted data is deleted.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Looks like we released 2.3.8 so I added the eraser back to the allImageTools example