### PR TITLE
[9/N] Use the drawRect function from drawing.js

### DIFF
--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -1,11 +1,10 @@
 import external from '../externalModules.js';
 import mouseButtonRectangleTool from './mouseButtonRectangleTool.js';
 import touchTool from './touchTool.js';
-import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw, path } from '../util/drawing.js';
+import { getNewContext, draw, path, drawRect } from '../util/drawing.js';
 
 const toolType = 'highlight';
 
@@ -102,8 +101,6 @@ function onImageRendered (e) {
   // We have tool data for this elemen
   const context = getNewContext(eventData.canvasContext.canvas);
 
-  const lineWidth = toolStyle.getToolWidth();
-
   const data = toolData.data[0];
 
   if (data.visible === false) {
@@ -139,15 +136,13 @@ function onImageRendered (e) {
     });
 
     color = toolColors.getColorIfActive(data);
+    const options = {
+      color,
+      lineDash: [4]
+    };
 
-    // Draw dashed stroke rectangle
-    const lineDash = [4];
-
-    path(context, { color,
-      lineWidth,
-      lineDash }, (context) => {
-      context.rect(rect.left, rect.top, rect.width, rect.height);
-    });
+    // Dashed stroke rectangle
+    drawRect(context, eventData.element, data.handles.start, data.handles.end, options);
 
     // Draw the handles last, so they will be on top of the overlay
     drawHandles(context, eventData, data.handles, color);

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -7,7 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
-import { getNewContext, draw, path, setShadow } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawRect } from '../util/drawing.js';
 
 const toolType = 'rectangleRoi';
 
@@ -167,22 +167,8 @@ function onImageRendered (e) {
       // Check which color the rendered tool should be
       const color = toolColors.getColorIfActive(data);
 
-      // Convert Image coordinates to Canvas coordinates given the element
-      const handleStartCanvas = cornerstone.pixelToCanvas(element, data.handles.start);
-      const handleEndCanvas = cornerstone.pixelToCanvas(element, data.handles.end);
-
-      // Retrieve the bounds of the ellipse (left, top, width, and height)
-      // In Canvas coordinates
-      const leftCanvas = Math.min(handleStartCanvas.x, handleEndCanvas.x);
-      const topCanvas = Math.min(handleStartCanvas.y, handleEndCanvas.y);
-      const widthCanvas = Math.abs(handleStartCanvas.x - handleEndCanvas.x);
-      const heightCanvas = Math.abs(handleStartCanvas.y - handleEndCanvas.y);
-
       // Draw the rectangle on the canvas
-      path(context, { color,
-        lineWidth }, (context) => {
-        context.rect(leftCanvas, topCanvas, widthCanvas, heightCanvas);
-      });
+      drawRect(context, element, data.handles.start, data.handles.end, { color });
 
       // If the tool configuration specifies to only draw the handles on hover / active,
       // Follow this logic

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -1,13 +1,12 @@
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
-import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import { getToolState, addToolState } from '../stateManagement/toolState.js';
 import getLuminance from '../util/getLuminance.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import clip from '../util/clip.js';
-import { draw, path, setShadow } from '../util/drawing.js';
+import { draw, setShadow, drawRect } from '../util/drawing.js';
 
 const toolType = 'wwwcRegion';
 
@@ -218,7 +217,6 @@ function onImageRendered (e) {
   const eventData = e.detail;
   const element = eventData.element;
   const context = eventData.canvasContext;
-  const cornerstone = external.cornerstone;
   const toolData = getToolState(eventData.element, toolType);
 
   if (!toolData || !toolData.data || !toolData.data.length) {
@@ -236,26 +234,12 @@ function onImageRendered (e) {
 
   // Set to the active tool color
   const color = toolColors.getActiveColor();
-
-  // Calculate the rectangle parameters
-  const startPointCanvas = cornerstone.pixelToCanvas(element, startPoint);
-  const endPointCanvas = cornerstone.pixelToCanvas(element, endPoint);
-
-  const left = Math.min(startPointCanvas.x, endPointCanvas.x);
-  const top = Math.min(startPointCanvas.y, endPointCanvas.y);
-  const width = Math.abs(startPointCanvas.x - endPointCanvas.x);
-  const height = Math.abs(startPointCanvas.y - endPointCanvas.y);
-
-  const lineWidth = toolStyle.getToolWidth();
   const config = wwwcRegion.getConfiguration();
 
   // Draw the rectangle
   draw(context, (context) => {
     setShadow(context, config);
-    path(context, { color,
-      lineWidth }, (context) => {
-      context.rect(left, top, width, height);
-    });
+    drawRect(context, element, startPoint, endPoint, { color });
   });
 }
 


### PR DESCRIPTION
This PR replaces calls to `context.rect()` with calls to the `drawRect()` function from the drawing.js API.

See #405 for full discussion.