### PR TITLE
Chore/length mouse test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-## Directorties
+## Directories
 node_modules
-coverage/
-dist/
 docs/_book/
 
 ## Files
@@ -10,3 +8,8 @@ docs/api.md
 
 ## File Types
 .idea
+
+## Output
+coverage/
+dist/
+junit.xml

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start": "npm run webpack",
     "start:dev": "webpack-dev-server --config ./config/webpack/webpack-dev",
     "test": "npm run test:chrome",
-    "test:unit": "jest",
+    "test:unit": "jest \\.test\\.js$",
     "test:ci": "npm run test:unit -- --coverage --coverageReporters=text-lcov | coveralls",
     "test:watch": "karma start config/karma/karma-watch.js",
     "test:chrome": "karma start config/karma/karma-chrome.js",
@@ -94,6 +94,7 @@
     "dist/cornerstoneTools.min.js.map"
   ],
   "jest": {
+    "verbose": true,
     "moduleFileExtensions": [
       "js"
     ],
@@ -101,6 +102,7 @@
       "node_modules"
     ],
     "reporters": [
+      "default",
       "jest-junit"
     ],
     "collectCoverageFrom": [

--- a/src/new-api-tools-and-examples/lengthMouse.js
+++ b/src/new-api-tools-and-examples/lengthMouse.js
@@ -17,7 +17,6 @@ const cornerstone = external.cornerstone;
 export default class extends baseMouseAnnotationTool {
   constructor () {
     super('lengthMouse');
-    console.log(`my name is ${this.name}`);
   }
 
   /**

--- a/src/new-api-tools-and-examples/lengthMouse.js
+++ b/src/new-api-tools-and-examples/lengthMouse.js
@@ -77,7 +77,17 @@ export default class extends baseMouseAnnotationTool {
    * @returns
    */
   pointNearTool (element, data, coords) {
-    if (data.visible === false) {
+    const hasStartAndEndHandles =
+      data && data.handles && data.handles.start && data.handles.end;
+    const validParameters = hasStartAndEndHandles;
+
+    if (!validParameters) {
+      console.warn(
+        `invalid parameters supplieed to tool ${this.name}'s pointNearTool`
+      );
+    }
+
+    if (!validParameters || data.visible === false) {
       return false;
     }
 
@@ -95,8 +105,6 @@ export default class extends baseMouseAnnotationTool {
    */
   renderToolData (evt) {
     const eventData = evt.detail;
-
-    // If we have no toolData for this element, return immediately as there is nothing to do
     const toolData = getToolState(evt.currentTarget, this.name);
 
     if (!toolData) {

--- a/src/new-api-tools-and-examples/lengthMouse.js
+++ b/src/new-api-tools-and-examples/lengthMouse.js
@@ -27,6 +27,19 @@ export default class extends baseMouseAnnotationTool {
    * @returns
    */
   createNewMeasurement (eventData) {
+    const goodEventData =
+      eventData && eventData.currentPoints && eventData.currentPoints.image;
+
+    if (!goodEventData) {
+      console.error(
+        `required eventData not supplieed to tool ${
+          this.name
+        }'s createNewMeasurement`
+      );
+
+      return;
+    }
+
     return {
       visible: true,
       active: true,

--- a/src/new-api-tools-and-examples/lengthMouse.test.js
+++ b/src/new-api-tools-and-examples/lengthMouse.test.js
@@ -1,4 +1,9 @@
 import LengthMouse from './lengthMouse.js';
+import { getToolState } from './../stateManagement/toolState.js';
+
+jest.mock('./../stateManagement/toolState.js', () => ({
+  getToolState: jest.fn()
+}));
 
 const badMouseEventData = 'hello world';
 const goodMouseEventData = {
@@ -14,6 +19,8 @@ describe('lengthMouse.js', () => {
   beforeEach(() => {
     console.error = jest.fn();
     console.error.mockClear();
+    console.warn = jest.fn();
+    console.warn.mockClear();
   });
 
   describe('default values', () => {
@@ -79,5 +86,69 @@ describe('lengthMouse.js', () => {
     });
   });
 
-  describe('pointNearTool', () => {});
+  describe('pointNearTool', () => {
+    let element, coords;
+
+    beforeEach(() => {
+      element = jest.fn();
+      coords = jest.fn();
+    });
+
+    // Todo: Not sure we want all of our methods to check for valid params.
+    it('emits a console warning when measurementData without start/end handles are supplied', () => {
+      const instantiatedTool = new LengthMouse();
+      const noHandlesMeasurementData = {
+        handles: {}
+      };
+
+      instantiatedTool.pointNearTool(element, noHandlesMeasurementData, coords);
+
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.mock.calls[0][0]).toContain('invalid parameters');
+    });
+
+    it('returns false when measurement data is null or undefined', () => {
+      const instantiatedTool = new LengthMouse();
+      const nullMeasurementData = null;
+
+      const isPointNearTool = instantiatedTool.pointNearTool(
+        element,
+        nullMeasurementData,
+        coords
+      );
+
+      expect(isPointNearTool).toBe(false);
+    });
+
+    it('returns false when measurement data is not visible', () => {
+      const instantiatedTool = new LengthMouse();
+      const notVisibleMeasurementData = {
+        visible: false
+      };
+
+      const isPointNearTool = instantiatedTool.pointNearTool(
+        element,
+        notVisibleMeasurementData,
+        coords
+      );
+
+      expect(isPointNearTool).toBe(false);
+    });
+  });
+
+  describe('renderToolData', () => {
+    it('returns undefined when no toolData exists for the tool', () => {
+      const instantiatedTool = new LengthMouse();
+      const mockEvent = {
+        detail: undefined,
+        currentTarget: undefined
+      };
+
+      getToolState.mockReturnValueOnce(undefined);
+
+      const renderResult = instantiatedTool.renderToolData(mockEvent);
+
+      expect(renderResult).toBe(undefined);
+    });
+  });
 });

--- a/src/new-api-tools-and-examples/lengthMouse.test.js
+++ b/src/new-api-tools-and-examples/lengthMouse.test.js
@@ -1,0 +1,83 @@
+import LengthMouse from './lengthMouse.js';
+
+const badMouseEventData = 'hello world';
+const goodMouseEventData = {
+  currentPoints: {
+    image: {
+      x: 0,
+      y: 0
+    }
+  }
+};
+
+describe('lengthMouse.js', () => {
+  beforeEach(() => {
+    console.error = jest.fn();
+    console.error.mockClear();
+  });
+
+  describe('default values', () => {
+    it('has a default name of "lengthMouse"', () => {
+      const instantiatedTool = new LengthMouse();
+
+      expect(instantiatedTool.name).toEqual('lengthMouse');
+    });
+  });
+
+  describe('createNewMeasurement', () => {
+    it('emits console error if required eventData is not provided', () => {
+      const instantiatedTool = new LengthMouse();
+
+      instantiatedTool.createNewMeasurement(badMouseEventData);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.mock.calls[0][0]).toContain(
+        'required eventData not supplieed to tool'
+      );
+    });
+
+    // Todo: create a more formal definition of a tool measurement object
+    it('returns a tool measurement object', () => {
+      const instantiatedTool = new LengthMouse();
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+
+      expect(typeof toolMeasurement).toBe(typeof {});
+    });
+
+    it('returns a measurement with a start and end handle at the eventData\'s x and y', () => {
+      const instantiatedTool = new LengthMouse();
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+      const startHandle = {
+        x: toolMeasurement.handles.start.x,
+        y: toolMeasurement.handles.start.y
+      };
+      const endHandle = {
+        x: toolMeasurement.handles.end.x,
+        y: toolMeasurement.handles.end.y
+      };
+
+      expect(startHandle.x).toBe(goodMouseEventData.currentPoints.image.x);
+      expect(startHandle.y).toBe(goodMouseEventData.currentPoints.image.y);
+      expect(endHandle.x).toBe(goodMouseEventData.currentPoints.image.x);
+      expect(endHandle.y).toBe(goodMouseEventData.currentPoints.image.y);
+    });
+
+    it('returns a measurement with a textBox handle', () => {
+      const instantiatedTool = new LengthMouse();
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+
+      expect(typeof toolMeasurement.handles.textBox).toBe(typeof {});
+    });
+  });
+
+  describe('pointNearTool', () => {});
+});


### PR DESCRIPTION
- At least one test per method
- Cleaned up test output in terminal
- Some missing logic for `lengthMouse` edge cases