### PR TITLE
[11/N] Add fillOutsideRect function to drawing.js API

### DIFF
--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -4,7 +4,7 @@ import touchTool from './touchTool.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
-import { getNewContext, draw, path, drawRect } from '../util/drawing.js';
+import { getNewContext, draw, fillOutsideRect, drawRect } from '../util/drawing.js';
 
 const toolType = 'highlight';
 
@@ -97,7 +97,6 @@ function onImageRendered (e) {
     return;
   }
 
-  const cornerstone = external.cornerstone;
   // We have tool data for this elemen
   const context = getNewContext(eventData.canvasContext.canvas);
 
@@ -113,37 +112,23 @@ function onImageRendered (e) {
 
   draw(context, (context) => {
 
-
-    const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start);
-    const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end);
-
-    const rect = {
-      left: Math.min(handleStartCanvas.x, handleEndCanvas.x),
-      top: Math.min(handleStartCanvas.y, handleEndCanvas.y),
-      width: Math.abs(handleStartCanvas.x - handleEndCanvas.x),
-      height: Math.abs(handleStartCanvas.y - handleEndCanvas.y)
+    // Draw dark fill outside the rectangle
+    let options = {
+      color: 'transparent',
+      fillStyle: 'rgba(0,0,0,0.7)'
     };
 
-      // Draw dark fill outside the rectangle
+    fillOutsideRect(context, eventData.element, data.handles.start, data.handles.end, options);
 
-    let color = 'transparent';
-    const fillStyle = 'rgba(0,0,0,0.7)';
+    const color = toolColors.getColorIfActive(data);
 
-    path(context, { color,
-      fillStyle }, (context) => {
-      context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
-      context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
-    });
-
-    color = toolColors.getColorIfActive(data);
-    const options = {
+    // Draw dashed stroke rectangle
+    options = {
       color,
       lineDash: [4]
     };
 
-    // Dashed stroke rectangle
     drawRect(context, eventData.element, data.handles.start, data.handles.end, options);
-
     // Draw the handles last, so they will be on top of the overlay
     drawHandles(context, eventData, data.handles, color);
   });

--- a/src/util/drawing.js
+++ b/src/util/drawing.js
@@ -279,6 +279,38 @@ export function drawRect (context, element, corner1, corner2, options, coordSyst
 }
 
 /**
+ * Fill the region outside a rectangle defined by `corner1` and `corner2`.
+ *
+ * @param {CanvasRenderingContext2D} context
+ * @param {HTMLElement} element - The DOM Element to draw on
+ * @param {Object} corner1 - `{ x, y }` in either pixel or canvas coordinates.
+ * @param {Object} corner2 - `{ x, y }` in either pixel or canvas coordinates.
+ * @param {Object} options - See {@link path}
+ * @param {String} [coordSystem='pixel'] - Can be "pixel" (default) or "canvas". The coordinate
+ *     system of the points passed in to the function. If "pixel" then cornerstone.pixelToCanvas
+ *     is used to transform the points from pixel to canvas coordinates.
+ */
+export function fillOutsideRect (context, element, corner1, corner2, options, coordSystem = 'pixel') {
+  if (coordSystem === 'pixel') {
+    const cornerstone = external.cornerstone;
+
+    corner1 = cornerstone.pixelToCanvas(element, corner1);
+    corner2 = cornerstone.pixelToCanvas(element, corner2);
+  }
+
+  const left = Math.min(corner1.x, corner2.x);
+  const top = Math.min(corner1.y, corner2.y);
+  const width = Math.abs(corner1.x - corner2.x);
+  const height = Math.abs(corner1.y - corner2.y);
+
+  path(context, options, (context) => {
+    context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
+    context.rect(left + width, top, -width, height);
+  });
+}
+
+
+/**
  * Draw a filled rectangle defined by `boundingBox` using the style defined by `fillStyle`.
  *
  * @param {CanvasRenderingContext2D} context


### PR DESCRIPTION
This PR adds a `fillOutsideRect` function to the `drawing.js` API. It fulfils the use case of needing to fill the entire canvas, with the exception of a particular rectangle bounded by two points. This use case comes up in `highlight.js` where most of the image is dimmed out, leaving the selected window highlighted.

This extends the API described in #405.

