### PR TITLE
[12/N] Use the drawing.js version of drawEllipse in the deprecated drawEllipse

### DIFF
--- a/src/util/drawEllipse.js
+++ b/src/util/drawEllipse.js
@@ -1,4 +1,4 @@
-import { path } from './drawing.js';
+import { drawEllipse } from './drawing.js';
 
 // http://stackoverflow.com/questions/2172798/how-to-draw-an-oval-in-html5-canvas
 
@@ -6,19 +6,15 @@ import { path } from './drawing.js';
  * @deprecated Use drawing.js:drawEllipse()
  */
 export default function (context, x, y, w, h) {
-  const kappa = 0.5522848,
-    ox = (w / 2) * kappa, // Control point offset horizontal
-    oy = (h / 2) * kappa, // Control point offset vertical
-    xe = x + w, // X-end
-    ye = y + h, // Y-end
-    xm = x + w / 2, // X-middle
-    ym = y + h / 2; // Y-middle
 
-  path(context, {}, (context) => {
-    context.moveTo(x, ym);
-    context.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
-    context.bezierCurveTo(xm + ox, y, xe, ym - oy, xe, ym);
-    context.bezierCurveTo(xe, ym + oy, xm + ox, ye, xm, ye);
-    context.bezierCurveTo(xm - ox, ye, x, ym + oy, x, ym);
-  });
+  const corner1 = {
+    x,
+    y
+  };
+  const corner2 = {
+    x: x + w,
+    y: y + h
+  };
+
+  drawEllipse(context, undefined, corner1, corner2, {}, 'canvas');
 }


### PR DESCRIPTION
This PR uses the `drawEllipse` function from the `drawing.js` API within the deprecated `drawEllipse.js`.

See #405 for full discussion.