### PR TITLE
Add a textBoxWidth function

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -3,7 +3,6 @@ import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';
 import roundToDecimal from '../util/roundToDecimal.js';
-import textStyle from '../stateManagement/textStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
@@ -74,7 +73,6 @@ function onImageRendered (e) {
   // We have tool data for this element - iterate over each one and draw it
   const context = getNewContext(eventData.canvasContext.canvas);
 
-  const font = textStyle.getFont();
   const config = angle.getConfiguration();
   const cornerstone = external.cornerstone;
 
@@ -97,9 +95,6 @@ function onImageRendered (e) {
       // Draw the handles
       drawHandles(context, eventData, data.handles);
 
-      // Draw the text
-      context.fillStyle = color;
-
       // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
       // Where lines cross to measure angle. For now it will show smallest angle.
       const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * eventData.image.columnPixelSpacing;
@@ -121,7 +116,6 @@ function onImageRendered (e) {
       const textX = (handleStartCanvas.x + handleEndCanvas.x) / 2;
       const textY = (handleStartCanvas.y + handleEndCanvas.y) / 2;
 
-      context.font = font;
       drawTextBox(context, text, textX, textY, color);
     });
   }

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -18,6 +18,7 @@ import { addToolState, removeToolState, getToolState } from '../stateManagement/
 import { getToolOptions } from '../toolOptions.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { getNewContext, draw, setShadow } from '../util/drawing.js';
+import { textBoxWidth } from '../util/drawTextBox.js';
 
 const toolType = 'arrowAnnotate';
 
@@ -150,7 +151,6 @@ function onImageRendered (e) {
   const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
-  const font = textStyle.getFont();
   const config = arrowAnnotate.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
@@ -188,10 +188,9 @@ function onImageRendered (e) {
 
       // Draw the text
       if (text && text !== '') {
-        context.font = font;
-
         // Calculate the text coordinates.
-        const textWidth = context.measureText(text).width + 10;
+        const padding = 5;
+        const textWidth = textBoxWidth(context, text, padding);
         const textHeight = textStyle.getFontSize() + 10;
 
         let distance = Math.max(textWidth, textHeight) / 2 + 5;

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -4,7 +4,7 @@ import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import touchDragTool from './touchDragTool.js';
 import textStyle from '../stateManagement/textStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
-import drawTextBox from '../util/drawTextBox.js';
+import drawTextBox, { textBoxWidth } from '../util/drawTextBox.js';
 import getRGBPixels from '../util/getRGBPixels.js';
 import calculateSUV from '../util/calculateSUV.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
@@ -22,7 +22,6 @@ function defaultStrategy (eventData) {
   const context = getNewContext(enabledElement.canvas);
 
   const color = toolColors.getActiveColor();
-  const font = textStyle.getFont();
   const fontHeight = textStyle.getFontSize();
   const config = dragProbe.getConfiguration();
 
@@ -66,9 +65,6 @@ function defaultStrategy (eventData) {
     };
     const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
 
-    context.font = font;
-    context.fillStyle = color;
-
     drawTextBox(context, str, textCoords.x, textCoords.y + fontHeight + 5, color);
     drawTextBox(context, text, textCoords.x, textCoords.y, color);
   });
@@ -83,7 +79,6 @@ function minimalStrategy (eventData) {
   const context = getNewContext(enabledElement.canvas);
 
   const color = toolColors.getActiveColor();
-  const font = textStyle.getFont();
   const config = dragProbe.getConfiguration();
 
   let toolCoords;
@@ -141,17 +136,15 @@ function minimalStrategy (eventData) {
     // Prepare text
     const textCoords = cornerstone.pixelToCanvas(element, toolCoords);
 
-    context.font = font;
-    context.fillStyle = color;
-
     // Translate the x/y away from the cursor
     let translation;
     const handleRadius = 6;
-    const width = context.measureText(text).width;
+    const padding = 5;
+    const width = textBoxWidth(context, text, padding);
 
     if (eventData.isTouchEvent === true) {
       translation = {
-        x: -width / 2 - 5,
+        x: -width / 2,
         y: -textStyle.getFontSize() - 10 - 2 * handleRadius
       };
     } else {

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -107,9 +107,6 @@ function onImageRendered (e) {
 
       drawHandles(context, eventData, data.handles, color, handleOptions);
 
-      // Draw the text
-      context.fillStyle = color;
-
       // Set rowPixelSpacing and columnPixelSpacing to 1 if they are undefined (or zero)
       const dx = (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1);
       const dy = (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1);

--- a/src/imageTools/orientationMarkers.js
+++ b/src/imageTools/orientationMarkers.js
@@ -2,7 +2,7 @@ import external from '../externalModules.js';
 import orientation from '../orientation/index.js';
 import displayTool from './displayTool.js';
 import toolColors from '../stateManagement/toolColors.js';
-import drawTextBox from '../util/drawTextBox.js';
+import drawTextBox, { textBoxWidth } from '../util/drawTextBox.js';
 import { getNewContext } from '../util/drawing.js';
 
 function getOrientationMarkers (element) {
@@ -82,10 +82,10 @@ function onImageRendered (e) {
   const color = toolColors.getToolColor();
 
   const textWidths = {
-    top: context.measureText(markers.top).width,
-    left: context.measureText(markers.left).width,
-    right: context.measureText(markers.right).width,
-    bottom: context.measureText(markers.bottom).width
+    top: textBoxWidth(context, markers.top, 0),
+    left: textBoxWidth(context, markers.left, 0),
+    right: textBoxWidth(context, markers.right, 0),
+    bottom: textBoxWidth(context, markers.bottom, 0)
   };
 
   drawTextBox(context, markers.top, coords.top.x - textWidths.top / 2, coords.top.y, color);

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -60,7 +60,6 @@ function onImageRendered (e) {
   // We have tool data for this element - iterate over each one and draw it
   const context = getNewContext(eventData.canvasContext.canvas);
 
-  const font = textStyle.getFont();
   const fontHeight = textStyle.getFontSize();
 
   for (let i = 0; i < toolData.data.length; i++) {
@@ -109,9 +108,6 @@ function onImageRendered (e) {
           y: data.handles.end.y - 3
         };
         const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
-
-        context.font = font;
-        context.fillStyle = color;
 
         drawTextBox(context, str, textCoords.x, textCoords.y + fontHeight + 5, color);
         drawTextBox(context, text, textCoords.x, textCoords.y, color);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -15,6 +15,7 @@ import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 import { drawCircle, getNewContext, draw, setShadow } from '../util/drawing.js';
+import { textBoxWidth } from '../util/drawTextBox.js';
 
 const toolType = 'seedAnnotate';
 
@@ -141,7 +142,6 @@ function onImageRendered (e) {
   const canvasWidth = eventData.canvasContext.canvas.width;
 
   const lineWidth = toolStyle.getToolWidth();
-  const font = textStyle.getFont();
   const config = seedAnnotate.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
@@ -176,10 +176,9 @@ function onImageRendered (e) {
       if (data.text && data.text !== '') {
         const text = textBoxText(data);
 
-        context.font = font;
-
         // Calculate the text coordinates.
-        const textWidth = context.measureText(text).width + 10;
+        const padding = 5;
+        const textWidth = textBoxWidth(context, text, padding);
         const textHeight = textStyle.getFontSize() + 10;
 
         let distance = Math.max(textWidth, textHeight) / 2 + 5;

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -3,7 +3,6 @@ import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import roundToDecimal from '../util/roundToDecimal.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
-import textStyle from '../stateManagement/textStyle.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
@@ -14,6 +13,7 @@ import touchTool from './touchTool.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
+import { textBoxWidth } from '../util/drawTextBox.js';
 
 
 const toolType = 'simpleAngle';
@@ -89,7 +89,6 @@ function onImageRendered (e) {
   const context = getNewContext(eventData.canvasContext.canvas);
 
   const lineWidth = toolStyle.getToolWidth();
-  const font = textStyle.getFont();
   const config = simpleAngle.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
@@ -116,9 +115,6 @@ function onImageRendered (e) {
       };
 
       drawHandles(context, eventData, data.handles, color, handleOptions);
-
-      // Draw the text
-      context.fillStyle = color;
 
       // Default to isotropic pixel size, update suffix to reflect this
       const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
@@ -163,11 +159,11 @@ function onImageRendered (e) {
             y: handleMiddleCanvas.y
           };
 
-          context.font = font;
-          const textWidth = context.measureText(text).width;
+          const padding = 5;
+          const textWidth = textBoxWidth(context, text, padding);
 
           if (handleMiddleCanvas.x < handleStartCanvas.x) {
-            textCoords.x -= distance + textWidth + 10;
+            textCoords.x -= distance + textWidth;
           } else {
             textCoords.x += distance;
           }

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -5,7 +5,7 @@ import touchTool from './touchTool.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import toolColors from '../stateManagement/toolColors.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
-import drawTextBox from '../util/drawTextBox.js';
+import drawTextBox, { textBoxWidth } from '../util/drawTextBox.js';
 import { removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getToolOptions } from '../toolOptions.js';
 import { getNewContext, draw, setShadow } from '../util/drawing.js';
@@ -125,10 +125,9 @@ function onImageRendered (e) {
       setShadow(context, config);
 
       // Draw text
-      context.fillStyle = color;
-      const measureText = context.measureText(data.text);
+      const padding = 5;
 
-      data.textWidth = measureText.width + 10;
+      data.textWidth = textBoxWidth(context, data.text, padding);
 
       const textCoords = external.cornerstone.pixelToCanvas(eventData.element, data.handles.end);
 

--- a/src/timeSeriesTools/probeTool4D.js
+++ b/src/timeSeriesTools/probeTool4D.js
@@ -4,9 +4,8 @@ import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import MeasurementManager from '../measurementManager/measurementManager.js';
 import LineSampleMeasurement from '../measurementManager/lineSampleMeasurement.js';
-import textStyle from '../stateManagement/textStyle.js';
 import drawTextBox from '../util/drawTextBox.js';
-import { draw, path } from '../util/drawing.js';
+import { draw } from '../util/drawing.js';
 
 const toolType = 'probe4D';
 
@@ -84,18 +83,12 @@ function onImageRendered (e) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   const color = 'white';
-  const font = textStyle.getFont();
 
   for (let i = 0; i < toolData.data.length; i++) {
     draw(context, (context) => {
       const data = toolData.data[i];
 
-      // Draw the handles
-      path(context, {}, (context) => {
-        drawHandles(context, eventData, data.handles, color);
-      });
-
-      context.font = font;
+      drawHandles(context, eventData, data.handles, color);
 
       const coords = {
         // Translate the x/y away from the cursor
@@ -104,8 +97,6 @@ function onImageRendered (e) {
       };
 
       const textCoords = cornerstone.pixelToCanvas(eventData.element, coords);
-
-      context.fillStyle = color;
 
       drawTextBox(context, `${data.handles.end.x}, ${data.handles.end.y}`, textCoords.x, textCoords.y, color);
     });

--- a/src/util/drawTextBox.js
+++ b/src/util/drawTextBox.js
@@ -1,6 +1,29 @@
 import textStyle from '../stateManagement/textStyle.js';
 import { draw, fillTextLines, fillBox } from './drawing.js';
 
+/**
+ * Compute the width of the box required to display the given `text` with a given `padding`.
+ *
+ * @param {CanvasRenderingContext2D} context
+ * @param {String} text - The text to find the width of.
+ * @param {Number} padding - The padding to apply on either end of the text.
+ */
+export function textBoxWidth (context, text, padding) {
+  const font = textStyle.getFont();
+  const origFont = context.font;
+
+  if (font && font !== origFont) {
+    context.font = font;
+  }
+  const width = context.measureText(text).width;
+
+  if (font && font !== origFont) {
+    context.font = origFont;
+  }
+
+  return width + 2 * padding;
+}
+
 export default function (context, textLines, x, y, color, options) {
   if (Object.prototype.toString.call(textLines) !== '[object Array]') {
     textLines = [textLines];
@@ -15,7 +38,7 @@ export default function (context, textLines, x, y, color, options) {
 
   textLines.forEach(function (text) {
     // Get the text width in the current font
-    const width = context.measureText(text).width;
+    const width = textBoxWidth(context, text, padding);
 
     // Find the maximum with for all the text rows;
     maxWidth = Math.max(maxWidth, width);
@@ -23,7 +46,7 @@ export default function (context, textLines, x, y, color, options) {
 
   // Calculate the bounding box for this text box
   const boundingBox = {
-    width: maxWidth + (padding * 2),
+    width: maxWidth,
     height: padding + textLines.length * (fontSize + padding)
   };
 


### PR DESCRIPTION
This PR adds a `textBoxWidth` function to `drawTextBox.js`. It abstracts away the common operation of determining how wide the textbox needs to be for a given text and padding.

This change also ensures that the width is calculated in terms of the currently selected font. Some tools did not previously do this and could potentially calculate the wrong value if the default font of the `context` was different to the font specified in `textStyle` (although I suspect this is a fairly rare situation).

This change also allows us to avoid setting `context.font` within each tool, as all the fonts are now managed by helper functions. We also remove setting of `context.fillStyle`, since the `drawing.js` API handles this for us.

Computing the text width with explicit reference to the `padding` brings us closer to having the padding defined once for each tool, rather than explicitly and implicitly in multiple places throughout the code. Future PRs will follow this line of investigation.