### PR TITLE
Fix: able to grab tools by handles w/ touch

### DIFF
--- a/src/eventDispatchers/touchToolEventDispatcher.js
+++ b/src/eventDispatchers/touchToolEventDispatcher.js
@@ -240,7 +240,7 @@ function touchStart (evt) {
 
     const firstToolWithMoveableHandles = toolsWithMoveableHandles[0];
     const toolState = getToolState(element, firstToolWithMoveableHandles.name);
-    const moveableHandle = toolState.data.find(
+    const dataWithMoveableHandle = toolState.data.find(
       (d) =>
         getHandleNearImagePoint(
           element,
@@ -249,6 +249,13 @@ function touchStart (evt) {
           distanceFromHandle
         ) !== undefined
     );
+    const moveableHandle = getHandleNearImagePoint(
+      element,
+      dataWithMoveableHandle.handles,
+      coords,
+      distanceFromHandle
+    );
+
 
     toolState.data.active = true;
     touchMoveHandle(

--- a/src/manipulators/getHandleNearImagePoint.js
+++ b/src/manipulators/getHandleNearImagePoint.js
@@ -25,7 +25,10 @@ export default function (element, handles, coords, distanceThreshold) {
       }
     } else {
       const handleCanvas = external.cornerstone.pixelToCanvas(element, handle);
-      const distance = external.cornerstoneMath.point.distance(handleCanvas, coords);
+      const distance = external.cornerstoneMath.point.distance(
+        handleCanvas,
+        coords
+      );
 
       if (distance <= distanceThreshold) {
         nearbyHandle = handle;


### PR DESCRIPTION
The previous implementation incorrectly set `moveableHandle` to a set of toolData. This updates the implementation to find the `moveableHandle` within the returned toolData