### PR TITLE
added MEASUREMENT_ADDING_END event

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -37,6 +37,7 @@ const EVENTS = {
 
   // Measurement / tool events
   MEASUREMENT_ADDED: 'cornerstonetoolsmeasurementadded',
+  MEASUREMENT_ADDING_END: 'cornerstonetoolsmeasurementaddingend',
   MEASUREMENT_MODIFIED: 'cornerstonetoolsmeasurementmodified',
   MEASUREMENT_REMOVED: 'cornerstonemeasurementremoved',
   TOOL_DEACTIVATED: 'cornerstonetoolstooldeactivated',

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -47,7 +47,9 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
     const eventData = e.detail;
 
     if (eventData.measurementData === data) {
-      moveEndCallback();
+      const hasBeenRemoved = true;
+
+      moveEndCallback(hasBeenRemoved);
     }
   }
 
@@ -72,7 +74,7 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
   element.addEventListener(EVENTS.MEASUREMENT_REMOVED, measurementRemovedCallback);
   element.addEventListener(EVENTS.TOOL_DEACTIVATED, toolDeactivatedCallback);
 
-  function moveEndCallback () {
+  function moveEndCallback (hasBeenRemoved = false) {
     element.removeEventListener(EVENTS.MOUSE_MOVE, moveCallback);
     element.removeEventListener(EVENTS.MOUSE_DRAG, moveCallback);
     element.removeEventListener(EVENTS.MOUSE_CLICK, moveEndCallback);
@@ -86,5 +88,15 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
     if (typeof doneMovingCallback === 'function') {
       doneMovingCallback();
     }
+
+    const eventType = EVENTS.MEASUREMENT_ADDING_END;
+    const modifiedEventData = {
+      toolType,
+      element,
+      hasBeenRemoved,
+      measurementData: data
+    };
+
+    triggerEvent(element, eventType, modifiedEventData);
   }
 }

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -47,9 +47,7 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
     const eventData = e.detail;
 
     if (eventData.measurementData === data) {
-      const hasBeenRemoved = true;
-
-      moveEndCallback(hasBeenRemoved);
+      moveEndCallback();
     }
   }
 
@@ -74,7 +72,7 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
   element.addEventListener(EVENTS.MEASUREMENT_REMOVED, measurementRemovedCallback);
   element.addEventListener(EVENTS.TOOL_DEACTIVATED, toolDeactivatedCallback);
 
-  function moveEndCallback (hasBeenRemoved = false) {
+  function moveEndCallback () {
     element.removeEventListener(EVENTS.MOUSE_MOVE, moveCallback);
     element.removeEventListener(EVENTS.MOUSE_DRAG, moveCallback);
     element.removeEventListener(EVENTS.MOUSE_CLICK, moveEndCallback);
@@ -93,7 +91,6 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
     const modifiedEventData = {
       toolType,
       element,
-      hasBeenRemoved,
       measurementData: data
     };
 


### PR DESCRIPTION
added trigger for MEASUREMENT_ADDING_END event for moveNewHandle (mouse) moveEndCallback function

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature



* **What is the current behavior?** (You can also link to an open issue here)

When an roi (using a cornerstone tool) is firstly added but not set yet, the MEASUREMENT_ADDED event is triggered.
There is no event triggered when the adding is finished.
example - 
When adding a rectangleRoi, the first mouse click will set one of the rectangle's corners and trigger the MEASUREMENT_ADDED.
There is no event triggered when the second corner is set.



* **What is the new behavior (if this is a feature change)?**

When the adding is done (for now only for mouse) a new event will be triggered 
MEASUREMENT_ADDING_END


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

There is no breaking change!


* **Other information**:

I think the naming of the original event (MEASUREMENT_ADDED) is wrong because with ROIs it is triggered before it was actually added but when the adding has started.
This event should be used in my case.
Anyway, because I didn't want to create a breaking change of the api so I named the new event a bit different but I believe this should be fine.