### PR TITLE
[WIP] Feature:freehand dispatcher changes

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/mouseMove.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseMove.js
@@ -57,6 +57,12 @@ export default function (evt) {
         data.active = !data.active;
         imageNeedsUpdate = true;
       }
+
+      // TODO: We may want to do _only_ this, and provide a default implementation
+      // TODO: On each tool?
+      if (typeof tool.mouseMoveCallback === 'function') {
+        tool.mouseMoveCallback(evt);
+      }
     }
   }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 export const state = {
   isToolLocked: false,
-  tools: []
+  tools: [],
+  clickProximity: 6
 };
 
 export const getters = {


### PR DESCRIPTION
I'll tag you as a reviewer when I wrap up @JamesAPetts 

- [Specialty Tools](https://github.com/dannyrb/cornerstoneTools/blob/4e24873ed15e330a220ed5e206cb1e1c4d021aa9/src/eventDispatchers/mouseEventHandlers/mouseDown.js#L43-L59) take priority over other tools; they can choose to `preventPropagation` if they'd like
- For AnnotationTools, [we first check handles](https://github.com/dannyrb/cornerstoneTools/blob/4e24873ed15e330a220ed5e206cb1e1c4d021aa9/src/eventDispatchers/mouseEventHandlers/mouseDown.js#L63-L88):
    - Which tools have handles near our point?
    - Which tool should we use? (For now, first one in array)
    - Use `mouseDownCallback` if it's defined, or `handleMover`
- Then [we check PointNearTool](https://github.com/dannyrb/cornerstoneTools/blob/4e24873ed15e330a220ed5e206cb1e1c4d021aa9/src/eventDispatchers/mouseEventHandlers/mouseDown.js#L91-L127):
    - Which tools have are near our point?
    - Which tool should we use? (For now, first one in array)
    - Use `mouseDownCallback` if it's defined, or `moveAllHandles` handle mover

