### PR TITLE
Fix/passive tools should take priority

### DIFF
--- a/src/base/baseAnnotationToolHelpers.js
+++ b/src/base/baseAnnotationToolHelpers.js
@@ -1,4 +1,4 @@
-import { getters, state } from '../store/index.js';
+import { mutations, state } from '../store/index.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import getHandleNearImagePoint from '../manipulators/getHandleNearImagePoint.js';
 import moveAllHandles from '../manipulators/moveAllHandles.js';
@@ -25,14 +25,10 @@ const getToolsWithMovableHandles = function (element, tools, coords) {
   });
 };
 
-const moveHandleNearImagePoint = function (
-  evt,
-  handle,
-  data,
-  toolName
-) {
+const moveHandleNearImagePoint = function (evt, handle, data, toolName) {
   // Todo: We've grabbed a handle, stop listening/ignore for MOUSE_MOVE
   data.active = true;
+  mutations.SET_IS_TOOL_LOCKED(true);
   moveHandle(
     evt.detail,
     toolName,
@@ -40,6 +36,7 @@ const moveHandleNearImagePoint = function (
     handle,
     () => {
       data.active = false;
+      mutations.SET_IS_TOOL_LOCKED(false);
     },
     true // PreventHandleOutsideImage
   );
@@ -76,23 +73,20 @@ const findHandleDataNearImagePoint = function (
   }
 };
 
-const moveAnnotationNearClick = function (
-  evt,
-  toolState,
-  tool,
-  data
-) {
+const moveAnnotationNearClick = function (evt, toolState, tool, data) {
   const opt = tool.options || {
     deleteIfHandleOutsideImage: true,
     preventHandleOutsideImage: false
   };
 
   data.active = true;
+  mutations.SET_IS_TOOL_LOCKED(true);
   // TODO: Ignore MOUSE_MOVE for a bit
   // TODO: Why do this and `moveHandle` expose this in different
   // TODO: ways? PreventHandleOutsideImage
   moveAllHandles(evt, data, toolState, tool.name, opt, () => {
     data.active = false;
+    mutations.SET_IS_TOOL_LOCKED(false);
   });
 
   evt.stopImmediatePropagation();
@@ -125,4 +119,4 @@ export {
   findHandleDataNearImagePoint,
   moveAnnotationNearClick,
   findAnnotationNearClick
-}
+};

--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -43,37 +43,16 @@ export default function (evt) {
     isMouseButtonEnabled(eventData.which, tool.options.mouseButtonMask)
   );
 
-  const activeTools = tools.filter((tool) => tool.mode === 'active');
-
-  // If any tools are active, check if they have a special reason for dealing with the event.
-  if (activeTools.length > 0) {
-    // TODO: If length > 1, you could assess fitness and select the ideal tool
-    // TODO: But because we're locking this to 'active' tools, that should rarely be an issue
-    // Super-Meta-TODO: ^ I think we should just take the approach of one active tool per mouse button?
-    const firstActiveToolWithCallback = activeTools.find(
-      (tool) => typeof tool.activeMouseDownCallback === 'function'
-    );
-
-    if (firstActiveToolWithCallback) {
-      const consumedEvent = firstActiveToolWithCallback.activeMouseDownCallback(
-        evt
-      );
-
-      if (consumedEvent) {
-        return;
-      }
-    }
-  }
-
   // Annotation tool specific
   const annotationTools = getToolsWithDataForElement(element, tools);
+
+  // NEAR HANDLES?
   const annotationToolsWithMoveableHandles = getToolsWithMovableHandles(
     element,
     annotationTools,
     coords
   );
 
-  // HANDLES
   if (annotationToolsWithMoveableHandles.length > 0) {
     const firstToolWithMoveableHandles = annotationToolsWithMoveableHandles[0];
     const toolState = getToolState(element, firstToolWithMoveableHandles.name);
@@ -91,7 +70,7 @@ export default function (evt) {
     return;
   }
 
-  // POINT NEAR
+  // NEAR TOOL?
   const annotationToolsWithPointNearClick = tools.filter((tool) => {
     const toolState = getToolState(element, tool.name);
 
@@ -125,5 +104,28 @@ export default function (evt) {
     firstToolWithPointNearClick.toolSelectedCallback(evt, toolData, toolState);
 
     return;
+  }
+
+  // ACTIVE TOOL W/ CALLBACK?
+  const activeTools = tools.filter((tool) => tool.mode === 'active');
+
+  // If any tools are active, check if they have a special reason for dealing with the event.
+  if (activeTools.length > 0) {
+    // TODO: If length > 1, you could assess fitness and select the ideal tool
+    // TODO: But because we're locking this to 'active' tools, that should rarely be an issue
+    // Super-Meta-TODO: ^ I think we should just take the approach of one active tool per mouse button?
+    const firstActiveToolWithCallback = activeTools.find(
+      (tool) => typeof tool.activeMouseDownCallback === 'function'
+    );
+
+    if (firstActiveToolWithCallback) {
+      const consumedEvent = firstActiveToolWithCallback.activeMouseDownCallback(
+        evt
+      );
+
+      if (consumedEvent) {
+        return;
+      }
+    }
   }
 }


### PR DESCRIPTION
Fix for `zoom` and other `passive` tools still executing `strategies` when a `handle` or `pointNearTool` should be claiming the event to update tool data.

CC: @galelis && @JamesAPetts 