### PR TITLE
Added a configuration to allow for prefetching to keep the existing pool

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added a configuration setting on the stackPrefetch tool, called "preserveExistingPool", that prevents resetting the prefetch pool each time a new stack viewer is activated.
 
 ## [2.3.9] - 2018-07-24
 ### Changed

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -9,7 +9,8 @@ const toolType = 'stackPrefetch';
 const requestType = 'prefetch';
 
 let configuration = {
-  maxImagesToPrefetch: Infinity
+  maxImagesToPrefetch: Infinity,
+  preserveExistingPool: false
 };
 
 let resetPrefetchTimeout;
@@ -127,8 +128,10 @@ function prefetch (element) {
     return;
   }
 
-  // Clear the requestPool of prefetch requests
-  requestPoolManager.clearRequestStack(requestType);
+  // Clear the requestPool of prefetch requests, if needed.
+  if (!configuration.preserveExistingPool) {
+    requestPoolManager.clearRequestStack(requestType);
+  }
 
   // Identify the nearest imageIdIndex to the currentImageIdIndex
   const nearest = nearestIndex(stackPrefetch.indicesToRequest, stack.currentImageIdIndex);
@@ -157,6 +160,7 @@ function prefetch (element) {
   // Prefetch images around the current image (before and after)
   let lowerIndex = nearest.low;
   let higherIndex = nearest.high;
+  const imageIdsToPrefetch = [];
 
   while (lowerIndex >= 0 || higherIndex < stackPrefetch.indicesToRequest.length) {
     const currentIndex = stack.currentImageIdIndex;
@@ -173,15 +177,20 @@ function prefetch (element) {
     if (shouldLoadLower) {
       nextImageIdIndex = stackPrefetch.indicesToRequest[lowerIndex--];
       imageId = stack.imageIds[nextImageIdIndex];
-      requestPoolManager.addRequest(element, imageId, requestType, preventCache, doneCallback, failCallback);
+      imageIdsToPrefetch.push(imageId);
     }
 
     if (shouldLoadHigher) {
       nextImageIdIndex = stackPrefetch.indicesToRequest[higherIndex++];
       imageId = stack.imageIds[nextImageIdIndex];
-      requestPoolManager.addRequest(element, imageId, requestType, preventCache, doneCallback, failCallback);
+      imageIdsToPrefetch.push(imageId);
     }
 
+  }
+
+  // Load images in reverse order, by adding them at the beginning of the pool.
+  for(const imageToLoad of imageIdsToPrefetch.reverse()) {
+    requestPoolManager.addRequest(element, imageToLoad, requestType, preventCache, doneCallback, failCallback, true);
   }
 
   // Try to start the requestPool's grabbing procedure


### PR DESCRIPTION
Currently, switching to a viewer with a stack prefetch tools removes all existing prefetch requests.
By changing a boolean value, this is no longer the case.

Solves issue #529

`config = cornerstoneTools.stackPrefetch.getConfiguration();
        config.preserveExistingPool = true;`

Please note that the build is currently K.O. but was before my commit.