### PR TITLE
MouseEvent.buttons to replace MouseEvent.which; and auto-tool `passive`

### DIFF
--- a/examples/icon-classes.css
+++ b/examples/icon-classes.css
@@ -1,0 +1,50 @@
+.mousebutton-1::after {
+  content: url("icons/mouse-left.svg");
+}
+.mousebutton-2::after {
+  content: url("icons/mouse-right.svg");
+}
+.mousebutton-3::after {
+  content: " - M3";
+}
+.mousebutton-4::after {
+  content: url("icons/mouse-middle.svg");
+}
+.mousebutton-5::after {
+  content: " - M5";
+}
+.mousebutton-6::after {
+  content: " - M6";
+}
+.mousebutton-7::after {
+  content: " - M7";
+}
+.mousebutton-8::after {
+  content: " - M8";
+}
+.mousebutton-9::after {
+  content: " - M9";
+}
+.mousebutton-10::after {
+  content: " - M10";
+}
+.mousebutton-11::after {
+  content: " - M11";
+}
+.mousebutton-12::after {
+  content: " - M12";
+}
+.mousebutton-wheel::after {
+  content: url("icons/mouse-middle.svg");
+}
+
+/* TOUCH */
+.touch-1::before {
+  content: url("https://unpkg.com/@mdi/svg@2.6.95/svg/gesture-tap.svg");
+}
+.touch-2::before {
+  content: url("https://unpkg.com/@mdi/svg@2.6.95/svg/gesture-two-tap.svg");
+}
+.touch-pinch::before {
+  content: url("https://unpkg.com/@mdi/svg@2.6.95/svg/gesture.svg");
+}

--- a/examples/icons/mouse-left.svg
+++ b/examples/icons/mouse-left.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<path d="M20,9c0-3.9-3.6-8.1-8-8.1S4,5.1,4,9v6c0,4.4,3.6,8,8,8s8-3.6,8-8L20,9L20,9z M11.5,9.5h-6c0-3.6,2.6-6.6,6-7V9.5z"/>
+</svg>

--- a/examples/icons/mouse-middle.svg
+++ b/examples/icons/mouse-middle.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<path d="M20,9c0-3.9-3.6-8.1-8-8.1S4,5.1,4,9v6c0,4.4,3.6,8,8,8s8-3.6,8-8L20,9L20,9z M13.5,9.1c0,0.8-0.7,1.4-1.5,1.4
+	s-1.5-0.6-1.5-1.4V4.9c0-0.8,0.7-1.4,1.5-1.4s1.5,0.6,1.5,1.4V9.1z"/>
+</svg>

--- a/examples/icons/mouse-right.svg
+++ b/examples/icons/mouse-right.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<path d="M20,9c0-3.9-3.6-8.1-8-8.1S4,5.1,4,9v6c0,4.4,3.6,8,8,8s8-3.6,8-8L20,9L20,9z M12.5,9.5v-7c3.4,0.4,6,3.4,6,7H12.5z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -168,10 +168,32 @@
 		}
 
 		// Setup button listener
-		toolBtn.addEventListener('click', (evt) => {
+		// Prevent right click context menu for our menu buttons
+		toolBtn.addEventListener('contextmenu', event => event.preventDefault(), true);
+		// Prevent middle click opening a new tab on Chrome & FF
+		toolBtn.addEventListener('auxclick', event => {
+			if (event.button && event.button === 1) {
+				event.preventDefault();
+			}
+		}, false);
+		toolBtn.addEventListener('mousedown', (evt) => {
+			// 	A number representing one or more buttons. For more than one button pressed simultaneously, the values are combined (e.g. 3 is primary + secondary).
+			// 0  : No button or un-initialized
+			// 1  : Primary button (usually left)
+			// 2  : Secondary button (usually right)
+			// 4  : Auxilary button (usually middle or mouse wheel button)
+			// 8  : 4th button (typically the "Browser Back" button)
+			// 16 : 5th button (typically the "Browser Forward" button)
+			console.log(`MouseEvent.buttons: ${evt.buttons}`);
+			console.log(`MouseEvent.which: ${evt.which}`);
 			setAllToolsPassive();
 			setButtonActive(toolName);
 			cTools.setToolActive(toolName, { mouseButtonMask: 1 });
+
+			evt.preventDefault();
+			evt.stopPropagation();
+			evt.stopImmediatePropagation();
+			return false;
 		});
 	});
 

--- a/index.html
+++ b/index.html
@@ -177,18 +177,14 @@
 			}
 		}, false);
 		toolBtn.addEventListener('mousedown', (evt) => {
-			// 	A number representing one or more buttons. For more than one button pressed simultaneously, the values are combined (e.g. 3 is primary + secondary).
-			// 0  : No button or un-initialized
-			// 1  : Primary button (usually left)
-			// 2  : Secondary button (usually right)
-			// 4  : Auxilary button (usually middle or mouse wheel button)
-			// 8  : 4th button (typically the "Browser Back" button)
-			// 16 : 5th button (typically the "Browser Forward" button)
-			console.log(`MouseEvent.buttons: ${evt.buttons}`);
-			console.log(`MouseEvent.which: ${evt.which}`);
+			console.log('mousedown')
+			const mouseButtonMask = evt.buttons
+				? evt.buttons
+				: convertMouseEventWhichToButtons(evt.which)
+			// TODO: Let's make this happen automagically for mask/touch conflicts?
 			setAllToolsPassive();
 			setButtonActive(toolName);
-			cTools.setToolActive(toolName, { mouseButtonMask: 1 });
+			cTools.setToolActive(toolName, { mouseButtonMask });
 
 			evt.preventDefault();
 			evt.stopPropagation();
@@ -252,6 +248,24 @@
 				toolBtn.classList.remove('active');
 			}
 		});
+	}
+
+	const convertMouseEventWhichToButtons = (which) => {
+		switch (which) {
+			// no button
+			case 0:
+				return 0;
+			// left
+			case 1:
+				return 1;
+			// middle
+			case 2:
+				return 4;
+			// right
+			case 3:
+				return 2;
+		}
+		return 0;
 	}
 </script>
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 	<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
 	<link rel="stylesheet" href="examples/reset.css">
 	<link rel="stylesheet" href="examples/app.css">
+	<link rel="stylesheet" href="examples/icon-classes.css">
 	<style>
 		/**
 		 * ~~ MagnifyTool:
@@ -177,13 +178,12 @@
 			}
 		}, false);
 		toolBtn.addEventListener('mousedown', (evt) => {
-			console.log('mousedown')
 			const mouseButtonMask = evt.buttons
 				? evt.buttons
 				: convertMouseEventWhichToButtons(evt.which)
 			// TODO: Let's make this happen automagically for mask/touch conflicts?
 			setAllToolsPassive();
-			setButtonActive(toolName);
+			setButtonActive(toolName, mouseButtonMask);
 			cTools.setToolActive(toolName, { mouseButtonMask });
 
 			evt.preventDefault();
@@ -239,13 +239,27 @@
 		});
 	}
 
-	const setButtonActive = (toolName) => {
+	const setButtonActive = (toolName, mouseButtonMask) => {
 		Array.from(toolButtons).forEach(toolBtn => {
+			const toolType = toolBtn.getAttribute('data-tool-type')
+			const mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
+			const touchIcon = `touch-1`
+
 			if (toolName === toolBtn.getAttribute('data-tool')) {
-				toolBtn.classList.remove('active');
+				toolBtn.className = "";
 				toolBtn.classList.add('active');
+				toolBtn.classList.add(mouseButtonIcon)
+				toolBtn.classList.add(touchIcon)
 			} else {
-				toolBtn.classList.remove('active');
+				if (toolBtn.classList.contains(mouseButtonIcon)) {
+					toolBtn.classList.remove(mouseButtonIcon);
+				}
+				if (toolBtn.classList.contains(touchIcon)) {
+					toolBtn.classList.remove(touchIcon);
+				}
+				if (toolBtn.classList.length === 1 && toolBtn.classList[0] === 'active') {
+					toolBtn.classList.remove('active');
+				}
 			}
 		});
 	}

--- a/index.html
+++ b/index.html
@@ -60,12 +60,12 @@
 				<li><a href="#" data-tool="zoom">Zoom</a></li>
 			</ul>
 			<ul class="tool-category" data-tool-category="multitouch-pinch">
-				<li><a href="#" data-tool="panMultiTouch">PanMultiTouch</a></li>
-				<li><a href="#" data-tool="zoomTouchPinch">ZoomTouchPinch</a></li>
+				<li><a href="#" data-tool="panMultiTouch" data-tool-type="multitouch">PanMultiTouch</a></li>
+				<li><a href="#" data-tool="zoomTouchPinch" data-tool-type="pinch">ZoomTouchPinch</a></li>
 			</ul>
 			<ul class="tool-category" data-tool-category="mousewheel">
-				<li><a href="#" data-tool="stackScrollMouseWheel">StackScrollMouseWheel</a></li>
-				<li><a href="#" data-tool="zoomMouseWheel">ZoomMouseWheel</a></li>
+				<li><a href="#" data-tool="stackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a></li>
+				<li><a href="#" data-tool="zoomMouseWheel" data-tool-type="wheel">ZoomMouseWheel</a></li>
 			</ul>
 			<ul class="tool-category" data-tool-category="overlay">
 				<li>
@@ -74,7 +74,7 @@
 						<label class="label-on"> ON</label>
 						<label class="label-off"> OFF</label>
 					</label>
-					<input id="scaleOverlayCheckbox" class="hide" data-tool="scaleOverlay" type="checkbox" />
+					<input id="scaleOverlayCheckbox" class="hide" data-tool="scaleOverlay" data-tool-type="none" type="checkbox" />
 				</li>
 			</ul>
 
@@ -183,7 +183,8 @@
 				: convertMouseEventWhichToButtons(evt.which)
 			// TODO: Let's make this happen automagically for mask/touch conflicts?
 			setAllToolsPassive();
-			setButtonActive(toolName, mouseButtonMask);
+			const toolType = evt.target.getAttribute('data-tool-type')
+			setButtonActive(toolName, mouseButtonMask, toolType);
 			cTools.setToolActive(toolName, { mouseButtonMask });
 
 			evt.preventDefault();
@@ -239,22 +240,42 @@
 		});
 	}
 
-	const setButtonActive = (toolName, mouseButtonMask) => {
+	const setButtonActive = (toolName, mouseButtonMask, toolType) => {
 		Array.from(toolButtons).forEach(toolBtn => {
-			const toolType = toolBtn.getAttribute('data-tool-type')
-			const mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
-			const touchIcon = `touch-1`
+			// Classes we need to set & remove
+			let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
+			let touchIcon = `touch-1`
 
+			// Update classes depending on the toolType we clicked
+			if (toolType === 'none') {
+				return;
+			} else if (toolType === 'multitouch') {
+				mouseButtonIcon = null;
+				touchIcon = 'touch-2';
+			} else if (toolType === 'pinch') {
+				mouseButtonIcon = null;
+				touchIcon = 'touch-pinch';
+			} else if (toolType === 'wheel') {
+				mouseButtonIcon = 'mousebutton-wheel';
+				touchIcon = null;
+			}
+
+			// Update our target button
 			if (toolName === toolBtn.getAttribute('data-tool')) {
 				toolBtn.className = "";
 				toolBtn.classList.add('active');
-				toolBtn.classList.add(mouseButtonIcon)
-				toolBtn.classList.add(touchIcon)
+				if (mouseButtonIcon) {
+					toolBtn.classList.add(mouseButtonIcon)
+				}
+				if (touchIcon) {
+					toolBtn.classList.add(touchIcon)
+				}
+				// Remove relevant classes from other buttons
 			} else {
-				if (toolBtn.classList.contains(mouseButtonIcon)) {
+				if (mouseButtonIcon && toolBtn.classList.contains(mouseButtonIcon)) {
 					toolBtn.classList.remove(mouseButtonIcon);
 				}
-				if (toolBtn.classList.contains(touchIcon)) {
+				if (touchIcon && toolBtn.classList.contains(touchIcon)) {
 					toolBtn.classList.remove(touchIcon);
 				}
 				if (toolBtn.classList.length === 1 && toolBtn.classList[0] === 'active') {

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 				<li><a href="#" data-tool="rectangleRoi">RectangleRoi</a></li>
 			</ul>
 			<ul class="tool-category" data-tool-category="drag">
-				<li><a href="#" data-tool="crosshair">Crosshair</a></li>
+				<li><a href="#" data-tool="crosshairs">Crosshairs</a></li>
 				<li><a href="#" data-tool="magnify">Magnify</a></li>
 				<li><a href="#" data-tool="pan">Pan</a></li>
 				<li><a href="#" data-tool="rotate">Rotate</a></li>

--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -2,7 +2,6 @@
 import { getters, state } from './../../store/index.js';
 import { getToolState } from './../../stateManagement/toolState.js';
 // Util
-import isMouseButtonEnabled from './../../util/isMouseButtonEnabled.js';
 import {
   getToolsWithMovableHandles,
   findHandleDataNearImagePoint,
@@ -36,8 +35,8 @@ export default function (evt) {
 
   // High level filtering
   tools = getInteractiveToolsForElement(element, getters.mouseTools());
-  tools = tools.filter((tool) =>
-    isMouseButtonEnabled(eventData.which, tool.options.mouseButtonMask)
+  tools = tools.filter(
+    (tool) => eventData.buttons === tool.options.mouseButtonMask
   );
 
   // ACTIVE TOOL W/ PRE CALLBACK?

--- a/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
@@ -1,6 +1,5 @@
 import addNewMeasurement from './addNewMeasurement.js';
 import { getters, state } from './../../store/index.js';
-import isMouseButtonEnabled from './../../util/isMouseButtonEnabled.js';
 import getActiveToolsForElement from './../../store/getActiveToolsForElement.js';
 import baseAnnotationTool from '../../base/baseAnnotationTool.js';
 
@@ -18,8 +17,8 @@ export default function (evt) {
   let tools = getActiveToolsForElement(element, getters.mouseTools());
 
   // Filter out tools that do not match mouseButtonMask
-  tools = tools.filter((tool) =>
-    isMouseButtonEnabled(eventData.which, tool.options.mouseButtonMask)
+  tools = tools.filter(
+    (tool) => eventData.buttons === tool.options.mouseButtonMask
   );
 
   if (tools.length === 0) {

--- a/src/eventDispatchers/mouseEventHandlers/mouseDrag.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDrag.js
@@ -1,5 +1,4 @@
 import { getters, state } from './../../store/index.js';
-import isMouseButtonEnabled from './../../util/isMouseButtonEnabled.js';
 import getActiveToolsForElement from './../../store/getActiveToolsForElement.js';
 
 // Tools like wwwc. Non-annotation tools w/ specific
@@ -18,8 +17,8 @@ export default function (evt) {
 
   // Filter out disabled, enabled, and passive
   tools = getActiveToolsForElement(element, getters.mouseTools());
-  tools = tools.filter((tool) =>
-    isMouseButtonEnabled(eventData.which, tool.options.mouseButtonMask)
+  tools = tools.filter(
+    (tool) => eventData.buttons === tool.options.mouseButtonMask
   );
   tools = tools.filter((tool) => typeof tool.mouseDragCallback === 'function');
 

--- a/src/eventDispatchers/touchEventHandlers/touchStartActive.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStartActive.js
@@ -14,7 +14,7 @@ export default function (evt) {
   const activeTool = tools[0];
 
   // Note: custom `addNewMeasurement` will need to prevent event bubbling
-  if (activeTool.addNewMeasurement) {
+  if (activeTool && activeTool.addNewMeasurement) {
     activeTool.addNewMeasurement(evt, 'touch');
   } else if (activeTool instanceof baseAnnotationTool) {
     addNewMeasurement(evt, activeTool);

--- a/src/eventListeners/mouseEventListeners.js
+++ b/src/eventListeners/mouseEventListeners.js
@@ -7,18 +7,23 @@ let isClickEvent = true;
 let preventClickTimeout;
 const clickDelay = 200;
 
-function getEventWhich (event) {
-  if (typeof event.buttons !== 'number') {
-    return event.which;
+function getEventButtons (event) {
+  if (typeof event.buttons === 'number') {
+    return event.buttons;
   }
 
-  if (event.buttons === 0) {
+  switch (event.which) {
+  // No button
+  case 0:
     return 0;
-  } else if (event.buttons % 2 === 1) {
+    // Left
+  case 1:
     return 1;
-  } else if (event.buttons % 4 === 2) {
-    return 3;
-  } else if (event.buttons % 8 === 4) {
+    // Middle
+  case 2:
+    return 4;
+    // Right
+  case 3:
     return 2;
   }
 
@@ -48,20 +53,17 @@ function mouseDoubleClick (e) {
     }
   };
 
-  startPoints.canvas = external.cornerstone.pixelToCanvas(element, startPoints.image);
+  startPoints.canvas = external.cornerstone.pixelToCanvas(
+    element,
+    startPoints.image
+  );
 
   const lastPoints = copyPoints(startPoints);
 
-  /* Note: It seems we can't trust MouseEvent.buttons for dblclick events?
-
-    For some reason they are always firing with e.buttons = 0
-    so we have to use e.which for now instead.
-
-    Might be related to using preventDefault on the original mousedown or click events?
-  */
+  console.log(`double-click: ${getEventButtons(e)}`);
   const eventData = {
     event: e,
-    which: e.which,
+    buttons: getEventButtons(e),
     viewport: external.cornerstone.getViewport(element),
     image: enabledElement.image,
     element,
@@ -102,12 +104,17 @@ function mouseDown (e) {
     }
   };
 
-  startPoints.canvas = external.cornerstone.pixelToCanvas(element, startPoints.image);
+  startPoints.canvas = external.cornerstone.pixelToCanvas(
+    element,
+    startPoints.image
+  );
 
   let lastPoints = copyPoints(startPoints);
+
+  console.log(`mousedown: ${getEventButtons(e)}`);
   const eventData = {
     event: e,
-    which: getEventWhich(e),
+    buttons: getEventButtons(e),
     viewport: external.cornerstone.getViewport(element),
     image: enabledElement.image,
     element,
@@ -128,8 +135,6 @@ function mouseDown (e) {
     eventData.type = EVENTS.MOUSE_DOWN_ACTIVATE;
     triggerEvent(eventData.element, EVENTS.MOUSE_DOWN_ACTIVATE, eventData);
   }
-
-  const whichMouseButton = getEventWhich(e);
 
   function onMouseMove (e) {
     // Calculate our current points in page and image coordinates
@@ -168,8 +173,9 @@ function mouseDown (e) {
       )
     };
 
+    console.log(`mousemove ${getEventButtons(e)}`);
     const eventData = {
-      which: whichMouseButton,
+      buttons: getEventButtons(e),
       viewport: external.cornerstone.getViewport(element),
       image: enabledElement.image,
       element,
@@ -236,9 +242,10 @@ function mouseDown (e) {
       )
     };
 
+    console.log(`mouseup: ${getEventButtons(e)}`);
     const eventData = {
       event: e,
-      which: whichMouseButton,
+      buttons: getEventButtons(e),
       viewport: external.cornerstone.getViewport(element),
       image: enabledElement.image,
       element,
@@ -282,7 +289,10 @@ function mouseMove (e) {
     }
   };
 
-  startPoints.canvas = external.cornerstone.pixelToCanvas(element, startPoints.image);
+  startPoints.canvas = external.cornerstone.pixelToCanvas(
+    element,
+    startPoints.image
+  );
 
   let lastPoints = copyPoints(startPoints);
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,9 +62,6 @@ export {
 } from './util/pointInsideBoundingBox.js';
 export { default as pointInEllipse } from './util/pointInEllipse.js';
 export { default as makeUnselectable } from './util/makeUnselectable.js';
-export {
-  default as isMouseButtonEnabled
-} from './util/isMouseButtonEnabled.js';
 export { default as getRGBPixels } from './util/getRGBPixels.js';
 export {
   getDefaultSimultaneousRequests,

--- a/src/tools/arrowAnnotateTool.js
+++ b/src/tools/arrowAnnotateTool.js
@@ -11,7 +11,6 @@ import drawHandles from '../manipulators/drawHandles.js';
 import drawArrow from '../util/drawArrow.js';
 import moveNewHandle from '../manipulators/moveNewHandle.js';
 import moveNewHandleTouch from '../manipulators/moveNewHandleTouch.js';
-import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
@@ -202,7 +201,9 @@ export default class extends baseAnnotationTool {
               };
             }
 
-            const transform = external.cornerstone.internal.getTransform(enabledElement);
+            const transform = external.cornerstone.internal.getTransform(
+              enabledElement
+            );
 
             transform.invert();
 
@@ -293,7 +294,7 @@ export default class extends baseAnnotationTool {
   }
 
   doubleClickCallback (evt) {
-    if (!isMouseButtonEnabled(evt.detail.which, this.options.mouseButtonMask)) {
+    if (evt.detail.buttons !== this.options.mouseButtonMask) {
       return;
     }
 

--- a/src/util/isMouseButtonEnabled.js
+++ b/src/util/isMouseButtonEnabled.js
@@ -1,7 +1,0 @@
-/* eslint no-bitwise:0 */
-
-export default function (which, mouseButtonMask) {
-  const mouseButton = 1 << (which - 1);
-
-  return (mouseButtonMask & mouseButton) !== 0;
-}


### PR DESCRIPTION
This addresses:

- [x] [Favoring `MouseEvent.buttons` over `MouseEvent.which`](https://github.com/cornerstonejs/cornerstoneTools/projects/1#card-12187119)
    - CC: @swederik 
    - Which means you can now bind tools, to some extent, to multiple buttons needing to be pressed for their strategies to be applies
    - IE. back/forward mouse buttons on fancier mice
- [x] [Global example updated to support binding to different masks](https://github.com/cornerstonejs/cornerstoneTools/projects/1#card-11479344)

Also touched:

- [x] Crosshairs example fixed
- [ ] Set tools to passive when a new tool is activated with the same mask / touch input/gesture
- [ ] Fix icon size