### PR TITLE
Add fill the region of brush tool

### DIFF
--- a/src/paintingTools/brush.js
+++ b/src/paintingTools/brush.js
@@ -336,9 +336,6 @@ function fill (eventData) {
         if (ny < 0 || ny >= rows || nx < 0 || nx >= columns || isSameColor(nx, ny, brushPixelValue)) {
           continue;
         }
-        if (!isSameColor(nx, ny, 0)) {
-          continue;
-        }
         q.enqueue({
           x: nx,
           y: ny

--- a/src/paintingTools/brush.js
+++ b/src/paintingTools/brush.js
@@ -3,7 +3,7 @@ import { getToolState } from '../stateManagement/toolState.js';
 import brushTool from './brushTool.js';
 import getCircle from './getCircle.js';
 import { drawBrushPixels, drawBrushOnCanvas } from './drawBrush.js';
-import { getEndOfCircle, connectEndsOfBrush, fillColor } from './fill.js';
+import { getEndOfCircle, connectEndsOfBrush, isCircleInPolygon, fillColor } from './fill.js';
 
 // This module is for creating segmentation overlays
 
@@ -136,9 +136,11 @@ function fill (eventData) {
     return;
   }
 
-  // Todo: If not point in polygon, return false
-  connectEndsOfBrush(x, y, columns, rows, thisCircle, pixelData, brushPixelValue);
-  fillColor(x, thisCircle[0] - 1, columns, rows, pixelData, brushPixelValue);
+  if (connectEndsOfBrush(x, y, columns, rows, thisCircle, pixelData, brushPixelValue)) {
+    if (isCircleInPolygon(x, y, columns, rows, thisCircle, pixelData, brushPixelValue)) {
+      fillColor(x, thisCircle[0] - 1, columns, rows, pixelData, brushPixelValue);
+    }
+  }
 
   layer.invalid = true;
 

--- a/src/paintingTools/brush.js
+++ b/src/paintingTools/brush.js
@@ -107,13 +107,197 @@ function onImageRendered (e) {
   }
 }
 
+// This method is for fill region of segmentation overlays
+
+function fill (eventData) {
+  const configuration = brush.getConfiguration();
+  const element = eventData.element;
+  const layer = external.cornerstone.getLayer(element, configuration.brushLayerId);
+  const { rows, columns } = layer.image;
+  let { x, y } = eventData.currentPoints.image;
+  const toolData = getToolState(element, TOOL_STATE_TOOL_TYPE);
+  const pixelData = toolData.data[0].pixelData;
+  const brushPixelValue = configuration.draw;
+  const dx = [0, 1, 0, -1];
+  const dy = [-1, 0, 1, 0];
+
+  if (x < 0 || x > columns ||
+    y < 0 || y > rows) {
+    return;
+  }
+
+  const getPixelIndex = (x, y) => (y * columns) + x;
+  const isSameColor = (x, y) => pixelData[getPixelIndex(x, y)] === brushPixelValue;
+  const draw = (x, y, brushPixelValue) => drawBrushPixels([[x, y]], pixelData, brushPixelValue, columns);
+  const drawRange = (range, color) => {
+    range.forEach((point) => {
+      const spIndex = getPixelIndex(point[0], point[1]);
+
+      pixelData[spIndex] = color;
+    });
+  };
+
+  x = Math.round(x);
+  y = Math.round(y);
+
+  const find = (low, high, condition, base, isY = false) => {
+    for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
+      if (isY) {
+        if (condition(base, t)) {
+          return t;
+        }
+      } else if (condition(t, base)) {
+        return t;
+      }
+    }
+
+    return null;
+  };
+  const thisCircle = [
+    find(y, 0, (x, y) => !isSameColor(x, y - 1), x, true),
+    find(x, columns, (x, y) => !isSameColor(x + 1, y), y, false),
+    find(y, rows, (x, y) => !isSameColor(x, y + 1), x, true),
+    find(x, 0, (x, y) => !isSameColor(x - 1, y), y, false)
+  ];
+  let [minDistance, idx, _base, _low, _high] = [2147483647, -1];
+
+  for (let i = 0; i < thisCircle.length; i += 1) {
+    let _b, _l, _h; 
+    if (i & 1) {
+      _b = y;
+      _l = find(thisCircle[i] + dx[i], i === 1 ? columns : 0, isSameColor, _b, false);
+      if (_l === null) {
+        continue;
+      }
+      _h = find(_l + dx[i], i === 1 ? columns : 0, (x, y) => !isSameColor(x + dx[i], y + dy[i]), _b, false);
+    } else {
+      _b = x;
+      _l = find(thisCircle[i] + dy[i], i === 0 ? 0 : rows, isSameColor, _b, true);
+      if (_l === null) {
+        continue;
+      }
+      _h = find(_l + dy[i], i === 0 ? 0 : rows, (x, y) => !isSameColor(x + dx[i], y + dy[i]), _b, true);
+    }
+    const distance = Math.abs(_l - (i & 1 ? x : y));
+    if (minDistance > distance) {
+      [minDistance, idx, _base, _low, _high] = [distance, i, _b, _l, _h];
+    }
+  }
+
+  const getPointList = (low, high, base, isY = false) => {
+    const ret = [];
+
+    for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
+      ret.push(isY ? [base, t] : [t, base]);
+    }
+
+    return ret;
+  };
+
+  drawRange(getPointList(_low, _high, _base, !(idx & 1)), 0);
+
+  class Queue {
+    constructor () {
+      this.store = {};
+      this.front = 0;
+      this.end = 0;
+    }
+    enqueue (data) {
+      this.store[this.end] = data;
+      this.end++;
+    }
+    dequeue () {
+      if (this.front === this.end) {
+        return null;
+      }
+      const data = this.store[this.front];
+
+      delete this.store[this.front];
+      this.front++;
+
+      return data;
+    }
+    size () {
+      return this.end - this.front;
+    }
+  }
+
+  const bfs = (x, y, columns, rows) => {
+    let [rx, ry, maxDepth] = [x, y, 0];
+    const q = new Queue();
+    const d = [];
+    let processing = 0;
+
+    q.enqueue({
+      x,
+      y
+    });
+    for (let i = 0; i < rows * columns; i += 1) {
+      d.push(0);
+    }
+    d[getPixelIndex(x, y)] = 1;
+    while (q.size() !== 0 && processing <= rows * columns) {
+      processing += 1;
+      const now = q.dequeue();
+      const idx = getPixelIndex(now.x, now.y);
+
+
+      if (maxDepth < d[idx]) {
+        [rx, ry, maxDepth] = [now.x, now.y, d[idx]];
+      }
+      for (let i = 0; i < 4; i += 1) {
+        const ny = now.y + dy[i];
+        const nx = now.x + dx[i];
+        const nidx = getPixelIndex(nx, ny);
+
+        if (ny < 0 || ny >= rows || nx < 0 || nx >= columns || !isSameColor(nx, ny) || d[nidx] !== 0) {
+          continue;
+        }
+        d[nidx] = d[idx] + 1;
+        q.enqueue({
+          x: nx,
+          y: ny
+        });
+      }
+    }
+
+    return [rx, ry, maxDepth];
+  };
+
+  let [lx, ly, hx, hy] = [-1, -1, -1, -1];
+  if (idx & 1) {
+    [lx, ly] = bfs(_low, _base - 1, columns, rows);
+    [hx, hy] = bfs(_low, _base + 1, columns, rows);
+    draw(lx, ly, 4);
+    draw(hx, hy, 4);
+  } else {
+    [lx, ly] = bfs(_base - 1, _low, columns, rows);
+    [hx, hy] = bfs(_base + 1, _low, columns, rows);
+    draw(lx, ly, 4);
+    draw(hx, hy, 4);
+  }
+
+  drawRange(getPointList(_low, _high, _base, !(idx & 1)), brushPixelValue);
+
+  layer.invalid = true;
+
+  external.cornerstone.updateImage(element);
+}
+
+function onMouseDoubleClick (e) {
+  const eventData = e.detail;
+
+  fill(eventData);
+}
+
 const brush = brushTool({
   onMouseMove,
   onMouseDown,
   onMouseUp,
   onDrag,
   toolType,
-  onImageRendered
+  onImageRendered,
+  onMouseDoubleClick
 });
 
 brush.setConfiguration(configuration);

--- a/src/paintingTools/brushTool.js
+++ b/src/paintingTools/brushTool.js
@@ -134,6 +134,10 @@ export default function brushTool (brushToolInterface) {
     return false;
   }
 
+  function mouseDoubleClickCallback (e) {
+    brushToolInterface.onMouseDoubleClick(e);
+  }
+
   function mouseDownActivateCallback (e) {
     const eventData = e.detail;
     const element = eventData.element;
@@ -143,6 +147,7 @@ export default function brushTool (brushToolInterface) {
       element.addEventListener(EVENTS.MOUSE_DRAG, dragCallback);
       element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
       element.addEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
+      element.addEventListener(EVENTS.MOUSE_DOUBLE_CLICK, mouseDoubleClickCallback);
       brushToolInterface.onMouseDown(e);
 
       return false;
@@ -290,6 +295,7 @@ export default function brushTool (brushToolInterface) {
     element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
+    element.removeEventListener(EVENTS.MOUSE_DOUBLE_CLICK, mouseDoubleClickCallback);
     element.removeEventListener(EVENTS.KEY_DOWN, keyDownCallback);
 
     element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);

--- a/src/paintingTools/fill.js
+++ b/src/paintingTools/fill.js
@@ -63,6 +63,9 @@ function findTheClosestDirection (x, y, columns, rows, thisCircle, pixelData, br
       [minDistance, idx, base, low, high] = [distance, i, b, l, h];
     }
   }
+  if (minDistance === Number.MAX_SAFE_INTEGER) {
+    return [null, null, null, null];
+  }
 
   return [idx, base, low, high];
 }
@@ -134,6 +137,9 @@ function connectEndsOfBrush (x, y, columns, rows, thisCircle, pixelData, brushPi
   const [direction, base, low, high] = findTheClosestDirection(x, y, columns, rows, thisCircle, pixelData, brushPixelValue);
   const points = [];
 
+  if (direction === null) {
+    return false;
+  }
   drawRange(getPointListInRange(low, high, base, !(direction % 2)), 0);
   if (direction % 2) {
     const p1 = getTheFarthestPointInSameColor(low, base - 1, columns, rows, pixelData, brushPixelValue);
@@ -174,6 +180,16 @@ function connectEndsOfBrush (x, y, columns, rows, thisCircle, pixelData, brushPi
       }
     }
   }
+
+  return true;
+}
+
+function isCircleInPolygon (x, y, columns, rows, thisCircle, pixelData, brushPixelValue) {
+  const getPixelIndex = (x, y) => (y * columns) + x;
+  const left = find(thisCircle[3] - 1, 0, (x, y) => isSameColor(getPixelIndex(x, y), pixelData, brushPixelValue), y, false);
+  const right = find(thisCircle[1] + 1, columns, (x, y) => isSameColor(getPixelIndex(x, y), pixelData, brushPixelValue), y, false);
+
+  return left && right;
 }
 
 function fillColor (x, y, columns, rows, pixelData, brushPixelValue) {
@@ -209,4 +225,4 @@ function fillColor (x, y, columns, rows, pixelData, brushPixelValue) {
   }
 }
 
-export { getEndOfCircle, connectEndsOfBrush, fillColor };
+export { getEndOfCircle, connectEndsOfBrush, isCircleInPolygon, fillColor };

--- a/src/paintingTools/fill.js
+++ b/src/paintingTools/fill.js
@@ -5,7 +5,7 @@ function find (low, high, condition, base, isY = false) {
   for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
     if (isY && condition(base, t)) {
       return t;
-    } else if (condition(t, base)) {
+    } else if (!isY && condition(t, base)) {
       return t;
     }
   }

--- a/src/paintingTools/fill.js
+++ b/src/paintingTools/fill.js
@@ -37,8 +37,8 @@ function findTheClosestDirection (x, y, columns, rows, thisCircle, pixelData, br
   let base, low, high;
   const getPixelIndex = (x, y) => (y * columns) + x;
 
-  for (let i = 0; i < thisCircle.length; i += 1) {
-    let b, l, h;
+  for (let i = 0; i < thisCircle.length; i++) {
+    let b, l, h; // Base, low, high;
 
     if (i % 2) {
       b = y;

--- a/src/paintingTools/fill.js
+++ b/src/paintingTools/fill.js
@@ -1,0 +1,212 @@
+import { drawBrushPixels } from './drawBrush.js';
+import { Queue } from './queue.js';
+
+function find (low, high, condition, base, isY = false) {
+  for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
+    if (isY) {
+      if (condition(base, t)) {
+        return t;
+      }
+    } else if (condition(t, base)) {
+      return t;
+    }
+  }
+
+  return null;
+}
+
+function isSameColor (pixelIndex, pixelData, color) {
+  return pixelData[pixelIndex] === color;
+}
+
+function getEndOfCircle (x, y, columns, rows, pixelData, brushPixelValue) {
+  const getPixelIndex = (x, y) => (y * columns) + x;
+
+  return [
+    find(y, 0, (x, y) => !isSameColor(getPixelIndex(x, y - 1), pixelData, brushPixelValue), x, true),
+    find(x, columns, (x, y) => !isSameColor(getPixelIndex(x + 1, y), pixelData, brushPixelValue), y, false),
+    find(y, rows, (x, y) => !isSameColor(getPixelIndex(x, y + 1), pixelData, brushPixelValue), x, true),
+    find(x, 0, (x, y) => !isSameColor(getPixelIndex(x - 1, y), pixelData, brushPixelValue), y, false)
+  ];
+}
+
+function findTheClosestDirection (x, y, columns, rows, thisCircle, pixelData, brushPixelValue) {
+  // Find a direction the closest point where same color from (x, y)
+  const dx = [0, 1, 0, -1];
+  const dy = [-1, 0, 1, 0];
+  let minDistance = Number.MAX_SAFE_INTEGER;
+  let idx = -1;
+  let base, low, high;
+  const getPixelIndex = (x, y) => (y * columns) + x;
+
+  for (let i = 0; i < thisCircle.length; i += 1) {
+    let b, l, h;
+
+    if (i % 2) {
+      b = y;
+      l = find(thisCircle[i] + dx[i], i === 1 ? columns : 0, (x, y) => isSameColor(getPixelIndex(x, y), pixelData, brushPixelValue), b, false);
+      if (l === null) {
+        continue;
+      }
+      h = find(l + dx[i], i === 1 ? columns : 0, (x, y) => !isSameColor(getPixelIndex(x + dx[i], y + dy[i]), pixelData, brushPixelValue), b, false);
+    } else {
+      b = x;
+      l = find(thisCircle[i] + dy[i], i === 0 ? 0 : rows, (x, y) => isSameColor(getPixelIndex(x, y), pixelData, brushPixelValue), b, true);
+      if (l === null) {
+        continue;
+      }
+      h = find(l + dy[i], i === 0 ? 0 : rows, (x, y) => !isSameColor(getPixelIndex(x + dx[i], y + dy[i]), pixelData, brushPixelValue), b, true);
+    }
+    const distance = Math.abs(l - (i % 2 ? x : y));
+
+    if (minDistance > distance) {
+      [minDistance, idx, base, low, high] = [distance, i, b, l, h];
+    }
+  }
+
+  return [idx, base, low, high];
+}
+
+function getTheFarthestPointInSameColor (x, y, columns, rows, pixelData, color) {
+  let [rx, ry, maxDepth] = [x, y, 0];
+  const q = new Queue();
+  const d = [];
+  const dx = [0, 1, 0, -1];
+  const dy = [-1, 0, 1, 0];
+  let processing = 0;
+
+  const getPixelIndex = (x, y) => (y * columns) + x;
+
+  q.enqueue({
+    x,
+    y
+  });
+  for (let i = 0; i < rows * columns; i += 1) {
+    d.push(0);
+  }
+  d[getPixelIndex(x, y)] = 1;
+  while (q.size() !== 0 && processing <= rows * columns) {
+    processing += 1;
+    const now = q.dequeue();
+    const idx = getPixelIndex(now.x, now.y);
+
+    if (maxDepth < d[idx]) {
+      [rx, ry, maxDepth] = [now.x, now.y, d[idx]];
+    }
+    for (let i = 0; i < 4; i += 1) {
+      const ny = now.y + dy[i];
+      const nx = now.x + dx[i];
+      const nidx = getPixelIndex(nx, ny);
+
+      if (ny < 0 || ny >= rows || nx < 0 || nx >= columns) {
+        continue;
+      }
+      if (!isSameColor(nidx, pixelData, color) || d[nidx] !== 0) {
+        continue;
+      }
+      d[nidx] = d[idx] + 1;
+      q.enqueue({
+        x: nx,
+        y: ny
+      });
+    }
+  }
+
+  return {
+    x: rx,
+    y: ry
+  };
+}
+
+function getPointListInRange (low, high, base, isY = false) {
+  const ret = [];
+
+  for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
+    ret.push(isY ? [base, t] : [t, base]);
+  }
+
+  return ret;
+}
+
+function connectEndsOfBrush (x, y, columns, rows, thisCircle, pixelData, brushPixelValue) {
+  const draw = (x, y, brushPixelValue) => drawBrushPixels([[x, y]], pixelData, brushPixelValue, columns);
+  const drawRange = (range, color) => drawBrushPixels(range, pixelData, color, columns);
+  const [direction, base, low, high] = findTheClosestDirection(x, y, columns, rows, thisCircle, pixelData, brushPixelValue);
+  const points = [];
+
+  drawRange(getPointListInRange(low, high, base, !(direction % 2)), 0);
+  if (direction % 2) {
+    const p1 = getTheFarthestPointInSameColor(low, base - 1, columns, rows, pixelData, brushPixelValue);
+    const p2 = getTheFarthestPointInSameColor(low, base + 1, columns, rows, pixelData, brushPixelValue);
+
+    points.push(p1);
+    points.push(p2);
+  } else {
+    const p1 = getTheFarthestPointInSameColor(base - 1, low, columns, rows, pixelData, brushPixelValue);
+    const p2 = getTheFarthestPointInSameColor(base + 1, low, columns, rows, pixelData, brushPixelValue);
+
+    points.push(p1);
+    points.push(p2);
+  }
+  drawRange(getPointListInRange(low, high, base, !(direction % 2)), brushPixelValue);
+
+  points.sort((x, y) => x.x - y.x);
+  if (points[0].x === points[1].x) {
+    // Gradient is infinity
+    drawRange(getPointListInRange(points[0].y, points[1].y, points[0].x, true), brushPixelValue);
+  } else {
+    const gradient = (points[1].y - points[0].y) / (points[1].x - points[0].x);
+    const bias = points[0].y - gradient * points[0].x;
+    const lineWidth = 1;
+
+    if (Math.abs(gradient) >= 1) {
+      points.sort((x, y) => x.y - y.y);
+      for (let ty = points[0].y; ty <= points[1].y; ty += 1) {
+        for (let r = -(lineWidth - 1); r <= (lineWidth + 1); r += 1) {
+          draw(Math.round((ty - bias) / gradient) + r, ty, brushPixelValue);
+        }
+      }
+    } else {
+      for (let tx = points[0].x; tx <= points[1].x; tx += 1) {
+        for (let r = -(lineWidth - 1); r <= (lineWidth + 1); r += 1) {
+          draw(tx, Math.round(gradient * tx + bias) + r, brushPixelValue);
+        }
+      }
+    }
+  }
+}
+
+function fillColor (x, y, columns, rows, pixelData, brushPixelValue) {
+  const q = new Queue();
+  const dx = [0, 1, 0, -1];
+  const dy = [-1, 0, 1, 0];
+  let processing = 0;
+  const getPixelIndex = (x, y) => (y * columns) + x;
+  const draw = (x, y, brushPixelValue) => drawBrushPixels([[x, y]], pixelData, brushPixelValue, columns);
+
+  q.enqueue({
+    x,
+    y
+  });
+  draw(x, y, brushPixelValue);
+  while (q.size() !== 0 && processing <= rows * columns) {
+    processing += 1;
+    const now = q.dequeue();
+
+    for (let i = 0; i < 4; i += 1) {
+      const ny = now.y + dy[i];
+      const nx = now.x + dx[i];
+
+      if (ny < 0 || ny >= rows || nx < 0 || nx >= columns || isSameColor(getPixelIndex(nx, ny), pixelData, brushPixelValue)) {
+        continue;
+      }
+      q.enqueue({
+        x: nx,
+        y: ny
+      });
+      draw(nx, ny, brushPixelValue);
+    }
+  }
+}
+
+export { getEndOfCircle, connectEndsOfBrush, fillColor };

--- a/src/paintingTools/fill.js
+++ b/src/paintingTools/fill.js
@@ -3,10 +3,8 @@ import { Queue } from './queue.js';
 
 function find (low, high, condition, base, isY = false) {
   for (let t = low; low < high ? (t <= high) : (t >= high); t += (low < high ? 1 : -1)) {
-    if (isY) {
-      if (condition(base, t)) {
-        return t;
-      }
+    if (isY && condition(base, t)) {
+      return t;
     } else if (condition(t, base)) {
       return t;
     }

--- a/src/paintingTools/queue.js
+++ b/src/paintingTools/queue.js
@@ -1,0 +1,25 @@
+export class Queue {
+  constructor () {
+    this.store = {};
+    this.front = 0;
+    this.end = 0;
+  }
+  enqueue (data) {
+    this.store[this.end] = data;
+    this.end++;
+  }
+  dequeue () {
+    if (this.front === this.end) {
+      return null;
+    }
+    const data = this.store[this.front];
+
+    delete this.store[this.front];
+    this.front++;
+
+    return data;
+  }
+  size () {
+    return this.end - this.front;
+  }
+}


### PR DESCRIPTION
I've implemented fill inside of segmentation with brush tools.

In the case of the closed space first, double-clicking will color the region.
If it is not a closed space, it will be colored by connecting both ends.
Please refer to attached images.

<img width="256" alt="2018-08-22 2 30 04" src="https://user-images.githubusercontent.com/3329885/44444702-16b2a600-a619-11e8-9513-c88739ae46c2.png">
<img width="256" alt="2018-08-22 2 30 28" src="https://user-images.githubusercontent.com/3329885/44444709-28944900-a619-11e8-8e7c-1f3f40af40cb.png">
<img width="256" alt="2018-08-22 2 30 51" src="https://user-images.githubusercontent.com/3329885/44444716-3053ed80-a619-11e8-8e4d-3951f816e35a.png">
<img width="256" alt="2018-08-22 2 31 00" src="https://user-images.githubusercontent.com/3329885/44444719-32b64780-a619-11e8-9980-4025142cec83.png">
