### PR TITLE
vNext brush rendering and image caching changes - WIP

### DIFF
--- a/src/base/baseBrushTool.js
+++ b/src/base/baseBrushTool.js
@@ -3,7 +3,6 @@ import EVENTS from './../events.js';
 import baseTool from './../base/baseTool.js';
 // Utils
 import isToolActive from '../tools/shared/isToolActive.js';
-import { getNewContext } from '../util/drawing.js';
 import store from '../store/index.js';
 
 const brushState = store.modules.brush;
@@ -60,17 +59,6 @@ export default class extends baseTool {
   //===================================================================
   // Virtual Methods - Have default behavior but may be overriden.
   //===================================================================
-
-  /**
-   * Callback for when the tool is activated.
-   *
-   * @virtual
-   */
-  //activeCallback () {
-  //  const configuration = this.configuration;
-
-
-  //}
 
   /**
   * Event handler for MOUSE_DRAG event.
@@ -213,34 +201,6 @@ export default class extends baseTool {
   //===================================================================
   // Implementation interface
   //===================================================================
-
-  /**
-   * Draws the ImageBitmap the canvas.
-   *
-   * @protected
-   * @param  {Object} evt description
-   */
-  _drawImageBitmap (evt) {
-    const configuration = this.configuration;
-    const eventData = evt.detail;
-    const context = getNewContext(eventData.canvasContext.canvas);
-
-    const canvasTopLeft = external.cornerstone.pixelToCanvas(eventData.element, {
-      x: 0,
-      y: 0
-    });
-    const canvasBottomRight = external.cornerstone.pixelToCanvas(eventData.element, {
-      x: eventData.image.width,
-      y: eventData.image.height
-    });
-    const canvasWidth = canvasBottomRight.x - canvasTopLeft.x;
-    const canvasHeight = canvasBottomRight.y - canvasTopLeft.y;
-
-    context.imageSmoothingEnabled = false;
-    context.globalAlpha = brushState.getters.alpha();
-    context.drawImage(this._imageBitmap, canvasTopLeft.x, canvasTopLeft.y, canvasWidth, canvasHeight);
-    context.globalAlpha = 1.0;
-  }
 
   /**
    *  Changes the draw color (segmentation) of the tool.

--- a/src/base/baseBrushTool.js
+++ b/src/base/baseBrushTool.js
@@ -147,7 +147,9 @@ export default class extends baseTool {
       drawId = 1;
     }
 
-    this._changeDrawColor(drawId);
+    brushState.mutations.SET_DRAW_COLOR(drawId);
+
+    //this._changeDrawColor(drawId);
   }
 
   /**
@@ -165,7 +167,9 @@ export default class extends baseTool {
       drawId = numberOfColors - 1;
     }
 
-    this._changeDrawColor(drawId);
+    brushState.mutations.SET_DRAW_COLOR(drawId);
+
+    //this._changeDrawColor(drawId);
   }
 
   /**
@@ -203,20 +207,20 @@ export default class extends baseTool {
   //===================================================================
 
   /**
-   *  Changes the draw color (segmentation) of the tool.
+   * Get the draw color (segmentation) of the tool.
    *
    * @protected
    * @param  {Number} drawId The id of the color (segmentation) to switch to.
    */
-  _changeDrawColor (drawId) {
-    const configuration = this.configuration;
+  _getBrushColor (drawId) {
     const colormap = external.cornerstone.colors.getColormap(brushState.getters.colorMapId());
-
-    brushState.mutations.SET_DRAW_COLOR(drawId);
     const colorArray = colormap.getColor(drawId);
 
-    configuration.hoverColor = `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${colorArray[[2]]}, 0.8 )`;
-    configuration.dragColor = `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${colorArray[[2]]}, 1.0 )`;
+    if (this._drawing) {
+      return `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${colorArray[[2]]}, 1.0 )`;
+    }
+
+    return `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${colorArray[[2]]}, 0.8 )`;
   }
 
   /**
@@ -231,7 +235,7 @@ export default class extends baseTool {
     const element = eventData.element;
 
     this._drawing = false;
-    this.configuration.mouseUpRender = true;
+    this._mouseUpRender = true;
 
     this._stopListeningForMouseUp(element);
   }

--- a/src/eventDispatchers/imageRenderedEventDispatcher.js
+++ b/src/eventDispatchers/imageRenderedEventDispatcher.js
@@ -1,10 +1,13 @@
 import EVENTS from './../events.js';
 import { state } from './../store/index.js';
+import BaseBrushTool from '../base/baseBrushTool.js';
+import onImageRenderedBrushEventHandler from '../eventListeners/onImageRenderedBrushEventHandler.js';
 
 const onImageRendered = function (evt) {
   const eventData = evt.detail;
   const element = eventData.element;
 
+  // Render Annotation Tools
   const toolsToRender = state.tools.filter(
     (tool) =>
       tool.element === element &&
@@ -12,6 +15,14 @@ const onImageRendered = function (evt) {
         tool.mode === 'passive' ||
         tool.mode === 'enabled')
   );
+
+  const brushTools = toolsToRender.filter(
+    (tool) => tool instanceof BaseBrushTool
+  );
+
+  if (brushTools.length > 0) {
+    onImageRenderedBrushEventHandler(evt);
+  }
 
   toolsToRender.forEach((tool) => {
     if (tool.renderToolData) {

--- a/src/eventDispatchers/newImageEventDispatcher.js
+++ b/src/eventDispatchers/newImageEventDispatcher.js
@@ -1,7 +1,8 @@
 import EVENTS from './../events.js';
 // TODO: Is this just customCallbackHandler, but for TOUCH and MOUSE?
 import { state } from './../store/index.js';
-import getActiveToolsForElement from './../store/getActiveToolsForElement.js';
+import BaseBrushTool from '../base/baseBrushTool.js';
+import onNewImageBrushEventHandler from '../eventListeners/onNewImageBrushEventHandler.js';
 
 const onNewImage = function (evt) {
   if (state.isToolLocked) {
@@ -27,6 +28,15 @@ const onNewImage = function (evt) {
       tool.newImageCallback(evt);
     }
   });
+
+  // Check if any brush tools are present.
+  const brushTools = tools.filter(
+    (tool) => tool instanceof BaseBrushTool
+  );
+
+  if (brushTools.length > 0) {
+    onNewImageBrushEventHandler(evt);
+  }
 };
 
 const enable = function (element) {

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -32,10 +32,6 @@ export default function (evt) {
     _drawImageBitmap(evt, imageBitmapCache);
   }
 
-  //if (!toolData.data[0].invalidated) {
-  //  return;
-  //}
-
   const colormapId = brushState.getters.colorMapId();
   const colormap = external.cornerstone.colors.getColormap(colormapId);
   const colorLut = colormap.createLookupTable();

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -1,0 +1,86 @@
+import store from '../store/index.js';
+import { getToolState, addToolState } from '../stateManagement/toolState.js';
+import external from '../externalModules.js';
+import { getNewContext } from '../util/drawing.js';
+
+const brushState = store.modules.brush;
+
+/**
+ * Used to redraw the brush label map data per render.
+ *
+ * @param {Object} evt - The event.
+ */
+export default function (evt) {
+  const eventData = evt.detail;
+  const element = eventData.element;
+  let toolData = getToolState(element, 'brush');
+
+  console.log(element);
+
+  let pixelData;
+
+  if (toolData) {
+    pixelData = toolData.data[0].pixelData;
+  } else {
+    pixelData = new Uint8ClampedArray(eventData.image.width * eventData.image.height);
+    addToolState(element, 'brush', { pixelData });
+    toolData = getToolState(element, 'brush');
+  }
+
+  const imageBitmapCache = brushState.getters.imageBitmapCache();
+
+  // Draw previous image, unless this is a new image, then don't!
+  if (imageBitmapCache) {
+    _drawImageBitmap(evt, imageBitmapCache);
+  }
+
+  if (!toolData.data[0].invalidated) {
+    return;
+  }
+
+  const colormapId = brushState.getters.colorMapId();
+  const colormap = external.cornerstone.colors.getColormap(colormapId);
+  const colorLut = colormap.createLookupTable();
+
+  const imageData = new ImageData(eventData.image.width, eventData.image.height);
+  const image = {
+    stats: {},
+    minPixelValue: 0,
+    getPixelData: () => pixelData
+  };
+
+  external.cornerstone.storedPixelDataToCanvasImageDataColorLUT(image, colorLut.Table, imageData.data);
+
+  window.createImageBitmap(imageData).then((newImageBitmap) => {
+    brushState.mutations.SET_IMAGE_BITMAP_CACHE(newImageBitmap);
+    toolData.data[0].invalidated = false;
+
+    external.cornerstone.updateImage(eventData.element);
+  });
+}
+
+/**
+ * Draws the ImageBitmap the canvas.
+ *
+ * @param  {Object} evt description
+ */
+function _drawImageBitmap (evt, imageBitmapCache) {
+  const eventData = evt.detail;
+  const context = getNewContext(eventData.canvasContext.canvas);
+
+  const canvasTopLeft = external.cornerstone.pixelToCanvas(eventData.element, {
+    x: 0,
+    y: 0
+  });
+  const canvasBottomRight = external.cornerstone.pixelToCanvas(eventData.element, {
+    x: eventData.image.width,
+    y: eventData.image.height
+  });
+  const canvasWidth = canvasBottomRight.x - canvasTopLeft.x;
+  const canvasHeight = canvasBottomRight.y - canvasTopLeft.y;
+
+  context.imageSmoothingEnabled = false;
+  context.globalAlpha = brushState.getters.alpha();
+  context.drawImage(imageBitmapCache, canvasTopLeft.x, canvasTopLeft.y, canvasWidth, canvasHeight);
+  context.globalAlpha = 1.0;
+}

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -14,9 +14,6 @@ export default function (evt) {
   const eventData = evt.detail;
   const element = eventData.element;
   let toolData = getToolState(element, 'brush');
-
-  console.log(element);
-
   let pixelData;
 
   if (toolData) {
@@ -27,11 +24,11 @@ export default function (evt) {
     toolData = getToolState(element, 'brush');
   }
 
-  const imageBitmapCache = brushState.getters.imageBitmapCache();
+  //const imageBitmapCache = brushState.getters.imageBitmapCache();
 
   // Draw previous image, unless this is a new image, then don't!
-  if (imageBitmapCache) {
-    _drawImageBitmap(evt, imageBitmapCache);
+  if (toolData.imageBitmapCache) {
+    _drawImageBitmap(evt, toolData.imageBitmapCache);
   }
 
   if (!toolData.data[0].invalidated) {
@@ -52,7 +49,8 @@ export default function (evt) {
   external.cornerstone.storedPixelDataToCanvasImageDataColorLUT(image, colorLut.Table, imageData.data);
 
   window.createImageBitmap(imageData).then((newImageBitmap) => {
-    brushState.mutations.SET_IMAGE_BITMAP_CACHE(newImageBitmap);
+    toolData.imageBitmapCache = newImageBitmap;
+    //brushState.mutations.SET_IMAGE_BITMAP_CACHE(newImageBitmap);
     toolData.data[0].invalidated = false;
 
     external.cornerstone.updateImage(eventData.element);

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -24,16 +24,17 @@ export default function (evt) {
     toolData = getToolState(element, 'brush');
   }
 
-  //const imageBitmapCache = brushState.getters.imageBitmapCache();
+  const enabledElement = external.cornerstone.getEnabledElement(element);
+  const imageBitmapCache = brushState.getters.imageBitmapCacheForElement(enabledElement.toolDataUID);
 
   // Draw previous image, unless this is a new image, then don't!
-  if (toolData.imageBitmapCache) {
-    _drawImageBitmap(evt, toolData.imageBitmapCache);
+  if (imageBitmapCache) {
+    _drawImageBitmap(evt, imageBitmapCache);
   }
 
-  if (!toolData.data[0].invalidated) {
-    return;
-  }
+  //if (!toolData.data[0].invalidated) {
+  //  return;
+  //}
 
   const colormapId = brushState.getters.colorMapId();
   const colormap = external.cornerstone.colors.getColormap(colormapId);
@@ -49,8 +50,7 @@ export default function (evt) {
   external.cornerstone.storedPixelDataToCanvasImageDataColorLUT(image, colorLut.Table, imageData.data);
 
   window.createImageBitmap(imageData).then((newImageBitmap) => {
-    toolData.imageBitmapCache = newImageBitmap;
-    //brushState.mutations.SET_IMAGE_BITMAP_CACHE(newImageBitmap);
+    brushState.mutations.SET_ELEMENT_IMAGE_BITMAP_CACHE(enabledElement.toolDataUID, newImageBitmap);
     toolData.data[0].invalidated = false;
 
     external.cornerstone.updateImage(eventData.element);

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -1,6 +1,7 @@
 import store from '../store/index.js';
 import { getToolState, addToolState } from '../stateManagement/toolState.js';
 import external from '../externalModules.js';
+import getToolForElement from '../store/getToolForElement.js';
 
 const brushState = store.modules.brush;
 
@@ -14,6 +15,7 @@ export default function (evt) {
   const eventData = evt.detail;
   const element = eventData.element;
   let toolData = getToolState(element, 'brush');
+  const brushTool = getToolForElement(element, '')
 
   if (!toolData) {
     const pixelData = new Uint8ClampedArray(eventData.image.width * eventData.image.height);
@@ -22,10 +24,11 @@ export default function (evt) {
     toolData = getToolState(element, 'brush');
   }
 
-  // Invalidate the data and clear the cache
+    const enabledElement = external.cornerstone.getEnabledElement(element);
+
+  // Invalidate the data and clear the element's cache
   toolData.data[0].invalidated = true;
-  toolData.imageBitmapCache = null;
-  //brushState.mutations.SET_IMAGE_BITMAP_CACHE(null);
+  brushState.mutations.SET_ELEMENT_IMAGE_BITMAP_CACHE(enabledElement.toolDataUID, null);
 
   external.cornerstone.updateImage(eventData.element);
 }

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -1,0 +1,30 @@
+import store from '../store/index.js';
+import { getToolState, addToolState } from '../stateManagement/toolState.js';
+import external from '../externalModules.js';
+
+const brushState = store.modules.brush;
+
+/**
+* Clears the brush imageBitmapCache,
+* invaldates the data and calls for a re-render.
+* @event
+* @param {Object} evt - The event.
+*/
+export default function (evt) {
+  const eventData = evt.detail;
+  const element = eventData.element;
+  let toolData = getToolState(element, 'brush');
+
+  if (!toolData) {
+    const pixelData = new Uint8ClampedArray(eventData.image.width * eventData.image.height);
+
+    addToolState(element, 'brush', { pixelData });
+    toolData = getToolState(element, 'brush');
+  }
+
+  // Invalidate the data and clear the cache
+  toolData.data[0].invalidated = true;
+  brushState.mutations.SET_IMAGE_BITMAP_CACHE(null);
+
+  external.cornerstone.updateImage(eventData.element);
+}

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -26,8 +26,7 @@ export default function (evt) {
 
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
-  // Invalidate the data and clear the element's cache
-  toolData.data[0].invalidated = true;
+  // Clear the element's cache
   brushState.mutations.SET_ELEMENT_IMAGE_BITMAP_CACHE(enabledElement.toolDataUID, null);
 
   external.cornerstone.updateImage(eventData.element);

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -24,7 +24,8 @@ export default function (evt) {
 
   // Invalidate the data and clear the cache
   toolData.data[0].invalidated = true;
-  brushState.mutations.SET_IMAGE_BITMAP_CACHE(null);
+  toolData.imageBitmapCache = null;
+  //brushState.mutations.SET_IMAGE_BITMAP_CACHE(null);
 
   external.cornerstone.updateImage(eventData.element);
 }

--- a/src/store/addEnabledElement.js
+++ b/src/store/addEnabledElement.js
@@ -11,11 +11,22 @@ import {
   touchToolEventDispatcher
 } from '../eventDispatchers/index.js';
 import { mutations } from './index.js';
+import generateGUID from './generateGUID.js';
+import external from '../externalModules';
 
 // TODO: Canvases are already tracked by `cornerstone`, but should we track them as well?
 // TODO: This might be easier if `cornerstone` emitted events for enable/disable of canvases
 // TODO: Then we could just respond to those events and not worry about tracking/lifecycle
 export default function (enabledElement) {
+
+  // TODO -> I know we are horribly of piggy-backing on Cornerstone here, UUID
+  // Generation should go core later, this is more of a POC.
+  // Plus Erik is on holiday so we're safe for now.
+  // NOTE: the 'enabledElement' argument here is actually the DOM element...
+  const cornerstoneEnabledElement = external.cornerstone.getEnabledElement(enabledElement);
+
+  cornerstoneEnabledElement.toolDataUID = generateGUID();
+
   // Listeners
   keyboardEventListeners.enable(enabledElement);
   mouseEventListeners.enable(enabledElement);

--- a/src/store/brushStore.js
+++ b/src/store/brushStore.js
@@ -7,7 +7,7 @@ const state = {
   maxRadius: 50,
   alpha: 0.4,
   colorMapId: 'BrushColorMap',
-  imageBitmapCache: null
+  imageBitmapCache: {}
 };
 
 const mutations = {
@@ -44,8 +44,8 @@ const mutations = {
       colormap.setColor(i, colors[i]);
     }
   },
-  SET_IMAGE_BITMAP_CACHE: (imageBitmap) => {
-    state.imageBitmapCache = imageBitmap
+  SET_ELEMENT_IMAGE_BITMAP_CACHE: (enabledElementUID, imageBitmap) => {
+    state.imageBitmapCache[enabledElementUID] = imageBitmap;
   }
 };
 
@@ -56,7 +56,7 @@ const getters = {
   maxRadius: () => state.maxRadius,
   alpha: () => state.alpha,
   colorMapId: () => state.colorMapId,
-  imageBitmapCache: () => state.imageBitmapCache
+  imageBitmapCacheForElement: (enabledElementUID) => state.imageBitmapCache[enabledElementUID]
 };
 
 export default {

--- a/src/store/brushStore.js
+++ b/src/store/brushStore.js
@@ -6,7 +6,8 @@ const state = {
   minRadius: 1,
   maxRadius: 50,
   alpha: 0.4,
-  colorMapId: 'BrushColorMap'
+  colorMapId: 'BrushColorMap',
+  imageBitmapCache: null
 };
 
 const mutations = {
@@ -42,6 +43,9 @@ const mutations = {
     for (let i = 0; i < colors.length; i++) {
       colormap.setColor(i, colors[i]);
     }
+  },
+  SET_IMAGE_BITMAP_CACHE: (imageBitmap) => {
+    state.imageBitmapCache = imageBitmap
   }
 };
 
@@ -51,7 +55,8 @@ const getters = {
   minRadius: () => state.minRadius,
   maxRadius: () => state.maxRadius,
   alpha: () => state.alpha,
-  colorMapId: () => state.colorMapId
+  colorMapId: () => state.colorMapId,
+  imageBitmapCache: () => state.imageBitmapCache
 };
 
 export default {

--- a/src/store/generateGUID.js
+++ b/src/store/generateGUID.js
@@ -1,0 +1,21 @@
+/**
+* Generates a UUID for the polygon.
+*
+* @return {String} the UUID.
+*/
+export default function () { // https://stackoverflow.com/a/8809472/9208320 Public Domain/MIT
+  /* eslint no-bitwise: ["error", { "allow": ["&","|"] }] */
+  let d = new Date().getTime();
+
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    d += performance.now(); // Use high-precision timer if available
+  }
+
+  return 'x.x.x.x.x.x.xxxx.xxx.x.x.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (d + Math.random() * 16) % 16 | 0;
+
+    d = Math.floor(d / 16);
+
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+  });
+}

--- a/src/tools/brushEraserTool.js
+++ b/src/tools/brushEraserTool.js
@@ -29,15 +29,14 @@ export default class extends baseBrushTool {
   renderBrush (evt) {
     // Render the brush
     const eventData = evt.detail;
-    const configuration = this._configuration;
 
     let mousePosition;
 
     if (this._drawing) {
       mousePosition = this._lastImageCoords;
-    } else if (configuration.mouseUpRender) {
+    } else if (this._mouseUpRender) {
       mousePosition = this._lastImageCoords;
-      configuration.mouseUpRender = false;
+      this._mouseUpRender = false;
     } else {
       mousePosition = getters.mousePositionImage();
     }
@@ -58,8 +57,7 @@ export default class extends baseBrushTool {
 
     const radius = brushState.getters.radius();
     const context = eventData.canvasContext;
-
-    const color = this._drawing ? configuration.dragColor : configuration.hoverColor;
+    const color = this._getBrushColor(0);
     const element = eventData.element;
 
     context.setTransform(1, 0, 0, 1, 0, 0);
@@ -125,8 +123,6 @@ export default class extends baseBrushTool {
 
 function defaultBrushConfiguration () {
   return {
-    hoverColor: 'rgba(255, 255, 255, 0.8 )',
-    dragColor: 'rgba(255, 255, 255, 1.0 )',
     keyBinds: {
       increaseBrushSize: '+',
       decreaseBrushSize: '-'

--- a/src/tools/brushTool.js
+++ b/src/tools/brushTool.js
@@ -48,8 +48,6 @@ export default class extends baseBrushTool {
       supportedInteractionTypes: ['mouse'],
       configuration: defaultBrushToolConfiguration()
     });
-
-    this._changeDrawColor(brushState.getters.draw());
   }
 
   /**
@@ -76,8 +74,10 @@ export default class extends baseBrushTool {
     const configuration = this._configuration;
     const radius = brushState.getters.radius();
     const context = eventData.canvasContext;
-    const color = this._drawing ? configuration.dragColor : configuration.hoverColor;
     const element = eventData.element;
+    const drawId = brushState.getters.draw();
+    const color = this._getBrushColor(drawId);
+
 
     context.setTransform(1, 0, 0, 1, 0, 0);
 
@@ -167,8 +167,6 @@ export default class extends baseBrushTool {
 
 function defaultBrushToolConfiguration () {
   return {
-    hoverColor: toolColors.getToolColor(),
-    dragColor: toolColors.getActiveColor(),
     keyBinds: {
       increaseBrushSize: '+',
       decreaseBrushSize: '-',

--- a/src/tools/freehandSculpterMouseTool.js
+++ b/src/tools/freehandSculpterMouseTool.js
@@ -10,10 +10,8 @@ import { FreehandHandleData } from './shared/freehandUtils/FreehandHandleData.js
 import getToolForElement from '../store/getToolForElement.js';
 import baseTool from '../base/baseTool.js';
 
-const referencedToolName = 'freehandMouse';
-
 export default class extends baseTool {
-  constructor (name = 'freehandSculpterMouse') {
+  constructor (name = 'freehandSculpterMouse', referencedToolName = 'freehandMouse') {
     super({
       name,
       supportedInteractionTypes: ['mouse'],
@@ -21,6 +19,7 @@ export default class extends baseTool {
     });
 
     this.hasCursor = true;
+    this._referencedToolName = referencedToolName;
 
     // Bind _onNewImageCallback so that the tool can
     // Be reset when changing whilst active.
@@ -102,7 +101,7 @@ export default class extends baseTool {
     }
 
     const eventData = evt.detail;
-    const toolState = getToolState(eventData.element, referencedToolName);
+    const toolState = getToolState(eventData.element, this._referencedToolName);
 
     if (!toolState) {
       return;
@@ -204,7 +203,7 @@ export default class extends baseTool {
     const config = this.configuration;
     const context = eventData.canvasContext.canvas.getContext('2d');
 
-    const toolState = getToolState(element, referencedToolName);
+    const toolState = getToolState(element, this._referencedToolName);
     const data = toolState.data[config.currentTool];
 
     let coords;
@@ -216,7 +215,7 @@ export default class extends baseTool {
       coords = getters.mousePositionImage();
     }
 
-    const freehandMouseTool = getToolForElement(element, referencedToolName);
+    const freehandMouseTool = getToolForElement(element, this._referencedToolName);
     let radiusCanvas = freehandMouseTool.distanceFromPointCanvas(element, data, coords);
 
     config.mouseLocation.handles.start.x = coords.x;
@@ -285,7 +284,7 @@ export default class extends baseTool {
   */
 
   _activateFreehandTool (element, toolIndex) {
-    const toolState = getToolState(element, referencedToolName);
+    const toolState = getToolState(element, this._referencedToolName);
     const data = toolState.data;
     const config = this.configuration;
 
@@ -629,10 +628,10 @@ export default class extends baseTool {
     const toolIndex = config.currentTool;
     const coords = eventData.currentPoints.image;
 
-    const toolState = getToolState(element, referencedToolName);
+    const toolState = getToolState(element, this._referencedToolName);
     const data = toolState.data[toolIndex];
 
-    const freehandMouseTool = getToolForElement(element, referencedToolName);
+    const freehandMouseTool = getToolForElement(element, this._referencedToolName);
 
     let radiusImage = freehandMouseTool.distanceFromPoint(element, data, coords);
     let radiusCanvas = freehandMouseTool.distanceFromPointCanvas(element, data, coords);
@@ -704,7 +703,7 @@ export default class extends baseTool {
   _invalidateToolData (eventData) {
     const config = this.configuration;
     const element = eventData.element;
-    const toolData = getToolState(element, referencedToolName);
+    const toolData = getToolState(element, this._referencedToolName);
     const data = toolData.data[config.currentTool];
 
     data.invalidated = true;
@@ -718,7 +717,7 @@ export default class extends baseTool {
   */
   _deselectAllTools (element) {
     const config = this.configuration;
-    const toolData = getToolState(element, referencedToolName);
+    const toolData = getToolState(element, this._referencedToolName);
 
     config.currentTool = null;
 
@@ -800,7 +799,7 @@ export default class extends baseTool {
     const image = eventData.image;
     const config = this.configuration;
 
-    const toolState = getToolState(element, referencedToolName);
+    const toolState = getToolState(element, this._referencedToolName);
     const data = toolState.data[config.currentTool];
 
     let areaModifier = 1.0;
@@ -836,8 +835,8 @@ export default class extends baseTool {
   * @return {Number} The tool index of the closest freehand tool.
   */
   static _getClosestFreehandToolOnElement (element, eventData) {
-    const freehand = getToolForElement(element, referencedToolName);
-    const toolState = getToolState(element, referencedToolName);
+    const freehand = getToolForElement(element, this._referencedToolName);
+    const toolState = getToolState(element, this._referencedToolName);
     const data = toolState.data;
     const pixelCoords = eventData.currentPoints.image;
 


### PR DESCRIPTION
In this PR I've centralized the rendering of labelmap data, so that it is rendered if any brush tool is active/passive/enabled (i.e. any tool which extends baseBrushTool).

The labelmap is always rendered first in the queue, such that all annotations appear in front of it.

WIP:
The bitmap generation is asynchronous, so I need a cache of the previous image before a new one is drawn. I'm currently caching once per toolData, which allows for seemless usage whilst working with multiple cornerstone enabled elements, however I'm going to look if I can cache just one slice per element. (i.e. one x*y image, rather than a potential whole data cube).

Demo: https://deploy-preview-564--cornerstone-tools.netlify.com/