### PR TITLE
Refactor brushStore and unit tests

### DIFF
--- a/src/store/brushStore.js
+++ b/src/store/brushStore.js
@@ -65,28 +65,29 @@ export default {
   mutations
 };
 
-
 // DEFAULT BRUSH COLOR MAP
-const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+if (external.cornerstone && external.cornerstone.colors) {
+  const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
 
-colormap.setNumberOfColors(20);
-colormap.setColor(0, [255, 255, 255, 0]);
-colormap.setColor(1, [230, 25, 75, 255]);
-colormap.setColor(2, [60, 180, 175, 255]);
-colormap.setColor(3, [255, 225, 25, 255]);
-colormap.setColor(4, [0, 130, 200, 255]);
-colormap.setColor(5, [245, 130, 48, 255]);
-colormap.setColor(6, [145, 30, 180, 255]);
-colormap.setColor(7, [70, 240, 240, 255]);
-colormap.setColor(8, [240, 50, 230, 255]);
-colormap.setColor(9, [210, 245, 60, 255]);
-colormap.setColor(10, [250, 190, 190, 255]);
-colormap.setColor(11, [0, 128, 128, 255]);
-colormap.setColor(12, [230, 190, 255, 255]);
-colormap.setColor(13, [170, 110, 40, 255]);
-colormap.setColor(14, [255, 250, 200, 255]);
-colormap.setColor(15, [128, 0, 0, 255]);
-colormap.setColor(16, [170, 255, 195, 255]);
-colormap.setColor(17, [128, 128, 0, 255]);
-colormap.setColor(18, [255, 215, 180, 255]);
-colormap.setColor(19, [0, 0, 128, 255]);
+  colormap.setNumberOfColors(20);
+  colormap.setColor(0, [255, 255, 255, 0]);
+  colormap.setColor(1, [230, 25, 75, 255]);
+  colormap.setColor(2, [60, 180, 175, 255]);
+  colormap.setColor(3, [255, 225, 25, 255]);
+  colormap.setColor(4, [0, 130, 200, 255]);
+  colormap.setColor(5, [245, 130, 48, 255]);
+  colormap.setColor(6, [145, 30, 180, 255]);
+  colormap.setColor(7, [70, 240, 240, 255]);
+  colormap.setColor(8, [240, 50, 230, 255]);
+  colormap.setColor(9, [210, 245, 60, 255]);
+  colormap.setColor(10, [250, 190, 190, 255]);
+  colormap.setColor(11, [0, 128, 128, 255]);
+  colormap.setColor(12, [230, 190, 255, 255]);
+  colormap.setColor(13, [170, 110, 40, 255]);
+  colormap.setColor(14, [255, 250, 200, 255]);
+  colormap.setColor(15, [128, 0, 0, 255]);
+  colormap.setColor(16, [170, 255, 195, 255]);
+  colormap.setColor(17, [128, 128, 0, 255]);
+  colormap.setColor(18, [255, 215, 180, 255]);
+  colormap.setColor(19, [0, 0, 128, 255]);
+}

--- a/src/tools/CrosshairsTool.test.js
+++ b/src/tools/CrosshairsTool.test.js
@@ -1,18 +1,5 @@
 import CrosshairsTool from './CrosshairsTool.js';
 
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
-
 describe('CrosshairsTool.js', () => {
   describe('default values', () => {
     it('has a default name of "Crosshairs"', () => {

--- a/src/tools/EllipticalRoiTool.test.js
+++ b/src/tools/EllipticalRoiTool.test.js
@@ -1,20 +1,6 @@
 import EllipticalRoiTool from './EllipticalRoiTool.js';
 import { getToolState } from './../stateManagement/toolState.js';
 
-jest.mock('./../manipulators/drawHandles.js');
-jest.mock('./../util/drawing.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 jest.mock('./../stateManagement/toolState.js', () => ({
   getToolState: jest.fn()
 }));

--- a/src/tools/FreehandMouseTool.test.js
+++ b/src/tools/FreehandMouseTool.test.js
@@ -3,22 +3,8 @@ import calculateFreehandStatistics from './shared/freehandUtils/calculateFreehan
 import freehandArea from './shared/freehandUtils/freehandArea.js';
 import freehandIntersect from './shared/freehandUtils/freehandIntersect.js';
 import pointInFreehand from './shared/freehandUtils/pointInFreehand.js';
-import { FreehandHandleData } from './shared/freehandUtils/FreehandHandleData.js'
+import { FreehandHandleData } from './shared/freehandUtils/FreehandHandleData.js';
 
-jest.mock('./../manipulators/drawHandles.js');
-jest.mock('./../util/drawing.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 jest.mock('./../stateManagement/toolState.js', () => ({
   getToolState: jest.fn()
 }));
@@ -83,28 +69,28 @@ describe('FreehandMouseTool.js', function () {
   });
 });
 
-describe('freehandIntersect.js', function() {
+describe('freehandIntersect.js', function () {
   let dataHandles;
 
   beforeEach(() => {
     // First 3 corners of a square.
     dataHandles = [
       new FreehandHandleData({
-          x: 0.0,
-          y: 0.0
+        x: 0.0,
+        y: 0.0
       }),
       new FreehandHandleData({
-          x: 0.0,
-          y: 1.0
+        x: 0.0,
+        y: 1.0
       }),
       new FreehandHandleData({
-          x: 1.0,
-          y: 1.0
+        x: 1.0,
+        y: 1.0
       })
     ];
   });
 
-  it('should return true if a new handle crosses any previous line', function() {
+  it('should return true if a new handle crosses any previous line', function () {
     const candidateHandle = new FreehandHandleData({
       x: -0.5,
       y: 0.5
@@ -114,7 +100,7 @@ describe('freehandIntersect.js', function() {
     expect(doesIntersect).toBeTruthy();
   });
 
-  it('should return false if a new handle doesn\'t cross any previous line', function() {
+  it('should return false if a new handle doesn\'t cross any previous line', function () {
     const candidateHandle = new FreehandHandleData({
       x: 0.5,
       y: 0.5
@@ -125,8 +111,8 @@ describe('freehandIntersect.js', function() {
     expect(doesIntersect).toBeFalsy();
   });
 
-  it('should return true if the line created by finishing the polygon crosses any previous line', function() {
-    //Add an additional handle above the triangle such the line (handle3,handle0) crosses (handle1,handle2).
+  it('should return true if the line created by finishing the polygon crosses any previous line', function () {
+    // Add an additional handle above the triangle such the line (handle3,handle0) crosses (handle1,handle2).
     const handle3 = new FreehandHandleData({
       x: 0.5,
       y: 1.5
@@ -139,22 +125,23 @@ describe('freehandIntersect.js', function() {
     expect(doesIntersect).toBeTruthy();
   });
 
-  it('should return false if the line created by finishing the polygon doesn\'t cross any previous line', function() {
+  it('should return false if the line created by finishing the polygon doesn\'t cross any previous line', function () {
     const doesIntersect = freehandIntersect.end(dataHandles);
 
     expect(doesIntersect).toBeDefined();
     expect(doesIntersect).toBeFalsy();
   });
 
-  it('should return true if one moves a polygon\'s vertex such that it causes an lines to cross', function() {
-    //add the 4th corner of the square first.
+  it('should return true if one moves a polygon\'s vertex such that it causes an lines to cross', function () {
+    // Add the 4th corner of the square first.
     const handle3 = new FreehandHandleData({
       x: 1.0,
       y: 0.0
     });
+
     dataHandles.push(handle3);
 
-    //Move handle2 so that it crosses line (handle0,handle1)
+    // Move handle2 so that it crosses line (handle0,handle1)
     const modifiedHandleId = 2;
 
     dataHandles[modifiedHandleId].x = -0.5;
@@ -165,15 +152,16 @@ describe('freehandIntersect.js', function() {
     expect(doesIntersect).toBeTruthy();
   });
 
-  it('should return false if one moves a polygon\'s vertex a bit such that no lines cross', function() {
-    //add the 4th corner of the square first.
+  it('should return false if one moves a polygon\'s vertex a bit such that no lines cross', function () {
+    // Add the 4th corner of the square first.
     const handle3 = new FreehandHandleData({
       x: 1.0,
       y: 0.0
     });
+
     dataHandles.push(handle3);
 
-    //Move handle2 in a non disruptive way.
+    // Move handle2 in a non disruptive way.
     const modifiedHandleId = 2;
 
     dataHandles[modifiedHandleId].x = 2.0;
@@ -186,28 +174,28 @@ describe('freehandIntersect.js', function() {
   });
 });
 
-describe('pointInFreehand.js', function() {
+describe('pointInFreehand.js', function () {
   // Simple square
   const dataHandles = [
     new FreehandHandleData({
-        x: 0.0,
-        y: 0.0
+      x: 0.0,
+      y: 0.0
     }),
     new FreehandHandleData({
-        x: 0.0,
-        y: 1.0
+      x: 0.0,
+      y: 1.0
     }),
     new FreehandHandleData({
-        x: 1.0,
-        y: 1.0
+      x: 1.0,
+      y: 1.0
     }),
     new FreehandHandleData({
-        x: 1.0,
-        y: 0.0
+      x: 1.0,
+      y: 0.0
     })
   ];
 
-  it('should return true if the point is inside the polygon', function() {
+  it('should return true if the point is inside the polygon', function () {
     const point = {
       x: 0.5,
       y: 0.5
@@ -217,7 +205,7 @@ describe('pointInFreehand.js', function() {
     expect(isInside).toBeTruthy();
   });
 
-  it('should return false if the point is outside the object, to the right', function() {
+  it('should return false if the point is outside the object, to the right', function () {
     const point = {
       x: 2.0,
       y: 0.5
@@ -228,7 +216,7 @@ describe('pointInFreehand.js', function() {
     expect(isInside).toBeFalsy();
   });
 
-  it('should return false if the point is outside the object, to the left', function() {
+  it('should return false if the point is outside the object, to the left', function () {
     const point = {
       x: -1.0,
       y: 0.5
@@ -239,7 +227,7 @@ describe('pointInFreehand.js', function() {
     expect(isInside).toBeFalsy();
   });
 
-  it('should return false if on the line exactly', function() {
+  it('should return false if on the line exactly', function () {
     const point = {
       x: 1.0,
       y: 0.5
@@ -250,7 +238,7 @@ describe('pointInFreehand.js', function() {
     expect(isInside).toBeFalsy();
   });
 
-  it('should return false if the point is outside the object, above or bellow', function() {
+  it('should return false if the point is outside the object, above or bellow', function () {
     const point1 = {
       x: 0.5,
       y: 2.0
@@ -270,24 +258,24 @@ describe('pointInFreehand.js', function() {
 });
 
 
-describe('freehandArea.js', function() {
+describe('freehandArea.js', function () {
   // A unit square
   const dataHandles = [
     new FreehandHandleData({
-        x: 0.0,
-        y: 0.0
+      x: 0.0,
+      y: 0.0
     }),
     new FreehandHandleData({
-        x: 0.0,
-        y: 1.0
+      x: 0.0,
+      y: 1.0
     }),
     new FreehandHandleData({
-        x: 1.0,
-        y: 1.0
+      x: 1.0,
+      y: 1.0
     }),
     new FreehandHandleData({
-        x: 1.0,
-        y: 0.0
+      x: 1.0,
+      y: 0.0
     })
   ];
 
@@ -305,32 +293,32 @@ describe('freehandArea.js', function() {
 
 });
 
-describe('calculateFreehandStatistics.js', function() {
+describe('calculateFreehandStatistics.js', function () {
   // 'L' shape: 10x10 square with top right quadrant missing
   const dataHandles = [
     new FreehandHandleData({
-        x: 0.0,
-        y: 0.0
+      x: 0.0,
+      y: 0.0
     }),
     new FreehandHandleData({
-        x: 0.0,
-        y: 10.0
+      x: 0.0,
+      y: 10.0
     }),
     new FreehandHandleData({
-        x: 5.0,
-        y: 10.0
+      x: 5.0,
+      y: 10.0
     }),
     new FreehandHandleData({
-        x: 5.0,
-        y: 5.0
+      x: 5.0,
+      y: 5.0
     }),
     new FreehandHandleData({
-        x: 10.0,
-        y: 5.0
+      x: 10.0,
+      y: 5.0
     }),
     new FreehandHandleData({
-        x: 10.0,
-        y: 0.0
+      x: 10.0,
+      y: 0.0
     })
   ];
 
@@ -341,9 +329,10 @@ describe('calculateFreehandStatistics.js', function() {
     width: 10.0
   };
 
-  it('should not include pixels outside the polygon', function() {
-    // create 100 dimensional pixel array
+  it('should not include pixels outside the polygon', function () {
+    // Create 100 dimensional pixel array
     const pixels = [];
+
     pixels.length = 100;
     pixels.fill(0.0);
 
@@ -358,9 +347,10 @@ describe('calculateFreehandStatistics.js', function() {
 
   });
 
-  it('should calculate that statistics of pixels within the polygon', function() {
-    // create 100 dimensional pixel array
+  it('should calculate that statistics of pixels within the polygon', function () {
+    // Create 100 dimensional pixel array
     const pixels = [];
+
     pixels.length = 100;
 
     // Set pixels within (0,0),(0,5),(10,5),(10,0) to 1

--- a/src/tools/LengthTool.test.js
+++ b/src/tools/LengthTool.test.js
@@ -1,20 +1,6 @@
 import LengthTool from './LengthTool.js';
 import { getToolState } from './../stateManagement/toolState.js';
 
-jest.mock('./../manipulators/drawHandles.js');
-jest.mock('./../util/drawing.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 jest.mock('./../stateManagement/toolState.js', () => ({
   getToolState: jest.fn()
 }));

--- a/src/tools/PanMultiTouchTool.test.js
+++ b/src/tools/PanMultiTouchTool.test.js
@@ -3,17 +3,7 @@ import PanMultiTouchTool from './PanMultiTouchTool.js';
 import external from './../externalModules.js';
 
 jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    setViewport: jest.fn(),
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
+  cornerstone: {}
 }));
 describe('PanMultiTouchTool.js', () => {
   describe('default values', () => {

--- a/src/tools/PanTool.test.js
+++ b/src/tools/PanTool.test.js
@@ -2,19 +2,8 @@ import PanTool from './PanTool.js';
 import external from './../externalModules.js';
 
 jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    setViewport: jest.fn(),
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
+  cornerstone: {}
 }));
-
 describe('PanTool.js', () => {
   describe('default values', () => {
     it('has a default name of "Pan"', () => {

--- a/src/tools/ProbeTool.test.js
+++ b/src/tools/ProbeTool.test.js
@@ -1,20 +1,6 @@
 import ProbeTool from './ProbeTool.js';
 import { getToolState } from './../stateManagement/toolState.js';
 
-jest.mock('./../manipulators/drawHandles.js');
-jest.mock('./../util/drawing.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 jest.mock('./../stateManagement/toolState.js', () => ({
   getToolState: jest.fn()
 }));

--- a/src/tools/RectangleRoiTool.test.js
+++ b/src/tools/RectangleRoiTool.test.js
@@ -1,20 +1,6 @@
 import RectangleRoiTool from './RectangleRoiTool.js';
 import { getToolState } from './../stateManagement/toolState.js';
 
-jest.mock('./../manipulators/drawHandles.js');
-jest.mock('./../util/drawing.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 jest.mock('./../stateManagement/toolState.js', () => ({
   getToolState: jest.fn()
 }));

--- a/src/tools/RotateTool.test.js
+++ b/src/tools/RotateTool.test.js
@@ -2,16 +2,7 @@ import RotateTool from './RotateTool.js';
 import external from './../externalModules.js';
 
 jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
+  cornerstone: {}
 }));
 
 const mockEvt = {

--- a/src/tools/ScaleOverlayTool.test.js
+++ b/src/tools/ScaleOverlayTool.test.js
@@ -8,14 +8,6 @@ jest.mock('./../externalModules.js', () => ({
     updateImage: jest.fn(),
     metaData: {
       get: jest.fn()
-    },
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
     }
   }
 }));

--- a/src/tools/StackScrollMouseWheelTool.test.js
+++ b/src/tools/StackScrollMouseWheelTool.test.js
@@ -2,18 +2,6 @@ import StackScrollMouseWheelTool from './StackScrollMouseWheelTool.js';
 import scroll from '../util/scroll.js';
 
 jest.mock('../util/scroll.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 
 const mockEvent = {
   detail: {

--- a/src/tools/StackScrollTool.test.js
+++ b/src/tools/StackScrollTool.test.js
@@ -3,18 +3,6 @@ import StackScrollTool from './StackScrollTool.js';
 import scroll from '../util/scroll.js';
 
 jest.mock('../util/scroll.js');
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
 
 const mockEvent = {
   detail: {

--- a/src/tools/WwwcRegionTool.test.js
+++ b/src/tools/WwwcRegionTool.test.js
@@ -1,23 +1,5 @@
 import WwwcRegionTool from './WwwcRegionTool.js';
 
-jest.mock('./../util/drawing.js', () => ({
-  draw: jest.fn(),
-  drawRect: jest.fn(),
-  getNewContext: jest.fn()
-}));
-jest.mock('./../externalModules.js', () => ({
-  cornerstone: {
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
-  }
-}));
-
 describe('WwwcRegionTool.js', () => {
   describe('default values', () => {
     it('has a default name of "WwwcRegion"', () => {

--- a/src/tools/WwwcTool.test.js
+++ b/src/tools/WwwcTool.test.js
@@ -3,15 +3,7 @@ import external from './../externalModules.js';
 
 jest.mock('./../externalModules.js', () => ({
   cornerstone: {
-    setViewport: jest.fn(),
-    colors: {
-      getColormap: jest.fn().mockImplementation(() => {
-        return {
-          setNumberOfColors: jest.fn(),
-          setColor: jest.fn()
-        }
-      })
-    }
+    setViewport: jest.fn()
   }
 }));
 


### PR DESCRIPTION
## Changes
- Make sure that external.cornerstone.colors exist before using 
- It will avoid breaking unit tests that does not mock this functions and also we can remove a lot of mock functions inside unit tests that are not being tested directly. 

NOTE: In case we want to test the colors/colorMap from Brush, we can mock the function inside the unit test and perform the tests desired. 