### PR TITLE
Use cornerstone events directly from  its own lib

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,10 +1,4 @@
 const EVENTS = {
-  // Events from Cornerstone Core
-  IMAGE_RENDERED: 'cornerstoneimagerendered',
-  NEW_IMAGE: 'cornerstonenewimage',
-  IMAGE_CACHE_PROMISE_REMOVED: 'cornerstoneimagecachepromiseremoved',
-  ELEMENT_DISABLED: 'cornerstoneelementdisabled',
-
   // Mouse events
   MOUSE_DOWN: 'cornerstonetoolsmousedown',
   MOUSE_UP: 'cornerstonetoolsmouseup',

--- a/src/imageTools/displayTool.js
+++ b/src/imageTools/displayTool.js
@@ -1,5 +1,4 @@
 
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 
 export default function (onImageRendered) {
@@ -7,11 +6,11 @@ export default function (onImageRendered) {
 
   return {
     disable (element) {
-      element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+      element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
     },
     enable (element) {
-      element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
-      element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+      element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
+      element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
       external.cornerstone.updateImage(element);
     },
     getConfiguration () {

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -163,7 +163,7 @@ function mouseUpCallback (e) {
   const eventData = e.detail;
   const element = eventData.element;
 
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, imageRenderedCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, imageRenderedCallback);
   element.removeEventListener(EVENTS.MOUSE_DRAG, dragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
@@ -176,7 +176,7 @@ function mouseDownCallback (e) {
   const options = getToolOptions(toolType, element);
 
   if (isMouseButtonEnabled(eventData.which, options.mouseButtonMask)) {
-    element.addEventListener(EVENTS.IMAGE_RENDERED, imageRenderedCallback);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, imageRenderedCallback);
     element.addEventListener(EVENTS.MOUSE_DRAG, dragCallback);
     element.addEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
     element.addEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
@@ -212,14 +212,14 @@ function touchStartCallback (e) {
   const eventData = e.detail;
   const element = eventData.element;
 
-  element.addEventListener(EVENTS.IMAGE_RENDERED, imageRenderedCallback);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, imageRenderedCallback);
 }
 
 function touchEndCallback (e) {
   const eventData = e.detail;
   const element = eventData.element;
 
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, imageRenderedCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, imageRenderedCallback);
 
   external.cornerstone.updateImage(element);
 }

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -1032,7 +1032,7 @@ function onImageRendered (e) {
 function enable (element) {
   removeEventListeners(element);
 
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
 
@@ -1058,7 +1058,7 @@ function activate (element, mouseButtonMask) {
 
   removeEventListeners(element);
 
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
@@ -1088,7 +1088,7 @@ function deactivate (element, mouseButtonMask) {
 
   removeEventListeners(element);
 
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.addEventListener(EVENTS.KEY_DOWN, keyDownCallback);
@@ -1109,7 +1109,7 @@ function removeEventListeners (element) {
   element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.removeEventListener(EVENTS.KEY_DOWN, keyDownCallback);
   element.removeEventListener(EVENTS.KEY_UP, keyUpCallback);
 }

--- a/src/imageTools/freehandSculpter.js
+++ b/src/imageTools/freehandSculpter.js
@@ -336,11 +336,11 @@ function activate (element, mouseButtonMask) {
   freehand.enable(element);
 
   removeEventListeners(element);
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.addEventListener(EVENTS.KEY_DOWN, keyDownCallback);
   element.addEventListener(EVENTS.KEY_UP, keyUpCallback);
-  element.addEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.addEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 
   element.focus();
   external.cornerstone.updateImage(element);
@@ -364,13 +364,13 @@ function deactivate (element) {
 * @modifies {element}
 */
 function removeEventListeners (element) {
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
   element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
   element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
   element.removeEventListener(EVENTS.KEY_DOWN, keyDownCallback);
   element.removeEventListener(EVENTS.KEY_UP, keyUpCallback);
-  element.removeEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 }
 
 /**

--- a/src/imageTools/magnify.js
+++ b/src/imageTools/magnify.js
@@ -51,7 +51,7 @@ function mouseDownCallback (e) {
     element.addEventListener(EVENTS.TOUCH_END, mouseUpCallback);
     element.addEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
 
-    element.addEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+    element.addEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 
     // Ignore until next event
     drawZoomedElement(eventData);
@@ -76,7 +76,7 @@ function dragEndCallback (e) {
 
   element.removeEventListener(EVENTS.TOUCH_DRAG_END, dragEndCallback);
   element.removeEventListener(EVENTS.TOUCH_END, dragEndCallback);
-  element.removeEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
   hideTool(eventData);
 }
 

--- a/src/imageTools/mouseButtonRectangleTool.js
+++ b/src/imageTools/mouseButtonRectangleTool.js
@@ -163,7 +163,7 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
 
   // Not visible, not interactive
   function disable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
@@ -173,12 +173,12 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
 
   // Visible but not interactive
   function enable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
 
     external.cornerstone.updateImage(element);
   }
@@ -187,12 +187,12 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
   function activate (element, mouseButtonMask) {
     setToolOptions(toolType, element, { mouseButtonMask });
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
     element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
@@ -204,12 +204,12 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
   function deactivate (element, mouseButtonMask) {
     setToolOptions(toolType, element, { mouseButtonMask });
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
 

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -234,7 +234,7 @@ export default function (mouseToolInterface) {
 
   // Not visible, not interactive
   function disable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDown);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivate);
@@ -248,7 +248,7 @@ export default function (mouseToolInterface) {
 
   // Visible but not interactive
   function enable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDown);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivate);
@@ -257,7 +257,7 @@ export default function (mouseToolInterface) {
       element.removeEventListener(EVENTS.MOUSE_DOUBLE_CLICK, mouseDoubleClick);
     }
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
 
     external.cornerstone.updateImage(element);
   }
@@ -266,12 +266,12 @@ export default function (mouseToolInterface) {
   function activate (element, mouseButtonMask) {
     setToolOptions(toolType, element, { mouseButtonMask });
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDown);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivate);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.addEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.addEventListener(EVENTS.MOUSE_DOWN, mouseDown);
     element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivate);
@@ -297,12 +297,12 @@ export default function (mouseToolInterface) {
 
     triggerEvent(element, eventType, statusChangeEventData);
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.removeEventListener(EVENTS.MOUSE_DOWN, mouseDown);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivate);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, mouseToolInterface.onImageRendered);
     element.addEventListener(EVENTS.MOUSE_MOVE, mouseMove);
     element.addEventListener(EVENTS.MOUSE_DOWN, mouseDown);
 

--- a/src/imageTools/scaleOverlayTool.js
+++ b/src/imageTools/scaleOverlayTool.js
@@ -1,5 +1,4 @@
 import displayTool from './displayTool.js';
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import { getNewContext, draw, drawLines, drawLine } from '../util/drawing.js';
 
@@ -207,7 +206,7 @@ function onImageRendered (e) {
 
 function disable (element) {
   // TODO: displayTool does not have cornerstone.updateImage(element) method to hide tool
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
 

--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -270,7 +270,7 @@ function touchTool (touchToolInterface) {
 
   // Not visible, not interactive
   function disable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
     element.removeEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
     element.removeEventListener(EVENTS.TAP, touchToolInterface.tapCallback || tapCallback);
@@ -288,12 +288,12 @@ function touchTool (touchToolInterface) {
 
   // Visible but not interactive
   function enable (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
     element.removeEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
     element.removeEventListener(EVENTS.TAP, touchToolInterface.tapCallback || tapCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
 
     if (touchToolInterface.doubleTapCallback) {
       element.removeEventListener(EVENTS.DOUBLE_TAP, touchToolInterface.doubleTapCallback);
@@ -308,12 +308,12 @@ function touchTool (touchToolInterface) {
 
   // Visible, interactive and can create
   function activate (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
     element.removeEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
     element.removeEventListener(EVENTS.TAP, touchToolInterface.tapCallback || tapCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.addEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
     element.addEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
     element.addEventListener(EVENTS.TAP, touchToolInterface.tapCallback || tapCallback);
@@ -341,12 +341,12 @@ function touchTool (touchToolInterface) {
 
     triggerEvent(element, eventType, statusChangeEventData);
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.removeEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
     element.removeEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
     element.removeEventListener(EVENTS.TAP, touchToolInterface.tapCallback || tapCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, touchToolInterface.onImageRendered);
     element.addEventListener(EVENTS.TOUCH_START, touchToolInterface.touchStartCallback || touchStartCallback);
 
     if (touchToolInterface.doubleTapCallback) {

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -253,8 +253,8 @@ function disable (element) {
   element.removeEventListener(EVENTS.MOUSE_DRAG, dragCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, dragCallback);
 
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
-  element.removeEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 
   external.cornerstone.updateImage(element);
 }
@@ -278,15 +278,15 @@ function activate (element, mouseButtonMask) {
   element.removeEventListener(EVENTS.MOUSE_DRAG, dragCallback);
   element.removeEventListener(EVENTS.MOUSE_MOVE, dragCallback);
 
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
-  element.removeEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 
   element.addEventListener(EVENTS.MOUSE_DOWN, mouseDownCallback);
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 
   // If the displayed image changes after the user has started clicking, we should
   // Cancel the handlers and prepare for another click
-  element.addEventListener(EVENTS.NEW_IMAGE, newImageCallback);
+  element.addEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageCallback);
 
   external.cornerstone.updateImage(element);
 }
@@ -296,7 +296,7 @@ function disableTouchDrag (element) {
   element.removeEventListener(EVENTS.TOUCH_DRAG, dragCallback);
   element.removeEventListener(EVENTS.TOUCH_START, recordStartPoint);
   element.removeEventListener(EVENTS.TOUCH_DRAG_END, applyWWWCRegion);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 }
 
 function activateTouchDrag (element) {
@@ -311,12 +311,12 @@ function activateTouchDrag (element) {
   element.removeEventListener(EVENTS.TOUCH_DRAG, dragCallback);
   element.removeEventListener(EVENTS.TOUCH_START, recordStartPoint);
   element.removeEventListener(EVENTS.TOUCH_DRAG_END, applyWWWCRegion);
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 
   element.addEventListener(EVENTS.TOUCH_DRAG, dragCallback);
   element.addEventListener(EVENTS.TOUCH_START, recordStartPoint);
   element.addEventListener(EVENTS.TOUCH_DRAG_END, applyWWWCRegion);
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 }
 
 function getConfiguration () {

--- a/src/paintingTools/brushTool.js
+++ b/src/paintingTools/brushTool.js
@@ -205,8 +205,8 @@ export default function brushTool (brushToolInterface) {
   function activate (element, mouseButtonMask) {
     setToolOptions(toolType, element, { mouseButtonMask });
 
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
-    element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
     element.addEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
@@ -287,12 +287,12 @@ export default function brushTool (brushToolInterface) {
   }
 
   function deactivate (element) {
-    element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+    element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
     element.removeEventListener(EVENTS.MOUSE_DOWN_ACTIVATE, mouseDownActivateCallback);
     element.removeEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
     element.removeEventListener(EVENTS.KEY_DOWN, keyDownCallback);
 
-    element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+    element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
 
     const configuration = brushTool.getConfiguration();
 

--- a/src/referenceLines/referenceLinesTool.js
+++ b/src/referenceLines/referenceLinesTool.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import renderActiveReferenceLine from './renderActiveReferenceLine.js';
@@ -49,14 +48,14 @@ function enable (element, synchronizationContext, renderer) {
     renderer
   });
 
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
-  element.addEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
 
 // Disables the reference line tool for the given element
 function disable (element) {
-  element.removeEventListener(EVENTS.IMAGE_RENDERED, onImageRendered);
+  element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
 

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import requestPoolManager from '../requestPool/requestPoolManager.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
@@ -293,22 +292,22 @@ function enable (element) {
 
   prefetch(element);
 
-  element.removeEventListener(EVENTS.NEW_IMAGE, onImageUpdated);
-  element.addEventListener(EVENTS.NEW_IMAGE, onImageUpdated);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, onImageUpdated);
+  element.addEventListener(external.cornerstone.EVENTS.NEW_IMAGE, onImageUpdated);
 
   const promiseRemovedHandler = getPromiseRemovedHandler(element);
 
-  external.cornerstone.events.removeEventListener(EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
-  external.cornerstone.events.addEventListener(EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
+  external.cornerstone.events.removeEventListener(external.cornerstone.EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
+  external.cornerstone.events.addEventListener(external.cornerstone.EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
 }
 
 function disable (element) {
   clearTimeout(resetPrefetchTimeout);
-  element.removeEventListener(EVENTS.NEW_IMAGE, onImageUpdated);
+  element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, onImageUpdated);
 
   const promiseRemovedHandler = getPromiseRemovedHandler(element);
 
-  external.cornerstone.events.removeEventListener(EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
+  external.cornerstone.events.removeEventListener(external.cornerstone.EVENTS.IMAGE_CACHE_PROMISE_REMOVED, promiseRemovedHandler);
 
   const stackPrefetchData = getToolState(element, toolType);
   // If there is actually something to disable, disable it

--- a/src/synchronization/Synchronizer.js
+++ b/src/synchronization/Synchronizer.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import convertToVector3 from '../util/convertToVector3.js';
 import { clearToolOptionsByElement } from '../toolOptions.js';
@@ -294,8 +293,8 @@ function Synchronizer (event, handler) {
     const elements = unique(sourceElements.concat(targetElements));
 
     elements.forEach(function (element) {
-      element.removeEventListener(EVENTS.ELEMENT_DISABLED, disableHandler);
-      element.addEventListener(EVENTS.ELEMENT_DISABLED, disableHandler);
+      element.removeEventListener(external.cornerstone.EVENTS.ELEMENT_DISABLED, disableHandler);
+      element.addEventListener(external.cornerstone.EVENTS.ELEMENT_DISABLED, disableHandler);
     });
   };
 

--- a/src/util/scroll.js
+++ b/src/util/scroll.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import scrollToIndex from './scrollToIndex.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import clip from './clip.js';
@@ -20,7 +19,7 @@ function scrollWithoutSkipping (stackData, pendingEvent, element) {
 
       if (index === pendingEvent.index) {
         stackData.pending.splice(stackData.pending.indexOf(pendingEvent), 1);
-        element.removeEventListener(EVENTS.NEW_IMAGE, newImageHandler);
+        element.removeEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageHandler);
 
         if (stackData.pending.length > 0) {
           scrollWithoutSkipping(stackData, stackData.pending[0], element);
@@ -28,7 +27,7 @@ function scrollWithoutSkipping (stackData, pendingEvent, element) {
       }
     };
 
-    element.addEventListener(EVENTS.NEW_IMAGE, newImageHandler);
+    element.addEventListener(external.cornerstone.EVENTS.NEW_IMAGE, newImageHandler);
 
     scrollToIndex(element, pendingEvent.index);
   }


### PR DESCRIPTION
## Changes
- Remove events from cornerstone-core from cornerstoneTools event list. 
- Use events direct from cornerstone-core library. 

(Closes #369)