### PR TITLE
Adding back eslint validation on jsdocs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -254,7 +254,7 @@ module.exports = {
       'warn',
       'never'
     ],
-    //'valid-jsdoc': 'warn',
+    'valid-jsdoc': 'warn',
     'vars-on-top': 'warn',
     'wrap-iife': ['warn', 'inside'],
     'wrap-regex': 'warn',


### PR DESCRIPTION
## Changes
- Adding 'valid-jsdoc' attribute into eslint in order to warn once a new file/function is missing a jsdocs. 