### PR TITLE
Add filter for touch tools

### DIFF
--- a/src/eventDispatchers/shared/customCallbackHandler.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.js
@@ -12,6 +12,13 @@ export default function (handlerType, customFunction, evt) {
   const element = evt.detail.element;
 
   tools = getActiveToolsForElement(element, tools);
+
+  if (handlerType === 'touch') {
+    tools = tools.filter(
+      (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
+    );  
+  }
+  
   tools = tools.filter((tool) => typeof tool[customFunction] === 'function');
 
   if (tools.length === 0) {

--- a/src/eventDispatchers/touchEventHandlers/touchStart.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStart.js
@@ -24,7 +24,10 @@ export default function (evt) {
   const element = eventData.element;
   const coords = eventData.startPoints.canvas;
 
-  const tools = getInteractiveToolsForElement(element, getters.touchTools());
+  let tools = getInteractiveToolsForElement(element, getters.touchTools());
+  tools = tools.filter(
+    (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
+  );
   const activeTools = tools.filter((tool) => tool.mode === 'active');
 
   // If any tools are active, check if they have a special reason for dealing with the event.

--- a/src/eventDispatchers/touchEventHandlers/touchStartActive.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStartActive.js
@@ -10,7 +10,16 @@ export default function (evt) {
   }
 
   const element = evt.detail.element;
-  const tools = getActiveToolsForElement(element, getters.touchTools());
+  let tools = getActiveToolsForElement(element, getters.touchTools());
+  
+  tools = tools.filter(
+    (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
+  );
+
+  if (tools.length === 0) {
+    return;
+  }
+  
   const activeTool = tools[0];
 
   // Note: custom `addNewMeasurement` will need to prevent event bubbling


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If there are multiple active tools with different button masks, in touch it won't be able to filter the current tool and will activate the first one in the list.


* **What is the new behavior (if this is a feature change)?**
A new option was added (touchEnable) and touch tools are filtered by this option. If it's false it won't be an active tool. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
