### PR TITLE
v2 - Fix freehand active drawing edge case

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "puppeteer": "^1.4.0",
     "shx": "^0.2.2",
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.9.1",
-    "webpack-cli": "^2.1.4",
-    "webpack-dev-server": "^3.1.4"
+    "webpack": "4.9.1",
+    "webpack-cli": "2.1.4",
+    "webpack-dev-server": "3.1.4"
   },
   "dependencies": {
     "cornerstone-math": "^0.1.6"

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -1030,8 +1030,8 @@ function onImageRendered (e) {
 * @modifies {element}
 */
 function enable (element) {
+  closeToolIfDrawing(element);
   removeEventListeners(element);
-
   element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   external.cornerstone.updateImage(element);
 }
@@ -1043,6 +1043,7 @@ function enable (element) {
 * @modifies {element}
 */
 function disable (element) {
+  closeToolIfDrawing(element);
   removeEventListeners(element);
   external.cornerstone.updateImage(element);
 }
@@ -1086,6 +1087,7 @@ function deactivate (element, mouseButtonMask) {
 
   triggerEvent(element, eventType, statusChangeEventData);
 
+  closeToolIfDrawing(element);
   removeEventListeners(element);
 
   element.addEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
@@ -1112,6 +1114,23 @@ function removeEventListeners (element) {
   element.removeEventListener(external.cornerstone.EVENTS.IMAGE_RENDERED, onImageRendered);
   element.removeEventListener(EVENTS.KEY_DOWN, keyDownCallback);
   element.removeEventListener(EVENTS.KEY_UP, keyUpCallback);
+}
+
+
+/**
+ * closeToolIfDrawing - Closes the ROI if the tool is not yet
+ * complete when changing tool mode.
+ *
+ * @param  {Object} element The element the ROI is associated with.
+ */
+function closeToolIfDrawing(element) {
+  const config = freehand.getConfiguration();
+  if (config.currentTool >= 0) {
+    // Actively drawing but changed mode.
+    const lastHandlePlaced = config.currentHandle;
+
+    endDrawing(element, lastHandlePlaced);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes a breaking issue that occurs when one attempts to switch tool half way through drawing a freehand ROI, by auto-completing the ROI before switching.