### PR TITLE
Feature/smart tool mode changing

### DIFF
--- a/docs/latest/SUMMARY.md
+++ b/docs/latest/SUMMARY.md
@@ -17,9 +17,9 @@
 
 - [Anatomy of a Tool](anatomy-of-a-tool/index.md)
   - [Modes](anatomy-of-a-tool/index.md#modes)
+  - [Configuration](anatomy-of-a-tool/index.md#configuration)
   - [Interaction Types](anatomy-of-a-tool/index.md#interaction-types)
   - [Strategies](anatomy-of-a-tool/index.md#strategies)
-  - [Configuration](anatomy-of-a-tool/index.md#configuration)
   - [Mixins](anatomy-of-a-tool/index.md#mixins)
   - [Measurement Data](anatomy-of-a-tool/index.md#measurement-data)
 - [Tool Types](tool-types/index.md)

--- a/docs/latest/anatomy-of-a-tool/configuration.md
+++ b/docs/latest/anatomy-of-a-tool/configuration.md
@@ -18,3 +18,11 @@ csTools.setToolModeActive("ToolName", { isTouchActive: false });
 //  The previous `mouseButtonMask` configuration property's value is updated to `2`
 csTools.setToolModeActive("ToolName", { mouseButtonMask: 2 });
 ```
+
+### Common Configuration Options
+
+| Option                      | Mouse | Touch | Annotation | Brush |
+| --------------------------- | :---: | :---: | :--------: | :---: |
+| `mouseButtonMask`           |   x   |       |            |       |
+| `preventHandleOutsideImage` |       |       |     x      |       |
+| `isTouchActive`             |       |   x   |            |       |

--- a/docs/latest/anatomy-of-a-tool/configuration.md
+++ b/docs/latest/anatomy-of-a-tool/configuration.md
@@ -21,6 +21,8 @@ csTools.setToolModeActive("ToolName", { mouseButtonMask: 2 });
 
 ### Common Configuration Options
 
+TODO: Create a property on base tool that is a string list of all configuration options used internally by the tool? Then maintain a list here that denotes what each property is used for?
+
 | Option                      | Mouse | Touch | Annotation | Brush |
 | --------------------------- | :---: | :---: | :--------: | :---: |
 | `mouseButtonMask`           |   x   |       |            |       |

--- a/documentation.yml
+++ b/documentation.yml
@@ -11,11 +11,11 @@ toc:
     description: |
       This section needs a description
     children:
-      #- setToolActive
+      - setToolActive
       - setToolActiveForElement
-      #- setToolPassive
+      - setToolPassive
       - setToolPassiveForElement
-      #- setToolEnabled
+      - setToolEnabled
       - setToolEnabledForElement
-      #- setToolDisabled
+      - setToolDisabled
       - setToolDisabledForElement

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
 
 			const toolType = evt.target.getAttribute('data-tool-type')
 			setButtonActive(toolName, mouseButtonMask, toolType);
-			cTools.setToolActive(toolName, { mouseButtonMask });
+			cTools.setToolActive(toolName, { mouseButtonMask, isTouchActive: true });
 
 			evt.preventDefault();
 			evt.stopPropagation();
@@ -228,7 +228,7 @@
 	});
 
 	// Activate first tool
-	cTools.setToolActive(cTools.store.state.tools[0].name, { mouseButtonMask: 1 });
+	cTools.setToolActive(cTools.store.state.tools[0].name, 1, true);
 
 	const setToolCategoryActive = (categoryName) => {
 		Array.from(toolCategoryLinks).forEach(toolLink => {

--- a/index.html
+++ b/index.html
@@ -148,17 +148,6 @@
 		});
 	})
 
-	function setAllToolsPassive() {
-		const exceptionList = [
-			'ScaleOverlay'
-		];
-		cTools.store.state.tools.forEach((tool) => {
-			if (!exceptionList.includes(tool.name)) {
-				cTools.setToolPassive(tool.name);
-			}
-		});
-	}
-
 	// Iterate over all tool-category links
 	const toolCategoryLinks = document.querySelectorAll('ul.tool-category-list a');
 	const toolCategorySections = document.querySelectorAll('ul.tool-category');
@@ -201,8 +190,7 @@
 			const mouseButtonMask = evt.buttons
 				? evt.buttons
 				: convertMouseEventWhichToButtons(evt.which)
-			// TODO: Let's make this happen automagically for mask/touch conflicts?
-			setAllToolsPassive();
+
 			const toolType = evt.target.getAttribute('data-tool-type')
 			setButtonActive(toolName, mouseButtonMask, toolType);
 			cTools.setToolActive(toolName, { mouseButtonMask });

--- a/index.html
+++ b/index.html
@@ -228,7 +228,10 @@
 	});
 
 	// Activate first tool
-	cTools.setToolActive(cTools.store.state.tools[0].name, 1, true);
+	cTools.setToolActive(cTools.store.state.tools[0].name, {
+		mouseButtonMask: 1,
+		isTouchActive: true
+	});
 
 	const setToolCategoryActive = (categoryName) => {
 		Array.from(toolCategoryLinks).forEach(toolLink => {

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -49,8 +49,13 @@ export default class BaseTool {
     return this._options;
   }
 
+  /**
+   * Merges provided options with existing options
+   *
+   * @memberof BaseTool
+   */
   set options (options) {
-    this._options = options;
+    this._options = Object.assign({}, this._options, options);
   }
 
   clearOptions () {

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -92,9 +92,7 @@ export default class BaseTool {
       if (typeof mixinCollection[mixinName] === 'object') {
         Object.assign(this, mixinCollection[mixinName]);
       } else {
-        console.warn(
-          `${this.name}: mixin ${mixins} does not exist.`
-        );
+        console.warn(`${this.name}: mixin ${mixins} does not exist.`);
       }
     }
   }

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -69,9 +69,9 @@ export default class BaseTool {
    */
   clearOptions () {
     this._options = {};
-    this.internalOptions().forEach((option) => {
-      this._options[option] = undefined;
-    });
+    this.internalOptions().forEach(
+      (option) => (this._options[option] = undefined)
+    );
   }
 
   /**

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -58,6 +58,11 @@ export default class BaseTool {
     this._options = Object.assign({}, this._options, options);
   }
 
+  /**
+   * Clears the tools options.
+   *
+   * @memberof BaseTool
+   */
   clearOptions () {
     this._options = {};
   }

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -24,7 +24,10 @@ export default class BaseTool {
 
     //
     this.data = {};
+    // Options are set when a tool is added, during a "mode" change,
+    // Or via a tool's option's setter
     this._options = {};
+    // Configuration is set at tool initalization
     this._configuration = Object.assign({}, configuration);
 
     // True if tool has a custom cursor, causes the frame to render on every mouse move when the tool is active.

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -62,12 +62,45 @@ export default class BaseTool {
   }
 
   /**
-   * Clears the tools options.
+   * Clears the tools options; preserves internal options, but
+   * with `undefined` values.
    *
    * @memberof BaseTool
    */
   clearOptions () {
     this._options = {};
+    this.internalOptions().forEach((option) => {
+      this._options[option] = undefined;
+    });
+  }
+
+  /**
+   * Internal options that "MUST" be in the tool's options if
+   * certain conditions are met. Method is also good for inspecting
+   * options that can be used to change tool behavior.
+   *
+   * @readonly
+   * @memberof BaseTool
+   */
+  get internalOptions () {
+    const internalOptions = [];
+
+    // Should be on _every_ mouse tool
+    if (this.supportedInteractionTypes.contains('mouse')) {
+      internalOptions.push('mouseButtonMask');
+    }
+
+    // Should be on _every_ tool that is touch AND mouse?
+    // Because doubleTap, pinch, etc. won't ever be set to "ACTIVE"
+    // Unless the intent is to set `isTouchActive` true?
+    if (
+      this.supportedInteractionTypes.contains('mouse') &&
+      this.supportedInteractionTypes.contains('touch')
+    ) {
+      internalOptions.push('isTouchActive');
+    }
+
+    return internalOptions;
   }
 
   /**

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -57,7 +57,7 @@ export default class BaseTool {
    *
    * @memberof BaseTool
    */
-  set options (options) {
+  addOptions (options) {
     this._options = Object.assign({}, this._options, options);
   }
 

--- a/src/eventDispatchers/shared/customCallbackHandler.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.js
@@ -15,10 +15,11 @@ export default function (handlerType, customFunction, evt) {
 
   if (handlerType === 'touch') {
     tools = tools.filter(
-      (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
-    );  
+      (tool) =>
+        tool.options.isTouchActive || tool.options.isTouchActive === undefined
+    );
   }
-  
+
   tools = tools.filter((tool) => typeof tool[customFunction] === 'function');
 
   if (tools.length === 0) {

--- a/src/eventDispatchers/shared/customCallbackHandler.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.js
@@ -14,10 +14,7 @@ export default function (handlerType, customFunction, evt) {
   tools = getActiveToolsForElement(element, tools);
 
   if (handlerType === 'touch') {
-    tools = tools.filter(
-      (tool) =>
-        tool.options.isTouchActive || tool.options.isTouchActive === undefined
-    );
+    tools = tools.filter((tool) => tool.options.isTouchActive);
   }
 
   tools = tools.filter((tool) => typeof tool[customFunction] === 'function');

--- a/src/eventDispatchers/touchEventHandlers/touchStart.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStart.js
@@ -12,7 +12,6 @@ import triggerEvent from '../../util/triggerEvent.js';
 import getInteractiveToolsForElement from '../../store/getInteractiveToolsForElement.js';
 import getToolsWithDataForElement from '../../store/getToolsWithDataForElement.js';
 
-
 export default function (evt) {
   console.log('touchStart');
   if (state.isToolLocked) {
@@ -25,8 +24,10 @@ export default function (evt) {
   const coords = eventData.startPoints.canvas;
 
   let tools = getInteractiveToolsForElement(element, getters.touchTools());
+
   tools = tools.filter(
-    (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
+    (tool) =>
+      tool.options.isTouchActive || tool.options.isTouchActive === undefined
   );
   const activeTools = tools.filter((tool) => tool.mode === 'active');
 

--- a/src/eventDispatchers/touchEventHandlers/touchStart.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStart.js
@@ -25,10 +25,7 @@ export default function (evt) {
 
   let tools = getInteractiveToolsForElement(element, getters.touchTools());
 
-  tools = tools.filter(
-    (tool) =>
-      tool.options.isTouchActive || tool.options.isTouchActive === undefined
-  );
+  tools = tools.filter((tool) => tool.options.isTouchActive);
   const activeTools = tools.filter((tool) => tool.mode === 'active');
 
   // If any tools are active, check if they have a special reason for dealing with the event.

--- a/src/eventDispatchers/touchEventHandlers/touchStartActive.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStartActive.js
@@ -12,10 +12,7 @@ export default function (evt) {
   const element = evt.detail.element;
   let tools = getActiveToolsForElement(element, getters.touchTools());
 
-  tools = tools.filter(
-    (tool) =>
-      tool.options.isTouchActive || tool.options.isTouchActive === undefined
-  );
+  tools = tools.filter((tool) => tool.options.isTouchActive);
 
   if (tools.length === 0) {
     return;

--- a/src/eventDispatchers/touchEventHandlers/touchStartActive.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStartActive.js
@@ -11,15 +11,16 @@ export default function (evt) {
 
   const element = evt.detail.element;
   let tools = getActiveToolsForElement(element, getters.touchTools());
-  
+
   tools = tools.filter(
-    (tool) => tool.options.touchEnable || tool.options.touchEnable === undefined
+    (tool) =>
+      tool.options.isTouchActive || tool.options.isTouchActive === undefined
   );
 
   if (tools.length === 0) {
     return;
   }
-  
+
   const activeTool = tools[0];
 
   // Note: custom `addNewMeasurement` will need to prevent event bubbling

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -19,7 +19,19 @@ const setToolActiveForElement = setToolModeForElement.bind(
   'active',
   null
 );
-const setToolActive = setToolMode.bind(null, 'active', null);
+/**
+ *
+ * @export
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
+ * @returns
+ */
+const setToolActive = function (toolName, options, isTouchActive) {
+  state.enabledElements.forEach((element) => {
+    setToolActiveForElement(element, toolName, options, isTouchActive);
+  });
+};
 
 /**
  * Sets a tool's state to 'disabled'. Disabled tools are not rendered,
@@ -37,6 +49,15 @@ const setToolDisabledForElement = setToolModeForElement.bind(
   'disabled',
   null
 );
+
+/**
+ *
+ * @export
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
+ * @returns
+ */
 const setToolDisabled = setToolMode.bind(null, 'disabled', null);
 
 /**
@@ -55,6 +76,15 @@ const setToolEnabledForElement = setToolModeForElement.bind(
   'enabled',
   null
 );
+
+/**
+ *
+ * @export
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
+ * @returns
+ */
 const setToolEnabled = setToolMode.bind(null, 'enabled', null);
 
 /**
@@ -73,6 +103,15 @@ const setToolPassiveForElement = setToolModeForElement.bind(
   'passive',
   EVENTS.TOOL_DEACTIVATED
 );
+
+/**
+ *
+ * @export
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
+ * @returns
+ */
 const setToolPassive = setToolMode.bind(
   null,
   'passive',

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -23,14 +23,7 @@ const setToolActiveForElement = function (
   const tool = getToolForElement(element, toolName);
 
   if (tool) {
-    _setActiveToolWithMatchingMouseButtonMaskToPassive(tool, element, options);
-    _setActiveToolWithIsTouchActiveToFalse(
-      tool,
-      element,
-      options,
-      isTouchActive
-    );
-
+    _resolveInputConflicts(element, tool, options, isTouchActive);
     // TODO: Find active tool w/ active two finger?
     // TODO: Find active tool w/ ...?
   }
@@ -236,18 +229,31 @@ function setToolMode (mode, changeEvent, toolName, options, isTouchActive) {
 }
 
 /**
+ * Find tool's that conflict with the incoming tool's mouse/touch bindings and
+ * resolve those conflicts.
  *
+ * @param {*} element
+ * @param {*} tool
+ * @param {*} options
+ * @param {*} isTouchActive
+ * @private
+ */
+function _resolveInputConflicts (element, tool, options, isTouchActive) {
+  _resolveMouseInputConflicts(tool, element, options);
+  _resolveTouchInputConflicts(tool, element, options, isTouchActive);
+}
+
+/**
+ * Try to find an active tool that use the same mouse button mask as
+ * the input tool. If found, set that tool to `passive` to prevent
+ * conflicts.
  *
  * @param {*} element
  * @param {*} options
  * @param {*} isTouchActive
  * @private
  */
-function _setActiveToolWithMatchingMouseButtonMaskToPassive (
-  tool,
-  element,
-  options
-) {
+function _resolveMouseInputConflicts (tool, element, options) {
   const mouseButtonMask =
     (typeof options === 'number' ? options : options.mouseButtonMask) ||
     tool.options.mouseButtonMask;
@@ -272,21 +278,21 @@ function _setActiveToolWithMatchingMouseButtonMaskToPassive (
 }
 
 /**
+ * If the incoming tool isTouchActive, find any conflicting tools
+ * and set their isTouchActive to false to avoid conflicts.
  *
- *
+ * @param {*} tool
  * @param {*} element
  * @param {*} options
  * @param {*} isTouchActive
  * @private
  */
-function _setActiveToolWithIsTouchActiveToFalse (
-  tool,
-  element,
-  options,
-  isTouchActive
-) {
+function _resolveTouchInputConflicts (tool, element, options, isTouchActive) {
   let value;
 
+  // There are multiple ways to set `isTouchActive`. This section of logic
+  // Sets `value` to the incoming tool's resulting `isTouchActive` after the
+  // Mode is set
   if (typeof options === 'number' && typeof isTouchActive === 'boolean') {
     value = isTouchActive === true;
   } else if (

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -24,6 +24,11 @@ const setToolActiveForElement = function (
   // Find active tool w/ active touch
   // Find active tool w/ active two finger?
   // Find active tool w/ ...?
+  const tool = getToolForElement(element, toolName);
+
+  if (tool) {
+    _setActiveToolWithMatchingMouseButtonMaskToPassive(tool, element, options);
+  }
 
   // Resume normal behavior
   setToolModeForElement(
@@ -225,6 +230,41 @@ function setToolMode (mode, changeEvent, toolName, options, isTouchActive) {
   });
 }
 
+/**
+ *
+ *
+ * @param {*} element
+ * @param {*} options
+ * @param {*} isTouchActive
+ * @private
+ */
+function _setActiveToolWithMatchingMouseButtonMaskToPassive (
+  tool,
+  element,
+  options
+) {
+  const mouseButtonMask =
+    (typeof options === 'number' ? options : options.mouseButtonMask) ||
+    tool.options.mouseButtonMask;
+  const hasMouseButtonMask =
+    mouseButtonMask !== undefined && mouseButtonMask > 0;
+  const activeToolWithMatchingMouseButtonMask = state.tools.find(
+    (tool) =>
+      tool.element === element &&
+      tool.mode === 'active' &&
+      tool.options.mouseButtonMask === mouseButtonMask
+  );
+
+  if (hasMouseButtonMask && activeToolWithMatchingMouseButtonMask) {
+    console.info(
+      `Setting tool ${activeToolWithMatchingMouseButtonMask.name} to passive`
+    );
+    setToolPassiveForElement(
+      element,
+      activeToolWithMatchingMouseButtonMask.name
+    );
+  }
+}
 export {
   setToolActive,
   setToolActiveForElement,

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -8,9 +8,10 @@ import { state } from './../store/index.js';
  * respond to user input, and can create new data
  *
  * @export
- * @param {*} element
- * @param {*} toolName
- * @param {*} options
+ * @param {object} element
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  * @returns
  */
 const setToolActiveForElement = setToolModeForElement.bind(
@@ -25,9 +26,10 @@ const setToolActive = setToolMode.bind(null, 'active', null);
  * and do not respond to user input
  *
  * @export
- * @param {*} element
- * @param {*} toolName
- * @param {*} options
+ * @param {object} element
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  * @returns
  */
 const setToolDisabledForElement = setToolModeForElement.bind(
@@ -42,9 +44,10 @@ const setToolDisabled = setToolMode.bind(null, 'disabled', null);
  * but do not respond to user input
  *
  * @export
- * @param {*} element
- * @param {*} toolName
- * @param {*} options
+ * @param {object} element
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  * @returns
  */
 const setToolEnabledForElement = setToolModeForElement.bind(
@@ -59,9 +62,10 @@ const setToolEnabled = setToolMode.bind(null, 'enabled', null);
  * but do not create new measurements or annotations.
  *
  * @export
- * @param {*} element
- * @param {*} toolName
- * @param {*} options
+ * @param {object} element
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  * @returns
  */
 const setToolPassiveForElement = setToolModeForElement.bind(
@@ -79,12 +83,12 @@ const setToolPassive = setToolMode.bind(
  * An internal method that helps make sure we change tool state in a consistent
  * way
  *
- * @param {*} mode
- * @param {*} changeEvent
- * @param {*} element
- * @param {*} toolName
- * @param {*} options
- * @param {*} isTouchActive
+ * @param {string} mode
+ * @param {string} changeEvent
+ * @param {object} element
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  * @returns
  */
 function setToolModeForElement (
@@ -138,10 +142,11 @@ function setToolModeForElement (
 /**
  * A helper/quick way to set a tool's mode for all canvases
  *
- * @param {*} mode
- * @param {*} changeEvent
- * @param {*} toolName
- * @param {*} options
+ * @param {string} mode
+ * @param {string} changeEvent
+ * @param {string} toolName
+ * @param {(object|number)} options
+ * @param {boolean} isTouchActive
  */
 function setToolMode (mode, changeEvent, toolName, options, isTouchActive) {
   state.enabledElements.forEach((element) => {

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -24,7 +24,7 @@ const setToolActiveForElement = function (
 
   if (tool) {
     _setActiveToolWithMatchingMouseButtonMaskToPassive(tool, element, options);
-    _setActiveToolWithIsTouchActiveToPassive(
+    _setActiveToolWithIsTouchActiveToFalse(
       tool,
       element,
       options,
@@ -279,7 +279,7 @@ function _setActiveToolWithMatchingMouseButtonMaskToPassive (
  * @param {*} isTouchActive
  * @private
  */
-function _setActiveToolWithIsTouchActiveToPassive (
+function _setActiveToolWithIsTouchActiveToFalse (
   tool,
   element,
   options,
@@ -310,7 +310,7 @@ function _setActiveToolWithIsTouchActiveToPassive (
   }
 
   if (activeToolWithIsTouchActive) {
-    setToolPassiveForElement(element, activeToolWithIsTouchActive.name);
+    activeToolWithIsTouchActive.options.isTouchActive = false;
   }
 }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -239,8 +239,18 @@ function setToolMode (mode, changeEvent, toolName, options, isTouchActive) {
  * @private
  */
 function _resolveInputConflicts (element, tool, options, isTouchActive) {
-  _resolveMouseInputConflicts(tool, element, options);
-  _resolveTouchInputConflicts(tool, element, options, isTouchActive);
+  // There are two API overloads for changing a tool's mode. This helps us
+  // Determine where to find our mask values.
+  const isValueApiOverload = typeof options === 'number';
+  const mouseButtonMaskValue = isValueApiOverload
+    ? options
+    : options.mouseButtonMask;
+  const isTouchActiveValue = isValueApiOverload
+    ? isTouchActive
+    : options.isTouchActive;
+
+  _resolveMouseInputConflicts(tool, element, mouseButtonMaskValue);
+  _resolveTouchInputConflicts(tool, element, isTouchActiveValue);
 }
 
 /**
@@ -253,10 +263,7 @@ function _resolveInputConflicts (element, tool, options, isTouchActive) {
  * @param {*} isTouchActive
  * @private
  */
-function _resolveMouseInputConflicts (tool, element, options) {
-  const mouseButtonMask =
-    (typeof options === 'number' ? options : options.mouseButtonMask) ||
-    tool.options.mouseButtonMask;
+function _resolveMouseInputConflicts (tool, element, mouseButtonMask) {
   const hasMouseButtonMask =
     mouseButtonMask !== undefined && mouseButtonMask > 0;
   const activeToolWithMatchingMouseButtonMask = state.tools.find(
@@ -287,36 +294,18 @@ function _resolveMouseInputConflicts (tool, element, options) {
  * @param {*} isTouchActive
  * @private
  */
-function _resolveTouchInputConflicts (tool, element, options, isTouchActive) {
-  let value;
-
-  // There are multiple ways to set `isTouchActive`. This section of logic
-  // Sets `value` to the incoming tool's resulting `isTouchActive` after the
-  // Mode is set
-  if (typeof options === 'number' && typeof isTouchActive === 'boolean') {
-    value = isTouchActive === true;
-  } else if (
-    typeof options === 'object' &&
-    typeof options.isTouchActive === 'boolean'
-  ) {
-    value = options.isTouchActive === true;
-  } else {
-    value = tool.options.isTouchActive;
-  }
-
-  let activeToolWithIsTouchActive;
-
-  if (typeof value === 'boolean' && value === true) {
-    activeToolWithIsTouchActive = state.tools.find(
+function _resolveTouchInputConflicts (tool, element, isTouchActive) {
+  if (isTouchActive === true) {
+    const activeToolWithIsTouchActive = state.tools.find(
       (tool) =>
         tool.element === element &&
         tool.mode === 'active' &&
         tool.options.isTouchActive === true
     );
-  }
 
-  if (activeToolWithIsTouchActive) {
-    activeToolWithIsTouchActive.options.isTouchActive = false;
+    if (activeToolWithIsTouchActive) {
+      activeToolWithIsTouchActive.options.isTouchActive = false;
+    }
   }
 }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -14,11 +14,28 @@ import { state } from './../store/index.js';
  * @param {boolean} isTouchActive
  * @returns
  */
-const setToolActiveForElement = setToolModeForElement.bind(
-  null,
-  'active',
-  null
-);
+const setToolActiveForElement = function (
+  element,
+  toolName,
+  options,
+  isTouchActive
+) {
+  // Find active tool w/ matching mouseButtonMask
+  // Find active tool w/ active touch
+  // Find active tool w/ active two finger?
+  // Find active tool w/ ...?
+
+  // Resume normal behavior
+  setToolModeForElement(
+    'active',
+    null,
+    element,
+    toolName,
+    options,
+    isTouchActive
+  );
+};
+
 /**
  *
  * @export

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -79,26 +79,39 @@ const setToolPassive = setToolMode.bind(
  * An internal method that helps make sure we change tool state in a consistent
  * way
  *
+ * @param {*} mode
+ * @param {*} changeEvent
  * @param {*} element
  * @param {*} toolName
  * @param {*} options
- * @param {*} mode
- * @param {*} changeEvent
+ * @param {*} isTouchActive
  * @returns
  */
-function setToolModeForElement (mode, changeEvent, element, toolName, options) {
+function setToolModeForElement (
+  mode,
+  changeEvent,
+  element,
+  toolName,
+  options,
+  isTouchActive
+) {
   const tool = getToolForElement(element, toolName);
 
   if (!tool) {
-    console.error(`Unable to find tool '${toolName}' for enabledElement`);
+    console.warn(`Unable to find tool '${toolName}' for enabledElement`);
 
     return;
   }
 
   // Set mode & options
   tool.mode = mode;
-  if (options) {
+  if (typeof options === 'object') {
     tool.options = Object.assign({}, tool.options, options);
+  } else if (typeof options === 'number') {
+    options = {
+      mouseButtonMaske: options,
+      isTouchActive: isTouchActive === undefined ? false : isTouchActive
+    };
   }
 
   // Call tool's hook for this event, if one exists
@@ -130,9 +143,16 @@ function setToolModeForElement (mode, changeEvent, element, toolName, options) {
  * @param {*} toolName
  * @param {*} options
  */
-function setToolMode (mode, changeEvent, toolName, options) {
+function setToolMode (mode, changeEvent, toolName, options, isTouchActive) {
   state.enabledElements.forEach((element) => {
-    setToolModeForElement(mode, changeEvent, element, toolName, options);
+    setToolModeForElement(
+      mode,
+      changeEvent,
+      element,
+      toolName,
+      options,
+      isTouchActive
+    );
   });
 }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -110,7 +110,7 @@ function setToolModeForElement (
   } else if (typeof options === 'number') {
     options = {
       mouseButtonMaske: options,
-      isTouchActive: isTouchActive === undefined ? false : isTouchActive
+      isTouchActive: isTouchActive === true
     };
   }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -20,14 +20,19 @@ const setToolActiveForElement = function (
   options,
   isTouchActive
 ) {
-  // Find active tool w/ matching mouseButtonMask
-  // Find active tool w/ active touch
-  // Find active tool w/ active two finger?
-  // Find active tool w/ ...?
   const tool = getToolForElement(element, toolName);
 
   if (tool) {
     _setActiveToolWithMatchingMouseButtonMaskToPassive(tool, element, options);
+    _setActiveToolWithIsTouchActiveToPassive(
+      tool,
+      element,
+      options,
+      isTouchActive
+    );
+
+    // TODO: Find active tool w/ active two finger?
+    // TODO: Find active tool w/ ...?
   }
 
   // Resume normal behavior
@@ -265,6 +270,50 @@ function _setActiveToolWithMatchingMouseButtonMaskToPassive (
     );
   }
 }
+
+/**
+ *
+ *
+ * @param {*} element
+ * @param {*} options
+ * @param {*} isTouchActive
+ * @private
+ */
+function _setActiveToolWithIsTouchActiveToPassive (
+  tool,
+  element,
+  options,
+  isTouchActive
+) {
+  let value;
+
+  if (typeof options === 'number' && typeof isTouchActive === 'boolean') {
+    value = isTouchActive === true;
+  } else if (
+    typeof options === 'object' &&
+    typeof options.isTouchActive === 'boolean'
+  ) {
+    value = options.isTouchActive === true;
+  } else {
+    value = tool.options.isTouchActive;
+  }
+
+  let activeToolWithIsTouchActive;
+
+  if (typeof value === 'boolean' && value === true) {
+    activeToolWithIsTouchActive = state.tools.find(
+      (tool) =>
+        tool.element === element &&
+        tool.mode === 'active' &&
+        tool.options.isTouchActive === true
+    );
+  }
+
+  if (activeToolWithIsTouchActive) {
+    setToolPassiveForElement(element, activeToolWithIsTouchActive.name);
+  }
+}
+
 export {
   setToolActive,
   setToolActiveForElement,

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -163,16 +163,24 @@ function setToolModeForElement (
     return;
   }
 
+  // MouseButtonMask (and isTouchActive) provided as values
+  if (typeof options === 'number') {
+    options = {
+      mouseButtonMask: options
+    };
+
+    if (isTouchActive === true || isTouchActive === false) {
+      options.isTouchActive = isTouchActive === true;
+    }
+  }
+  // Options is an object, or null/undefined
+  else {
+    options = options || {};
+  }
+
   // Set mode & options
   tool.mode = mode;
-  if (typeof options === 'object') {
-    tool.options = Object.assign({}, tool.options, options);
-  } else if (typeof options === 'number') {
-    options = {
-      mouseButtonMaske: options,
-      isTouchActive: isTouchActive === true
-    };
-  }
+  tool.options = Object.assign({}, tool.options, options);
 
   // Call tool's hook for this event, if one exists
   if (tool[`${mode}Callback`]) {


### PR DESCRIPTION
### Previously
```js
csTools.setToolActive('Length') // OR
csTools.setToolActive('Length', { mouseButtonMask: 1 });
```

### Now
```js
// ~~ Still works
csTools.setToolActive('Length'); // OR
csTools.setToolActive('Length', { mouseButtonMask: 1 }); // OR

// ~~ Also Works
csTools.setToolActive('Length', {
    mouseButtonMask: 1,
    isTouchActive: true
}); // OR
csTools.setToolActive('Length', 1); // OR
csTools.setToolActive('Length', 1, true); // OR
```

Addresses: https://github.com/cornerstonejs/cornerstoneTools/projects/1#card-12693686
CC: @diego0020 

> We need a way to _not_ activate a tool for touch, such that activating many tools at once doesn't leave multiple tools for touch fighting for an event by accident.