### PR TITLE
Fixed roi stats recalc on handle move.

### DIFF
--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -44,6 +44,11 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
     element.removeEventListener(EVENTS.MOUSE_DRAG, mouseDragCallback);
     element.removeEventListener(EVENTS.MOUSE_UP, mouseUpCallback);
     element.removeEventListener(EVENTS.MOUSE_CLICK, mouseUpCallback);
+
+    if (data.invalidated !== undefined) {
+      data.invalidated = true;
+    }
+
     external.cornerstone.updateImage(element);
 
     if (typeof doneMovingCallback === 'function') {

--- a/src/util/findAndMoveHelpers.js
+++ b/src/util/findAndMoveHelpers.js
@@ -4,7 +4,9 @@ import moveAllHandles from '../manipulators/moveAllHandles.js';
 import moveHandle from '../manipulators/moveHandle.js';
 
 const moveHandleNearImagePoint = function (evt, handle, data, toolName) {
-  // Todo: We've grabbed a handle, stop listening/ignore for MOUSE_MOVE
+  const eventData = evt.detail;
+  const elememt = eventData.element;
+
   data.active = true;
   state.isToolLocked = true;
   moveHandle(

--- a/src/util/findAndMoveHelpers.js
+++ b/src/util/findAndMoveHelpers.js
@@ -4,11 +4,9 @@ import moveAllHandles from '../manipulators/moveAllHandles.js';
 import moveHandle from '../manipulators/moveHandle.js';
 
 const moveHandleNearImagePoint = function (evt, handle, data, toolName) {
-  const eventData = evt.detail;
-  const elememt = eventData.element;
-
   data.active = true;
   state.isToolLocked = true;
+  
   moveHandle(
     evt.detail,
     toolName,


### PR DESCRIPTION
Fixes bug whereby vNext's `RectangleRoiTool` and `EllipticalRoiTool` didn't update stats when you move their handles.