### PR TITLE
Fix manipulation of tool's options property

### DIFF
--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -183,7 +183,7 @@ function setToolModeForElement (
 
   // Set mode & options
   tool.mode = mode;
-  tool.options = Object.assign({}, tool.options, options);
+  tool.addOptions(options);
 
   // Call tool's hook for this event, if one exists
   if (tool[`${mode}Callback`]) {

--- a/src/store/setToolOptions.js
+++ b/src/store/setToolOptions.js
@@ -13,7 +13,7 @@ const setToolOptionsForElement = function (element, toolName, options) {
   const tool = getToolForElement(element, toolName);
 
   if (tool) {
-    tool.options = Object.assign({}, tool.options, options);
+    tool.addOptions(options);
   }
 };
 


### PR DESCRIPTION
Base Tools has being changed lately and places that we were setting options should be using `addOptions` instead. 
