### PR TITLE
Fix image position synchronizers using previous source image

### DIFF
--- a/src/synchronization/stackImagePositionOffsetSynchronizer.js
+++ b/src/synchronization/stackImagePositionOffsetSynchronizer.js
@@ -16,8 +16,9 @@ export default function (synchronizer, sourceElement, targetElement, eventData, 
   }
 
   const cornerstone = external.cornerstone;
-  const sourceEnabledElement = cornerstone.getEnabledElement(sourceElement);
-  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceEnabledElement.image.imageId);
+  const sourceStackData = getToolState(sourceElement, 'stack').data[0];
+  const sourceImageId = sourceStackData.imageIds[sourceStackData.currentImageIdIndex];
+  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImageId);
 
   if (sourceImagePlane === undefined || sourceImagePlane.imagePositionPatient === undefined) {
     return;

--- a/src/synchronization/stackImagePositionSynchronizer.js
+++ b/src/synchronization/stackImagePositionSynchronizer.js
@@ -13,8 +13,9 @@ export default function (synchronizer, sourceElement, targetElement) {
   }
 
   const cornerstone = external.cornerstone;
-  const sourceImage = cornerstone.getEnabledElement(sourceElement).image;
-  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImage.imageId);
+  const sourceStackData = getToolState(sourceElement, 'stack').data[0];
+  const sourceImageId = sourceStackData.imageIds[sourceStackData.currentImageIdIndex];
+  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImageId);
 
   if (sourceImagePlane === undefined || sourceImagePlane.imagePositionPatient === undefined) {
     // Console.log('No position found for image ' + sourceImage.imageId);


### PR DESCRIPTION
The `stackImagePositionSynchronizer` and `stackImagePositionOffsetSynchronizer` were both using `cornerstone.getEnabledElement(sourceElement).image.imageId`.  When these synchronizers are called, that image has not yet been updated from the scroll event, which means all the distance calculations are done against the previous image.

Getting the source `imageId` via the stack data `getToolState(sourceElement, 'stack').data[0]` (the same way the _target_ `imageId` is retrieved later) gives us the correct image because the stack's `currentImageIdIndex` has already been updated when this is called.
