### PR TITLE
vNext Freehand UX

### DIFF
--- a/src/tools/FreehandMouseTool.js
+++ b/src/tools/FreehandMouseTool.js
@@ -877,8 +877,6 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     const element = eventData.element;
     const mousePoint = config.mouseLocation.handles.start;
 
-    console.log(mousePoint);
-
     const handleFurtherThanMinimumSpacing = ((handle) => {
       return this._isDistanceLargerThanSpacingCanvas(element, handle, mousePoint);
     }).bind(this);
@@ -1085,6 +1083,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    *
    * @private
    * @param {Object} data - data object associated with the tool.
+   * @param {Object} eventData The data associated with the event.
    * @return {Boolean}
    */
   _checkHandlesPencilMode (data, eventData) {
@@ -1148,6 +1147,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
   /**
    * Returns true if two points are closer than this.configuration.spacing.
    *
+   * @private
    * @param  {Object} element     The element on which the roi is being drawn.
    * @param  {Object} p1          The first point, in pixel space.
    * @param  {Object} p2          The second point, in pixel space.
@@ -1161,6 +1161,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
   /**
    * Returns true if two points are farther than this.configuration.spacing.
    *
+   * @private
    * @param  {Object} element     The element on which the roi is being drawn.
    * @param  {Object} p1          The first point, in pixel space.
    * @param  {Object} p2          The second point, in pixel space.
@@ -1174,6 +1175,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
   /**
    * Compares the distance between two points to this.configuration.spacing.
    *
+   * @private
    * @param  {Object} element     The element on which the roi is being drawn.
    * @param  {Object} p1          The first point, in pixel space.
    * @param  {Object} p2          The second point, in pixel space.

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -66,6 +66,14 @@ export default class FreehandSculpterMouseTool extends BaseTool {
     }
   }
 
+  doubleClickCallback (evt) {
+    const eventData = evt.detail;
+
+    this._selectFreehandTool(eventData);
+
+    external.cornerstone.updateImage(eventData.element);
+  }
+
   /**
    * Event handler for MOUSE_DOWN.
    *
@@ -77,24 +85,15 @@ export default class FreehandSculpterMouseTool extends BaseTool {
 
     let imageNeedsUpdate = false;
 
-    if (eventData.event.ctrlKey) {
-      // Select
+    if (config.currentTool === null) {
       this._selectFreehandTool(eventData);
-      imageNeedsUpdate = true;
-    } else if (config.currentTool !== null) {
-      // Drag
+    } else {
       this._initialiseSculpting(eventData);
-      imageNeedsUpdate = true;
     }
 
-    if (imageNeedsUpdate) {
-      // Force onImageRendered
-      external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(eventData.element);
 
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   /**
@@ -1145,11 +1144,6 @@ function getDefaultFreehandSculpterMouseToolConfiguration () {
           active: true
         }
       }
-    },
-    keyDown: {
-      shift: false,
-      ctrl: false,
-      alt: false
     },
     minSpacing: 5,
     maxSpacing: 20,


### PR DESCRIPTION
Based on a combination of some recent feedback and in the interest of keyboard clutter, both the `FreehandMouseTool` and the `FreehandSculpterMouseTool` no longer use modifier keys.

`FreehandMouseTool`:
- Polygon and and Pencil modes are now baked into user input rather than activating with a modifier key. You can also freely switch between the two whilst drawing the ROI.
- Dragging with the mouse uses pencil mode.
- click -> move -> click -> ... allows you to place points manually (polygon mode).

`FreehandSculpterMouseTool`:
- When first activated, with no ROI selected, clicking/double-clicking near an ROI will make it the subject.
- You can change subject ROI by double-clicking near a new subject.
- Sculpting your subject ROI works as before.