### PR TITLE
fix: disable zoomCanvas instead of zoomElement, avoid events to be unbound

### DIFF
--- a/src/tools/MagnifyTool.js
+++ b/src/tools/MagnifyTool.js
@@ -206,7 +206,7 @@ export default class MagnifyTool extends BaseTool {
    */
   _removeZoomElement () {
     if (this.zoomElement !== undefined) {
-      external.cornerstone.disable(this.zoomElement);
+      external.cornerstone.disable(this.zoomCanvas);
       this.zoomElement = undefined;
       this.zoomCanvas = undefined;
     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes #634 


* **What is the current behavior?** (You can also link to an open issue here)
After using Magnifying glasses once no tool work anymore


* **What is the new behavior (if this is a feature change)?**
Magnifying can be used multiple time and any other tool too


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
