### PR TITLE
Fixes being able to set shadowOptions to falsy values, adds shadowBlu…

### DIFF
--- a/src/util/drawing.js
+++ b/src/util/drawing.js
@@ -1,5 +1,6 @@
 import external from '../externalModules.js';
 import { toolStyle, textStyle } from '../index.js';
+import { getDefault } from './getDefault.js'
 
 /**
  * A {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle|color, gradient or pattern} to use inside shapes.
@@ -90,14 +91,16 @@ export function path (context, options, fn) {
  * @param {Object} options
  * @param {Boolean} options.shadow - Whether to set any shadow options
  * @param {String} options.shadowColor - Default value: #000000
+ * @param {Number} options.shadowBlur - Default Value: 0
  * @param {Number} options.shadowOffsetX - Default value: 1
  * @param {Number} options.shadowOffsetY - Default value: 1
  */
 export function setShadow (context, options) {
   if (options.shadow) {
-    context.shadowColor = options.shadowColor || '#000000';
-    context.shadowOffsetX = options.shadowOffsetX || 1;
-    context.shadowOffsetY = options.shadowOffsetY || 1;
+    context.shadowColor = getDefault(options.shadowColor, '#000000');
+    context.shadowBlur = getDefault(options.shadowBlur, 0);
+    context.shadowOffsetX = getDefault(options.shadowOffsetX, 1);
+    context.shadowOffsetY = getDefault(options.shadowOffsetY, 1);
   }
 }
 

--- a/src/util/getDefault.js
+++ b/src/util/getDefault.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the first argument if defined, otherwise returns the second
+ *
+ * @param {any} value
+ * @param {any} defaultValue
+ */
+export function getDefault (value, defaultValue) {
+    return value !== undefined ? value : defaultValue;
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I didn't do any changes to tests or docs

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When setting shadowOffsetX, if 0 is provided it instead uses 1 from the defaults.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It fixes broken behaviour, if someone is relying on the broken behaviour then it will break for them.


* **Other information**:
I also added in the shadowBlur option, which was missing before