### PR TITLE
Prevent circular import dependency

### DIFF
--- a/src/util/drawing.js
+++ b/src/util/drawing.js
@@ -1,5 +1,6 @@
 import external from '../externalModules.js';
-import { toolStyle, textStyle } from '../index.js';
+import { default as toolStyle } from '../stateManagement/toolStyle.js';
+import { default as textStyle } from '../stateManagement/textStyle.js';
 
 /**
  * A {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle|color, gradient or pattern} to use inside shapes.


### PR DESCRIPTION
import toolStyle and textStyle from where they are defined instead of index.js
