### PR TITLE
Use wheel event only in mouseWheelInput.js

### DIFF
--- a/src/inputSources/mouseWheelInput.js
+++ b/src/inputSources/mouseWheelInput.js
@@ -23,7 +23,7 @@ function mouseWheel (e) {
   if (e.type === 'DOMMouseScroll' && e.axis === 1) {
     return;
   }
-
+  
   e.preventDefault();
 
   let x;
@@ -70,7 +70,7 @@ function mouseWheel (e) {
   triggerEvent(element, EVENTS.MOUSE_WHEEL, mouseWheelData);
 }
 
-const mouseWheelEvents = ['mousewheel', 'DOMMouseScroll'];
+const mouseWheelEvents = ['wheel'];
 
 function enable (element) {
   // Prevent handlers from being attached multiple times


### PR DESCRIPTION
Previously, both mousewheel and DOMMouseScroll Events were used, the
latter of which is firefox specific. DOMMouseScroll shows problems when
two finger scrolling on Laptops. Newer browser versions all use the
standardized wheel event now, which should be the right thing to use
here.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

See [this issue](https://github.com/cornerstonejs/cornerstoneTools/issues/643)
