### PR TITLE
bugfix defaulting rowPixelSpacing and colPixelSpacing to 1

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -97,10 +97,12 @@ function onImageRendered (e) {
 
       // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
       // Where lines cross to measure angle. For now it will show smallest angle.
-      const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * eventData.image.columnPixelSpacing;
-      const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * eventData.image.rowPixelSpacing;
-      const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * eventData.image.columnPixelSpacing;
-      const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * eventData.image.rowPixelSpacing;
+      const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
+      const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
+      const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * columnPixelSpacing;
+      const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * rowPixelSpacing;
+      const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * columnPixelSpacing;
+      const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * rowPixelSpacing;
 
       let angle = Math.acos(Math.abs(((dx1 * dx2) + (dy1 * dy2)) / (Math.sqrt((dx1 * dx1) + (dy1 * dy1)) * Math.sqrt((dx2 * dx2) + (dy2 * dy2)))));
 

--- a/src/imageTools/pan.js
+++ b/src/imageTools/pan.js
@@ -38,10 +38,13 @@ function dragCallback (e) {
   let widthScale = eventData.viewport.scale;
   let heightScale = eventData.viewport.scale;
 
-  if (eventData.image.rowPixelSpacing < eventData.image.columnPixelSpacing) {
-    widthScale *= (eventData.image.columnPixelSpacing / eventData.image.rowPixelSpacing);
-  } else if (eventData.image.columnPixelSpacing < eventData.image.rowPixelSpacing) {
-    heightScale *= (eventData.image.rowPixelSpacing / eventData.image.columnPixelSpacing);
+  const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
+  const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
+
+  if (rowPixelSpacing < columnPixelSpacing) {
+    widthScale *= (columnPixelSpacing / rowPixelSpacing);
+  } else if (columnPixelSpacing < rowPixelSpacing) {
+    heightScale *= (rowPixelSpacing / columnPixelSpacing);
   }
 
   eventData.viewport.translation.x += (eventData.deltaPoints.page.x / widthScale);

--- a/src/util/pointProjector.js
+++ b/src/util/pointProjector.js
@@ -25,10 +25,10 @@ export function imagePointToPatientPoint (imagePoint, imagePlane) {
 
   const x = rowCosines.clone().multiplyScalar(imagePoint.x);
 
-  x.multiplyScalar(imagePlane.columnPixelSpacing);
+  x.multiplyScalar(imagePlane.columnPixelSpacing || 1);
   const y = columnCosines.clone().multiplyScalar(imagePoint.y);
 
-  y.multiplyScalar(imagePlane.rowPixelSpacing);
+  y.multiplyScalar(imagePlane.rowPixelSpacing || 1);
   const patientPoint = x.add(y);
 
   patientPoint.add(imagePositionPatient);


### PR DESCRIPTION
fixes 
https://github.com/cornerstonejs/cornerstoneTools/issues/645

make sure rowPixelSpacing and colPixelSpacing default to 1 if null before being used in divisions etc ..

