### PR TITLE
feature/Smarter global add tools

### DIFF
--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -99,7 +99,7 @@ export default class BaseTool {
     return internalOptions;
   }
 
-  setDefaultStrategy() {
+  setDefaultStrategy () {
     this.activeStrategy = this.defaultStrategy;
   }
 
@@ -121,8 +121,6 @@ export default class BaseTool {
   _applyMixins (mixinsArray) {
     for (let i = 0; i < mixinsArray.length; i++) {
       const mixin = mixins[`${mixinsArray[i]}`];
-
-      console.log(mixinsArray[i]);
 
       if (typeof mixin === 'object') {
         Object.assign(this, mixin);

--- a/src/base/BaseTool.js
+++ b/src/base/BaseTool.js
@@ -1,8 +1,21 @@
 import mixins from '../mixins/index.js';
 
 /**
- * @export @abstract @class
+ * The fundemental abstract class from which all other tools inherit.
+ *
+ * @typedef {Object} BaseTool
+ * @property {String} activeStrategy Strategy name to use when a strategy needs to be applied
+ * @property {String} defaultStrategy Strategy name to "reset" the activeStrategy to if default behavior is desired
+ * @property {String} mode 1 of 4 modes that influence the tool's behavior
+ * @property {String} name
+ * @property {Object} strategies
+ * @property {Array} supportedInteractionTypes
+ */
+
+/**
+ * @export @interface @class
  * @name BaseTool
+ * @type {BaseTool}
  * @classdesc The fundemental abstract class from which all other tools inherit.
  */
 export default class BaseTool {

--- a/src/eventDispatchers/touchToolEventDispatcher.js
+++ b/src/eventDispatchers/touchToolEventDispatcher.js
@@ -28,8 +28,8 @@ import {
  */
 const enable = function (element) {
   element.addEventListener(EVENTS.TAP, tap);
-  element.addEventListener(EVENTS.TOUCH_START, touchStart);
-  element.addEventListener(EVENTS.TOUCH_DRAG, touchDrag);
+  element.addEventListener(EVENTS.TOUCH_START, touchStart, { passive: false });
+  element.addEventListener(EVENTS.TOUCH_DRAG, touchDrag, { passive: false });
   element.addEventListener(EVENTS.TOUCH_END, touchEnd);
   // Mouse equivelant is `mouse_down_activate`
   // Should the naming pattern here match?

--- a/src/eventDispatchers/touchToolEventDispatcher.test.js
+++ b/src/eventDispatchers/touchToolEventDispatcher.test.js
@@ -47,8 +47,8 @@ describe('touchToolEventDispatcher.js', () => {
     // https://github.com/jasmine/jasmine/issues/228#issuecomment-270599719
     expect(element.addEventListener.mock.calls).toEqual([
       [EVENTS.TAP, tap], // First call
-      [EVENTS.TOUCH_START, touchStart], // Second call
-      [EVENTS.TOUCH_DRAG, touchDrag],
+      [EVENTS.TOUCH_START, touchStart, { passive: false }], // Second call
+      [EVENTS.TOUCH_DRAG, touchDrag, { passive: false }],
       [EVENTS.TOUCH_END, touchEnd],
       [EVENTS.TOUCH_START_ACTIVE, touchStartActive],
       [EVENTS.TOUCH_PRESS, touchPress],

--- a/src/eventListeners/mouseWheelEventListeners.js
+++ b/src/eventListeners/mouseWheelEventListeners.js
@@ -77,7 +77,7 @@ function enable (element) {
   disable(element);
 
   mouseWheelEvents.forEach((eventType) => {
-    element.addEventListener(eventType, mouseWheel);
+    element.addEventListener(eventType, mouseWheel, { passive: false });
   });
 }
 

--- a/src/eventListeners/preventGhostClick.js
+++ b/src/eventListeners/preventGhostClick.js
@@ -38,7 +38,7 @@ function attachEvents (element, eventList, interactionType) {
   const tapHandler = interactionType ? handleTapMouse : handleTapTouch;
 
   eventList.forEach(function (eventName) {
-    element.addEventListener(eventName, tapHandler);
+    element.addEventListener(eventName, tapHandler, { passive: false });
   });
 }
 

--- a/src/eventListeners/touchEventListeners.js
+++ b/src/eventListeners/touchEventListeners.js
@@ -571,7 +571,7 @@ function enable (element) {
   const touchEvents = ['touchstart', 'touchend'];
 
   touchEvents.forEach((eventType) => {
-    element.addEventListener(eventType, onTouch);
+    element.addEventListener(eventType, onTouch, { passive: false });
   });
 
   const options = getToolOptions(toolType, element);

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -7,8 +7,8 @@ import getToolForElement from './getToolForElement.js';
  * @export @public @method
  * @name addToolForElement
  * @param {HTMLElement} element The element to add the tool to.
- * @param {baseTool} tool The tool to add to the element.
- * @param {configuration} [configuration] Override the default tool configuration
+ * @param {import('./../base/BaseTool').BaseTool} apiTool The tool to add to the element.
+ * @param {Object} [configuration] Override the default tool configuration
  */
 const addToolForElement = function (element, apiTool, configuration) {
   // Instantiating the tool here makes it harder to accidentally add
@@ -29,10 +29,12 @@ const addToolForElement = function (element, apiTool, configuration) {
 };
 
 /**
- * Adds a tool to each element.
+ * Adds a tool to all enabled element.
+ *
  * @export @public @method
  * @name addTool
- * @param {baseTool} tool The tool to add to each element.
+ * @param {import('./../base/BaseTool').BaseTool} apiTool The tool to add to each element.
+ * @param {object} [configuration] Override the default tool configuration
  */
 const addTool = function (apiTool, configuration) {
   _addToolGlobally(apiTool, configuration);
@@ -41,6 +43,15 @@ const addTool = function (apiTool, configuration) {
   });
 };
 
+/**
+ * Adds tool with matching name from globally registered tools.
+ * Requires `globalToolSyncEnabled` to be set to true
+ *
+ * @private @method
+ * @name addToolGlobally
+ * @param {import('./../base/BaseTool').BaseTool} apiTool
+ * @param {object} [configuration] Override the default tool configuration
+ */
 const _addToolGlobally = function (apiTool, configuration) {
   if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
     return;

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -38,15 +38,13 @@ const addTool = function (apiTool, configuration) {
   const tool = new apiTool(configuration);
   const toolAlreadyAddedGlobally = state.globalTools[tool.name] !== undefined;
 
-  console.log(state.globalTools[tool.name]);
-
   if (toolAlreadyAddedGlobally) {
     console.warn(`${tool.name} has already been added globally`);
 
     return;
   }
 
-  state.globalTools = state.globalTools[tool.name] = {
+  state.globalTools[tool.name] = {
     tool: apiTool,
     configuration
   };

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -1,4 +1,4 @@
-import { state } from './index.js';
+import store from './index.js';
 import getToolForElement from './getToolForElement.js';
 
 /**
@@ -25,7 +25,7 @@ const addToolForElement = function (element, apiTool, configuration) {
   }
 
   tool.element = element;
-  state.tools.push(tool);
+  store.state.tools.push(tool);
 };
 
 /**
@@ -35,8 +35,21 @@ const addToolForElement = function (element, apiTool, configuration) {
  * @param {baseTool} tool The tool to add to each element.
  */
 const addTool = function (apiTool, configuration) {
+  _addToolGlobally(apiTool, configuration);
+  store.state.enabledElements.forEach((element) => {
+    addToolForElement(element, apiTool);
+  });
+};
+
+const _addToolGlobally = function (apiTool, configuration) {
+  console.log(store.modules.globalConfiguration.state.globalToolSyncEnabled);
+  if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
+    return;
+  }
+
   const tool = new apiTool(configuration);
-  const toolAlreadyAddedGlobally = state.globalTools[tool.name] !== undefined;
+  const toolAlreadyAddedGlobally =
+    store.state.globalTools[tool.name] !== undefined;
 
   if (toolAlreadyAddedGlobally) {
     console.warn(`${tool.name} has already been added globally`);
@@ -44,14 +57,10 @@ const addTool = function (apiTool, configuration) {
     return;
   }
 
-  state.globalTools[tool.name] = {
+  store.state.globalTools[tool.name] = {
     tool: apiTool,
     configuration
   };
-
-  state.enabledElements.forEach((element) => {
-    addToolForElement(element, apiTool);
-  });
 };
 
 export { addTool, addToolForElement };

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -36,8 +36,9 @@ const addToolForElement = function (element, apiTool, configuration) {
  */
 const addTool = function (apiTool, configuration) {
   const tool = new apiTool(configuration);
-  const toolAlreadyAddedGlobally =
-    typeof state.globalTools[tool.name] !== undefined;
+  const toolAlreadyAddedGlobally = state.globalTools[tool.name] !== undefined;
+
+  console.log(state.globalTools[tool.name]);
 
   if (toolAlreadyAddedGlobally) {
     console.warn(`${tool.name} has already been added globally`);

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -42,7 +42,6 @@ const addTool = function (apiTool, configuration) {
 };
 
 const _addToolGlobally = function (apiTool, configuration) {
-  console.log(store.modules.globalConfiguration.state.globalToolSyncEnabled);
   if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
     return;
   }

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -34,7 +34,22 @@ const addToolForElement = function (element, apiTool, configuration) {
  * @name addTool
  * @param {baseTool} tool The tool to add to each element.
  */
-const addTool = function (apiTool) {
+const addTool = function (apiTool, configuration) {
+  const tool = new apiTool();
+  const toolAlreadyAddedGlobally =
+    typeof state.globalTools[tool.name] !== undefined;
+
+  if (toolAlreadyAddedGlobally) {
+    console.warn(`${tool.name} has already been added globally`);
+
+    return;
+  }
+
+  state.globalTools = state.globalTools[tool.name] = {
+    tool: apiTool,
+    configuration
+  };
+
   state.enabledElements.forEach((element) => {
     addToolForElement(element, apiTool);
   });

--- a/src/store/addTool.js
+++ b/src/store/addTool.js
@@ -35,7 +35,7 @@ const addToolForElement = function (element, apiTool, configuration) {
  * @param {baseTool} tool The tool to add to each element.
  */
 const addTool = function (apiTool, configuration) {
-  const tool = new apiTool();
+  const tool = new apiTool(configuration);
   const toolAlreadyAddedGlobally =
     typeof state.globalTools[tool.name] !== undefined;
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import globalConfiguration from './modules/globalConfigurationModule.js';
 
 export const state = {
   isToolLocked: false,
+  globalTools: {},
   tools: [],
   clickProximity: 6,
   mousePositionImage: {},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import globalConfiguration from './modules/globalConfigurationModule.js';
 export const state = {
   isToolLocked: false,
   globalTools: {},
+  globalToolChangeHistory: [],
   tools: [],
   clickProximity: 6,
   mousePositionImage: {},

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -97,6 +97,10 @@ function _initModulesOnElement (enabledElement) {
 }
 
 function _addGlobalToolsToElement (enabledElement) {
+  if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
+    return;
+  }
+
   Object.keys(store.state.globalTools).forEach(function (key) {
     const { tool, configuration } = store.state.globalTools[key];
 
@@ -105,6 +109,10 @@ function _addGlobalToolsToElement (enabledElement) {
 }
 
 function _repeatGlobalToolHistory (enabledElement) {
+  if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
+    return;
+  }
+
   const setToolModeFns = {
     active: setToolActiveForElement,
     passive: setToolPassiveForElement,

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -9,6 +9,7 @@ import {
   newImageEventDispatcher,
   touchToolEventDispatcher
 } from '../../eventDispatchers/index.js';
+import { addToolForElement } from './../addTool.js';
 import store from '../index.js';
 
 /**
@@ -69,6 +70,7 @@ const _addEnabledElmenet = function (enabledElement) {
   if (store.modules) {
     _initModulesOnElement(enabledElement);
   }
+  _addGlobalToolsToElement(enabledElement);
 };
 
 /**
@@ -84,5 +86,13 @@ function _initModulesOnElement (enabledElement) {
     if (typeof modules[key].enabledElementCallback === 'function') {
       modules[key].enabledElementCallback(enabledElement);
     }
+  });
+}
+
+function _addGlobalToolsToElement (enabledElement) {
+  Object.keys(store.state.globalTools).forEach(function (key) {
+    const { tool, configuration } = store.state.globalTools[key];
+
+    addToolForElement(enabledElement, tool, configuration);
   });
 }

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -2,15 +2,21 @@ import {
   mouseEventListeners,
   mouseWheelEventListeners,
   touchEventListeners
-} from '../../eventListeners/index.js';
+} from "../../eventListeners/index.js";
 import {
   imageRenderedEventDispatcher,
   mouseToolEventDispatcher,
   newImageEventDispatcher,
   touchToolEventDispatcher
-} from '../../eventDispatchers/index.js';
-import { addToolForElement } from './../addTool.js';
-import store from '../index.js';
+} from "../../eventDispatchers/index.js";
+import { addToolForElement } from "./../addTool.js";
+import {
+  setToolActiveForElement,
+  setToolPassiveForElement,
+  setToolEnabledForElement,
+  setToolDisabledForElement
+} from "./../setToolMode.js";
+import store from "../index.js";
 
 /**
  * Element Enabled event.
@@ -36,7 +42,7 @@ import store from '../index.js';
  * @param {Cornerstone#ElementEnabled} elementEnabledEvt
  * @listens Cornerstone#ElementEnabled
  */
-export default function (elementEnabledEvt) {
+export default function(elementEnabledEvt) {
   const enabledElement = elementEnabledEvt.detail.element;
 
   // Dispatchers
@@ -65,12 +71,13 @@ export default function (elementEnabledEvt) {
  * @private @method
  * @param {HTMLElement} enabledElement
  */
-const _addEnabledElmenet = function (enabledElement) {
+const _addEnabledElmenet = function(enabledElement) {
   store.state.enabledElements.push(enabledElement);
   if (store.modules) {
     _initModulesOnElement(enabledElement);
   }
   _addGlobalToolsToElement(enabledElement);
+  _repeatGlobalToolHistory(enabledElement);
 };
 
 /**
@@ -79,20 +86,34 @@ const _addEnabledElmenet = function (enabledElement) {
  * @private @method
  * @param  {Object} enabledElement
  */
-function _initModulesOnElement (enabledElement) {
+function _initModulesOnElement(enabledElement) {
   const modules = store.modules;
 
-  Object.keys(modules).forEach(function (key) {
-    if (typeof modules[key].enabledElementCallback === 'function') {
+  Object.keys(modules).forEach(function(key) {
+    if (typeof modules[key].enabledElementCallback === "function") {
       modules[key].enabledElementCallback(enabledElement);
     }
   });
 }
 
-function _addGlobalToolsToElement (enabledElement) {
-  Object.keys(store.state.globalTools).forEach(function (key) {
+function _addGlobalToolsToElement(enabledElement) {
+  Object.keys(store.state.globalTools).forEach(function(key) {
     const { tool, configuration } = store.state.globalTools[key];
 
     addToolForElement(enabledElement, tool, configuration);
+  });
+}
+
+function _repeatGlobalToolHistory(enabledElement) {
+  const setToolModeFns = {
+    active: setToolActiveForElement,
+    passive: setToolPassiveForElement,
+    enabled: setToolEnabledForElement,
+    disabled: setToolDisabledForElement
+  };
+
+  store.state.globalToolChangeHistory.forEach(historyEvent => {
+    const arguments = historyEvent.arguments.unshift(enabledElement);
+    setToolModeFns[historyEvent.mode].apply(null, arguments);
   });
 }

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -113,8 +113,9 @@ function _repeatGlobalToolHistory (enabledElement) {
   };
 
   store.state.globalToolChangeHistory.forEach((historyEvent) => {
-    const args = historyEvent.args.unshift(enabledElement);
+    const args = historyEvent.args.slice(0);
 
+    args.unshift(enabledElement);
     setToolModeFns[historyEvent.mode].apply(null, args);
   });
 }

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -2,21 +2,21 @@ import {
   mouseEventListeners,
   mouseWheelEventListeners,
   touchEventListeners
-} from "../../eventListeners/index.js";
+} from '../../eventListeners/index.js';
 import {
   imageRenderedEventDispatcher,
   mouseToolEventDispatcher,
   newImageEventDispatcher,
   touchToolEventDispatcher
-} from "../../eventDispatchers/index.js";
-import { addToolForElement } from "./../addTool.js";
+} from '../../eventDispatchers/index.js';
+import { addToolForElement } from './../addTool.js';
 import {
   setToolActiveForElement,
   setToolPassiveForElement,
   setToolEnabledForElement,
   setToolDisabledForElement
-} from "./../setToolMode.js";
-import store from "../index.js";
+} from './../setToolMode.js';
+import store from '../index.js';
 
 /**
  * Element Enabled event.
@@ -42,7 +42,7 @@ import store from "../index.js";
  * @param {Cornerstone#ElementEnabled} elementEnabledEvt
  * @listens Cornerstone#ElementEnabled
  */
-export default function(elementEnabledEvt) {
+export default function (elementEnabledEvt) {
   const enabledElement = elementEnabledEvt.detail.element;
 
   // Dispatchers
@@ -71,7 +71,7 @@ export default function(elementEnabledEvt) {
  * @private @method
  * @param {HTMLElement} enabledElement
  */
-const _addEnabledElmenet = function(enabledElement) {
+const _addEnabledElmenet = function (enabledElement) {
   store.state.enabledElements.push(enabledElement);
   if (store.modules) {
     _initModulesOnElement(enabledElement);
@@ -86,25 +86,25 @@ const _addEnabledElmenet = function(enabledElement) {
  * @private @method
  * @param  {Object} enabledElement
  */
-function _initModulesOnElement(enabledElement) {
+function _initModulesOnElement (enabledElement) {
   const modules = store.modules;
 
-  Object.keys(modules).forEach(function(key) {
-    if (typeof modules[key].enabledElementCallback === "function") {
+  Object.keys(modules).forEach(function (key) {
+    if (typeof modules[key].enabledElementCallback === 'function') {
       modules[key].enabledElementCallback(enabledElement);
     }
   });
 }
 
-function _addGlobalToolsToElement(enabledElement) {
-  Object.keys(store.state.globalTools).forEach(function(key) {
+function _addGlobalToolsToElement (enabledElement) {
+  Object.keys(store.state.globalTools).forEach(function (key) {
     const { tool, configuration } = store.state.globalTools[key];
 
     addToolForElement(enabledElement, tool, configuration);
   });
 }
 
-function _repeatGlobalToolHistory(enabledElement) {
+function _repeatGlobalToolHistory (enabledElement) {
   const setToolModeFns = {
     active: setToolActiveForElement,
     passive: setToolPassiveForElement,
@@ -112,8 +112,9 @@ function _repeatGlobalToolHistory(enabledElement) {
     disabled: setToolDisabledForElement
   };
 
-  store.state.globalToolChangeHistory.forEach(historyEvent => {
-    const arguments = historyEvent.arguments.unshift(enabledElement);
-    setToolModeFns[historyEvent.mode].apply(null, arguments);
+  store.state.globalToolChangeHistory.forEach((historyEvent) => {
+    const args = historyEvent.args.unshift(enabledElement);
+
+    setToolModeFns[historyEvent.mode].apply(null, args);
   });
 }

--- a/src/store/modules/globalConfigurationModule.js
+++ b/src/store/modules/globalConfigurationModule.js
@@ -1,6 +1,7 @@
 const state = {
   mouseEnabled: true,
-  touchEnabled: true
+  touchEnabled: true,
+  globalToolSyncEnabled: false
 };
 
 export default {

--- a/src/store/removeTool.js
+++ b/src/store/removeTool.js
@@ -1,34 +1,53 @@
-import { state } from './index.js';
+import store from './index.js';
 
 /**
- * Removes all tools from the target element with the provided name
+ * Deactivates and removes the tool from the target element with the provided name
+ *
  * @export @public @method
  * @name removeToolForElement
- *
  * @param {HTMLElement} element The element.
  * @param {string} toolName The name of the tool.
  */
 const removeToolForElement = function (element, toolName) {
-  const toolIndex = state.tools.findIndex(
+  const toolIndex = store.state.tools.findIndex(
     (tool) => tool.element === element && tool.name === toolName
   );
 
   if (toolIndex >= 0) {
-    state.tools.splice(toolIndex, 1);
+    store.state.tools.splice(toolIndex, 1);
   }
 };
 
 /**
  * Removes all tools from all enabled elements with the provided name.
+ *
  * @export @public @method
  * @name removeTool
- *
  * @param {string} toolName The name of the tool.
  */
 const removeTool = function (toolName) {
-  state.enabledElements.forEach((element) => {
+  _removeToolGlobally(toolName);
+  store.state.enabledElements.forEach((element) => {
     removeToolForElement(element, toolName);
   });
+};
+
+/**
+ * Removes tool with matching name from globally registered tools.
+ * Requires `globalToolSyncEnabled` to be set to true
+ *
+ * @private @method
+ * @name removeToolGlobally
+ * @param {string} toolName The name of the tool to remove.
+ */
+const _removeToolGlobally = function (toolName) {
+  if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
+    return;
+  }
+
+  if (store.state.globalTools[toolName]) {
+    delete store.state.globalTools[toolName];
+  }
 };
 
 export { removeTool, removeToolForElement };

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -436,7 +436,7 @@ function _resolveGenericInputConflicts (
 function _trackGlobalToolModeChange (mode, toolName, options, interactionTypes) {
   const historyEvent = {
     mode,
-    arguments: [toolName, options]
+    args: [toolName, options]
   };
 
   if (interactionTypes) {

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -1,7 +1,7 @@
 import EVENTS from './../events.js';
 import triggerEvent from './../util/triggerEvent.js';
 import getToolForElement from './getToolForElement.js';
-import { state } from './../store/index.js';
+import store from './../store/index.js';
 
 /**
  * Sets a tool's state, with the provided toolName and element, to 'active'. Active tools are rendered,
@@ -72,7 +72,7 @@ const setToolActiveForElement = function (
  */
 const setToolActive = function (toolName, options, interactionTypes) {
   _trackGlobalToolModeChange('active', toolName, options, interactionTypes);
-  state.enabledElements.forEach((element) => {
+  store.state.enabledElements.forEach((element) => {
     setToolActiveForElement(element, toolName, options, interactionTypes);
   });
 };
@@ -222,7 +222,7 @@ function setToolModeForElement (mode, changeEvent, element, toolName, options) {
  */
 function setToolMode (mode, changeEvent, toolName, options) {
   _trackGlobalToolModeChange(mode, toolName, options);
-  state.enabledElements.forEach((element) => {
+  store.state.enabledElements.forEach((element) => {
     setToolModeForElement(mode, changeEvent, element, toolName, options);
   });
 }
@@ -259,7 +259,7 @@ function _resolveInputConflicts (element, tool, options, interactionTypes) {
     }
   });
 
-  const activeToolsForElement = state.tools.filter(
+  const activeToolsForElement = store.state.tools.filter(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
@@ -296,7 +296,7 @@ function _resolveMouseInputConflicts (tool, element, options) {
   const hasMouseButtonMask =
     mouseButtonMask !== undefined && mouseButtonMask > 0;
 
-  const activeToolWithMatchingMouseButtonMask = state.tools.find(
+  const activeToolWithMatchingMouseButtonMask = store.state.tools.find(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
@@ -323,14 +323,14 @@ function _resolveMouseInputConflicts (tool, element, options) {
  * @returns {undefined}
  */
 function _resolveTouchInputConflicts (tool, element, options) {
-  const activeTouchTool = state.tools.find(
+  const activeTouchTool = store.state.tools.find(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
       t.options.isTouchActive === true
   );
 
-  const activeMultiTouchToolWithOneTouchPointer = state.tools.find(
+  const activeMultiTouchToolWithOneTouchPointer = store.state.tools.find(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
@@ -363,7 +363,7 @@ function _resolveTouchInputConflicts (tool, element, options) {
  * @returns {undefined}
  */
 function _resolveMultiTouchInputConflicts (tool, element, options) {
-  const activeMultiTouchTool = state.tools.find(
+  const activeMultiTouchTool = store.state.tools.find(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
@@ -374,7 +374,7 @@ function _resolveMultiTouchInputConflicts (tool, element, options) {
   let activeTouchTool;
 
   if (tool.configuration.touchPointers === 1) {
-    activeTouchTool = state.tools.find(
+    activeTouchTool = store.state.tools.find(
       (t) =>
         t.element === element &&
         t.mode === 'active' &&
@@ -414,7 +414,7 @@ function _resolveGenericInputConflicts (
   element,
   options
 ) {
-  const activeToolWithActiveInteractionType = state.tools.find(
+  const activeToolWithActiveInteractionType = store.state.tools.find(
     (t) =>
       t.element === element &&
       t.mode === 'active' &&
@@ -434,6 +434,11 @@ function _resolveGenericInputConflicts (
 }
 
 function _trackGlobalToolModeChange (mode, toolName, options, interactionTypes) {
+  console.log(store);
+  if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
+    return;
+  }
+
   const historyEvent = {
     mode,
     args: [toolName, options]
@@ -443,12 +448,14 @@ function _trackGlobalToolModeChange (mode, toolName, options, interactionTypes) 
     historyEvent.push(interactionTypes);
   }
 
-  state.globalToolChangeHistory.push(historyEvent);
+  store.state.globalToolChangeHistory.push(historyEvent);
 
   const arbitraryChangeHistoryLimit = 50;
 
-  if (state.globalToolChangeHistory.length > arbitraryChangeHistoryLimit) {
-    state.globalToolChangeHistory.shift();
+  if (
+    store.state.globalToolChangeHistory.length > arbitraryChangeHistoryLimit
+  ) {
+    store.state.globalToolChangeHistory.shift();
   }
 }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -71,6 +71,7 @@ const setToolActiveForElement = function (
  * @returns {undefined}
  */
 const setToolActive = function (toolName, options, interactionTypes) {
+  _trackGlobalToolModeChange('active', toolName, options, interactionTypes);
   state.enabledElements.forEach((element) => {
     setToolActiveForElement(element, toolName, options, interactionTypes);
   });
@@ -220,6 +221,7 @@ function setToolModeForElement (mode, changeEvent, element, toolName, options) {
  * @returns {undefined}
  */
 function setToolMode (mode, changeEvent, toolName, options) {
+  _trackGlobalToolModeChange(mode, toolName, options);
   state.enabledElements.forEach((element) => {
     setToolModeForElement(mode, changeEvent, element, toolName, options);
   });
@@ -428,6 +430,25 @@ function _resolveGenericInputConflicts (
     activeToolWithActiveInteractionType.options[
       `is${interactionType}Active`
     ] = false;
+  }
+}
+
+function _trackGlobalToolModeChange (mode, toolName, options, interactionTypes) {
+  const historyEvent = {
+    mode,
+    arguments: [toolName, options]
+  };
+
+  if (interactionTypes) {
+    historyEvent.push(interactionTypes);
+  }
+
+  state.globalToolChangeHistory.push(historyEvent);
+
+  const arbitraryChangeHistoryLimit = 50;
+
+  if (state.globalToolChangeHistory.length > arbitraryChangeHistoryLimit) {
+    state.globalToolChangeHistory.shift();
   }
 }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -434,7 +434,6 @@ function _resolveGenericInputConflicts (
 }
 
 function _trackGlobalToolModeChange (mode, toolName, options, interactionTypes) {
-  console.log(store);
   if (!store.modules.globalConfiguration.state.globalToolSyncEnabled) {
     return;
   }


### PR DESCRIPTION
## Work in progress

Ideally, for our simpler setups, this should reduce or remove the need for a tool manager entirely.

### Goal

When you enable a new element, it's added tools and state should reflect that of globally added and state changed tools.

- This should be configurable. Some users may want a "blank enabledElement" every time one is created.



### Two options...

1. Track all global state changes, resolve conflicts for those changes, and use those as the "defaults" for when we enable a new element
2. Add the ability to "duplicate" the enabled/active tools from one enabledElement to the other
    - Least complex


The tricky parts here are:
- If you call `setToolActiveForElement` you can throw things out of whack. It makes it difficult to blanket copy options/configuration/active interaction types.
    - Maybe if a `forElement` call is made, we disable this restoration behavior?
- Conflict resolver logic takes place in the `ForElement` portion of the internal code. This makes it difficult to reuse and reliably restore the individual interaction type's state per tool.