### PR TITLE
Fix: Calling `init` multiple times should not leave lingering listeners

### DIFF
--- a/src/eventListeners/windowResizeHandler.js
+++ b/src/eventListeners/windowResizeHandler.js
@@ -6,7 +6,7 @@ const enable = function () {
 };
 
 const disable = function () {
-  window.addEventListener('resize', resizeThrottler, false);
+  window.removeEventListener('resize', resizeThrottler, false);
 };
 
 let resizeTimeout;

--- a/src/eventListeners/windowResizeHandler.js
+++ b/src/eventListeners/windowResizeHandler.js
@@ -2,6 +2,7 @@ import { state } from './../store/index.js';
 import external from './../externalModules.js';
 
 const enable = function () {
+  disable(); // Clean up any lingering listeners
   window.addEventListener('resize', resizeThrottler, false);
 };
 

--- a/src/init.js
+++ b/src/init.js
@@ -32,12 +32,32 @@ export default function (configuration) {
  * @private @method
  */
 function _addCornerstoneEventListeners () {
+  // Clear any listeners that may already be set
+  _removeCornerstoneEventListeners();
+
   const cornerstone = external.cornerstone;
   const elementEnabledEvent = cornerstone.EVENTS.ELEMENT_ENABLED;
   const elementDisabledEvent = cornerstone.EVENTS.ELEMENT_DISABLED;
 
   cornerstone.events.addEventListener(elementEnabledEvent, addEnabledElement);
   cornerstone.events.addEventListener(
+    elementDisabledEvent,
+    removeEnabledElement
+  );
+}
+
+/**
+ * Removes event listeners for the Cornerstone#ElementDisabled and
+ * Cornerstone#ElementEnabled events.
+ * @private @method
+ */
+function _removeCornerstoneEventListeners () {
+  const cornerstone = external.cornerstone;
+  const elementEnabledEvent = cornerstone.EVENTS.ELEMENT_ENABLED;
+  const elementDisabledEvent = cornerstone.EVENTS.ELEMENT_DISABLED;
+
+  cornerstone.events.removeEventListener(elementEnabledEvent, addEnabledElement);
+  cornerstone.events.removeEventListener(
     elementDisabledEvent,
     removeEnabledElement
   );


### PR DESCRIPTION
This PR patches the `init` method

- Make sure we remove any lingering listeners before adding new ones
- Update `windowResizeHandler`'s `disable` method to remove the event listener (previously added)