### PR TITLE
Fix: export mistake, `elementDisabled` tool filtering logic

### DIFF
--- a/src/eventListeners/windowResizeHandler.js
+++ b/src/eventListeners/windowResizeHandler.js
@@ -17,21 +17,20 @@ function resizeThrottler () {
   if (!resizeTimeout) {
     resizeTimeout = setTimeout(function () {
       resizeTimeout = null;
-      actualResizeHandler();
+      forceEnabledElementResize();
 
       // The actualResizeHandler will execute at a rate of 15fps
     }, 66);
   }
 }
 
-function actualResizeHandler () {
+export const forceEnabledElementResize = function () {
   state.enabledElements.forEach((element) => {
     external.cornerstone.resize(element);
   });
-}
+};
 
 export default {
   enable,
-  disable,
-  forceEnabledElementResize: actualResizeHandler
+  disable
 };

--- a/src/store/internals/removeEnabledElement.js
+++ b/src/store/internals/removeEnabledElement.js
@@ -63,7 +63,7 @@ const _removeAllToolsForElement = function (enabledElement) {
   // Note: We may want to `setToolDisabled` before removing from store
   // Or take other action to remove any lingering eventListeners/state
   store.state.tools = store.state.tools.filter(
-    (tool) => tool.element === enabledElement
+    (tool) => tool.element !== enabledElement
   );
 };
 


### PR DESCRIPTION
- fix export of force resize method
- fix tool filtering logic that fires when an enabled element is `disabled`