### PR TITLE
Feature: Expand supported schema for tooldata's handles

### DIFF
--- a/src/store/getToolsWithMoveableHandles.js
+++ b/src/store/getToolsWithMoveableHandles.js
@@ -5,6 +5,7 @@ import getHandleNearImagePoint from '../manipulators/getHandleNearImagePoint.js'
 /**
  * Filters an array of tools, returning only tools with moveable handles at the
  * mouse location.
+ *
  * @export @public @method
  * @name getToolsWithMoveableHandles
  *


### PR DESCRIPTION
- Before: Tool handles had to be an object of named handles
- After: Tool handles can be an object of named handles, an array of handles, or an object of named handles and named arrays that contain handles