### PR TITLE
fix(bidirectional-tool): Set hasMoved to true by default

### DIFF
--- a/src/tools/bidirectionalTool/createNewMeasurement.js
+++ b/src/tools/bidirectionalTool/createNewMeasurement.js
@@ -23,7 +23,7 @@ export default function (mouseEventData) {
       perpendicularEnd: getHandle(x, y, 3),
       textBox: getHandle(x - 50, y - 70, null, {
         highlight: false,
-        hasMoved: false,
+        hasMoved: true,
         active: false,
         movesIndependently: false,
         drawnIndependently: true,


### PR DESCRIPTION
Set hasMoved to true by default for bidirectional tool so that the textbox has a link line

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Set hasMoved to true by default for bidirectional tool so that the textbox has a link line


* **What is the current behavior?** (You can also link to an open issue here)
hasMoved is false by default, which sounds sensible, but it means the original drawn textBox has no dashed line linking it to the measurement. Since this textbox is far away from the measurement by default, this looks odd.


* **What is the new behavior (if this is a feature change)?**
Sets 'hasMoved' on the textBox to true by default. This adds the dashed line by default. Now things look normal.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
