### PR TITLE
Feature to disable probe textbox by setting the configuration. 

### DIFF
--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -61,6 +61,7 @@ function onImageRendered (e) {
   const context = getNewContext(eventData.canvasContext.canvas);
 
   const fontHeight = textStyle.getFontSize();
+  const config = probe.getConfiguration();
 
   for (let i = 0; i < toolData.data.length; i++) {
     const data = toolData.data[i];
@@ -75,6 +76,8 @@ function onImageRendered (e) {
 
       // Draw the handles
       drawHandles(context, eventData, data.handles, color);
+
+      if (config.disableTextBox) return;
 
       const x = Math.round(data.handles.end.x);
       const y = Math.round(data.handles.end.y);

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -77,7 +77,7 @@ function onImageRendered (e) {
       // Draw the handles
       drawHandles(context, eventData, data.handles, color);
 
-      if (config.disableTextBox) return;
+      if (config && config.disableTextBox) return;
 
       const x = Math.round(data.handles.end.x);
       const y = Math.round(data.handles.end.y);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR hotfixes issue #693. It does not solve the underlying problem which is the call to getRGBPixels in the draw function of the probe tool(After investigating a while with firefox perfomance tool).

* **What is the current behavior?** (You can also link to an open issue here)
The current behavior makes the canvas too unresponsive if the amount of probes is larger than ~5 (See #693.) 

* **What is the new behavior (if this is a feature change)?**
The new behavior is that the text box is not drawn and that makes the page more responsive if the textbox is not desired.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Users do not have to make changes with the current implementation. If the want to remove the textbox it is possible by setting the configuration object in their application. 
e.g.

const config = { disableTextBox: true};

cornerstoneTools.probe.setConfiguration(config);

This disables the rendering of the textbox.

* **Other information**:
It would be a nice addition to add this configuration to all tools which use a textbox.