### PR TITLE
fix(MultiTouch): Tools with different touchPointers activated at the same time

### DIFF
--- a/src/eventDispatchers/touchEventHandlers/index.js
+++ b/src/eventDispatchers/touchEventHandlers/index.js
@@ -1,4 +1,5 @@
 import customCallbackHandler from './../shared/customCallbackHandler.js';
+import multiTouchDrag from './multiTouchDrag.js';
 import tap from './tap.js';
 import touchStart from './touchStart.js';
 import touchStartActive from './touchStartActive.js';
@@ -26,11 +27,6 @@ const touchPress = customCallbackHandler.bind(
   null,
   'Touch',
   'touchPressCallback'
-);
-const multiTouchDrag = customCallbackHandler.bind(
-  null,
-  'MultiTouch',
-  'multiTouchDragCallback'
 );
 const touchRotate = customCallbackHandler.bind(
   null,

--- a/src/eventDispatchers/touchEventHandlers/multiTouchDrag.js
+++ b/src/eventDispatchers/touchEventHandlers/multiTouchDrag.js
@@ -1,0 +1,31 @@
+import { state } from '../../store/index.js';
+import getActiveToolsForElement from '../../store/getActiveToolsForElement.js';
+
+export default function(evt) {
+  if (state.isToolLocked) {
+    return false;
+  }
+
+  // TODO: We sometimes see a null detail for TOUCH_PRESS
+  const { element, numPointers } = evt.detail;
+  let tools = state.tools.filter(tool =>
+    tool.supportedInteractionTypes.includes('MultiTouch')
+  );
+
+  // Tool is active, and specific callback is active
+  tools = getActiveToolsForElement(element, tools, 'MultiTouch');
+  // Tool has expected callback custom function
+  tools = tools.filter(
+    tool =>
+      typeof tool.multiTouchDragCallback === 'function' &&
+      numPointers === tool.configuration.touchPointers
+  );
+
+  if (tools.length === 0) {
+    return false;
+  }
+
+  const activeTool = tools[0];
+
+  activeTool.multiTouchDragCallback(evt);
+}


### PR DESCRIPTION
## Changes
- Check the numPointers to get the first activated tool for interaction. 

Solve issues when we have Pan on two-fingers and Stackscroll with three-fingers.