### PR TITLE
fix(bidirectional): Remove distanceThreshold from bidirectional tool

### DIFF
--- a/src/tools/annotation/BidirectionalTool.js
+++ b/src/tools/annotation/BidirectionalTool.js
@@ -35,7 +35,6 @@ export default class BidirectionalTool extends BaseAnnotationTool {
         shadow: shadowConfig,
         drawHandlesOnHover: true,
         additionalData: [],
-        distanceThreshold: 6,
       },
     };
 

--- a/src/tools/annotation/bidirectionalTool/mouseMoveCallback.js
+++ b/src/tools/annotation/bidirectionalTool/mouseMoveCallback.js
@@ -77,10 +77,9 @@ export default function(event) {
       imageNeedsUpdate = true;
     }
 
-    const nearToolAndInactive =
-      this.pointNearTool(element, data, coords) && !data.active;
-    const notNearToolAndActive =
-      !this.pointNearTool(element, data, coords) && data.active;
+    const nearTool = this.pointNearTool(element, data, coords, 'mouse');
+    const nearToolAndInactive = nearTool && !data.active;
+    const notNearToolAndActive = !nearTool && data.active;
 
     if (nearToolAndInactive || notNearToolAndActive) {
       data.active = !data.active;

--- a/src/tools/annotation/bidirectionalTool/pointNearTool.js
+++ b/src/tools/annotation/bidirectionalTool/pointNearTool.js
@@ -1,3 +1,4 @@
+import { state } from '../../../store/index.js';
 import external from './../../../externalModules.js';
 import pointInsideBoundingBox from './../../../util/pointInsideBoundingBox.js';
 
@@ -22,7 +23,7 @@ const pointNearPerpendicular = (
   return distanceToPoint < distanceThreshold;
 };
 
-export default function(element, data, coords) {
+export default function(element, data, coords, interactionType = 'mouse') {
   const cornerstone = external.cornerstone;
   const cornerstoneMath = external.cornerstoneMath;
   const { handles } = data;
@@ -40,16 +41,12 @@ export default function(element, data, coords) {
     return true;
   }
 
-  if (
-    pointNearPerpendicular(
-      element,
-      handles,
-      coords,
-      this.configuration.distanceThreshold
-    )
-  ) {
+  const distanceThreshold =
+    interactionType === 'mouse' ? state.clickProximity : state.touchProximity;
+
+  if (pointNearPerpendicular(element, handles, coords, distanceThreshold)) {
     return true;
   }
 
-  return distanceToPoint < this.configuration.distanceThreshold;
+  return distanceToPoint < distanceThreshold;
 }

--- a/src/tools/annotation/bidirectionalTool/preMouseDownCallback.js
+++ b/src/tools/annotation/bidirectionalTool/preMouseDownCallback.js
@@ -1,5 +1,6 @@
 /* jshint -W083 */
 import external from './../../../externalModules.js';
+import { state } from '../../../store/index.js';
 import EVENTS from './../../../events.js';
 import {
   removeToolState,
@@ -15,6 +16,8 @@ export default function(evt) {
 
   const { element } = eventData;
   let data;
+
+  const distanceThreshold = state.clickProximity;
 
   const handleDoneMove = handle => {
     data.invalidated = true;
@@ -44,12 +47,7 @@ export default function(evt) {
   // Now check to see if there is a handle we can move
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    const handleParams = [
-      element,
-      data.handles,
-      coords,
-      this.configuration.distanceThreshold,
-    ];
+    const handleParams = [element, data.handles, coords, distanceThreshold];
     const handle = getHandleNearImagePoint(...handleParams);
 
     if (handle) {
@@ -76,7 +74,7 @@ export default function(evt) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (this.pointNearTool(element, data, coords)) {
+    if (this.pointNearTool(element, data, coords, 'mouse')) {
       element.removeEventListener(EVENTS.MOUSE_MOVE, this._moveCallback);
       element.removeEventListener(EVENTS.TOUCH_START, this._moveCallback);
       data.active = true;

--- a/src/tools/annotation/bidirectionalTool/preTouchStartCallback.js
+++ b/src/tools/annotation/bidirectionalTool/preTouchStartCallback.js
@@ -1,5 +1,6 @@
 /* jshint -W083 */
 import external from './../../../externalModules.js';
+import { state } from '../../../store/index.js';
 import EVENTS from './../../../events.js';
 import {
   removeToolState,
@@ -14,6 +15,8 @@ export default function(evt) {
   const eventData = evt.detail;
   const { element } = eventData;
   let data;
+
+  const distanceThreshold = state.touchProximity;
 
   const handleDoneMove = handle => {
     data.invalidated = true;
@@ -42,12 +45,7 @@ export default function(evt) {
   // Now check to see if there is a handle we can move
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    const handleParams = [
-      element,
-      data.handles,
-      coords,
-      this.configuration.distanceThreshold,
-    ];
+    const handleParams = [element, data.handles, coords, distanceThreshold];
     const handle = getHandleNearImagePoint(...handleParams);
 
     if (handle) {
@@ -73,7 +71,7 @@ export default function(evt) {
 
   for (let i = 0; i < toolData.data.length; i++) {
     data = toolData.data[i];
-    if (this.pointNearTool(element, data, coords)) {
+    if (this.pointNearTool(element, data, coords, 'touch')) {
       element.removeEventListener(EVENTS.TOUCH_DRAG, this._moveCallback);
       data.active = true;
 


### PR DESCRIPTION
Use click and touch proximity instead

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Removes the weird config.distanceThreshold that was present in the bidirectional tool


* **What is the current behavior?** (You can also link to an open issue here)
You have to set a distance threshold which makes no sense since it needs to be different between mouse and touch devices.


* **What is the new behavior (if this is a feature change)?**
We use state.clickProximity and state.touchProximity instead.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
