### PR TITLE
fix(bidirectional): Fix movement of handles for bidirectional tool

### DIFF
--- a/src/tools/annotation/bidirectionalTool/moveHandle/moveHandle.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/moveHandle.js
@@ -26,7 +26,7 @@ export default function(
       handle.x = eventData.currentPoints.image.x + distanceFromTool.x;
       handle.y = eventData.currentPoints.image.y + distanceFromTool.y;
     } else {
-      setHandlesPosition(handle, eventData, data);
+      setHandlesPosition(handle, eventData, data, distanceFromTool);
     }
 
     if (preventHandleOutsideImage) {

--- a/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularBothFixedLeft.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularBothFixedLeft.js
@@ -1,10 +1,9 @@
 import external from './../../../../externalModules.js';
 
 // Move long-axis start point
-export default function(eventData, data) {
+export default function(proposedPoint, data) {
   const { distance } = external.cornerstoneMath.point;
   const { start, end, perpendicularStart, perpendicularEnd } = data.handles;
-  const { image } = eventData.currentPoints;
 
   const longLine = {
     start: {
@@ -40,20 +39,20 @@ export default function(eventData, data) {
   const distanceFromPerpendicularP2 = distance(perpendicularEnd, intersection);
 
   const distanceToLineP2 = distance(end, intersection);
-  const newLineLength = distance(end, image);
+  const newLineLength = distance(end, proposedPoint);
 
   if (newLineLength <= distanceToLineP2) {
     return false;
   }
 
-  const dx = (end.x - image.x) / newLineLength;
-  const dy = (end.y - image.y) / newLineLength;
+  const dx = (end.x - proposedPoint.x) / newLineLength;
+  const dy = (end.y - proposedPoint.y) / newLineLength;
 
   const k = distanceToLineP2 / newLineLength;
 
   const newIntersection = {
-    x: end.x + (image.x - end.x) * k,
-    y: end.y + (image.y - end.y) * k,
+    x: end.x + (proposedPoint.x - end.x) * k,
+    y: end.y + (proposedPoint.y - end.y) * k,
   };
 
   perpendicularStart.x = newIntersection.x - distanceFromPerpendicularP1 * dy;

--- a/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularBothFixedRight.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularBothFixedRight.js
@@ -1,10 +1,9 @@
 import external from './../../../../externalModules.js';
 
 // Move long-axis end point
-export default function(eventData, data) {
+export default function(proposedPoint, data) {
   const { distance } = external.cornerstoneMath.point;
   const { start, end, perpendicularStart, perpendicularEnd } = data.handles;
-  const { image } = eventData.currentPoints;
 
   const longLine = {
     start: {
@@ -40,20 +39,20 @@ export default function(eventData, data) {
   const distanceFromPerpendicularP2 = distance(perpendicularEnd, intersection);
 
   const distanceToLineP2 = distance(start, intersection);
-  const newLineLength = distance(start, image);
+  const newLineLength = distance(start, proposedPoint);
 
   if (newLineLength <= distanceToLineP2) {
     return false;
   }
 
-  const dx = (start.x - image.x) / newLineLength;
-  const dy = (start.y - image.y) / newLineLength;
+  const dx = (start.x - proposedPoint.x) / newLineLength;
+  const dy = (start.y - proposedPoint.y) / newLineLength;
 
   const k = distanceToLineP2 / newLineLength;
 
   const newIntersection = {
-    x: start.x + (image.x - start.x) * k,
-    y: start.y + (image.y - start.y) * k,
+    x: start.x + (proposedPoint.x - start.x) * k,
+    y: start.y + (proposedPoint.y - start.y) * k,
   };
 
   perpendicularStart.x = newIntersection.x + distanceFromPerpendicularP1 * dy;

--- a/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularLeftFixedPoint.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularLeftFixedPoint.js
@@ -1,14 +1,12 @@
 import external from './../../../../externalModules.js';
 
 // Move perpendicular line start point
-export default function(eventData, data) {
+export default function(movedPoint, data) {
   const { distance } = external.cornerstoneMath.point;
   const { start, end, perpendicularStart, perpendicularEnd } = data.handles;
 
   const fudgeFactor = 1;
-
   const fixedPoint = perpendicularEnd;
-  const movedPoint = eventData.currentPoints.image;
 
   const distanceFromFixed = external.cornerstoneMath.lineSegment.distanceToPoint(
     data.handles,

--- a/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularRightFixedPoint.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/perpendicularRightFixedPoint.js
@@ -1,14 +1,13 @@
 import external from './../../../../externalModules.js';
 
 // Move perpendicular line end point
-export default function(eventData, data) {
+export default function(movedPoint, data) {
   const { distance } = external.cornerstoneMath.point;
   const { start, end, perpendicularStart, perpendicularEnd } = data.handles;
 
   const fudgeFactor = 1;
 
   const fixedPoint = perpendicularStart;
-  const movedPoint = eventData.currentPoints.image;
 
   const distanceFromFixed = external.cornerstoneMath.lineSegment.distanceToPoint(
     data.handles,

--- a/src/tools/annotation/bidirectionalTool/moveHandle/setHandlesPosition.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/setHandlesPosition.js
@@ -5,7 +5,7 @@ import perpendicularLeftFixedPoint from './perpendicularLeftFixedPoint.js';
 import perpendicularRightFixedPoint from './perpendicularRightFixedPoint.js';
 
 // Sets position of handles(start, end, perpendicularStart, perpendicularEnd)
-export default function(handle, eventData, data) {
+export default function(handle, eventData, data, distanceFromTool) {
   let movedPoint;
   let outOfBounds;
   let result;
@@ -15,23 +15,27 @@ export default function(handle, eventData, data) {
 
   const longLine = {};
   const perpendicularLine = {};
+  const proposedPoint = {
+    x: eventData.currentPoints.image.x + distanceFromTool.x,
+    y: eventData.currentPoints.image.y + distanceFromTool.y,
+  };
 
   if (handle.index === 0) {
     // If long-axis start point is moved
-    result = perpendicularBothFixedLeft(eventData, data);
+    result = perpendicularBothFixedLeft(proposedPoint, data);
     if (result) {
-      handle.x = eventData.currentPoints.image.x;
-      handle.y = eventData.currentPoints.image.y;
+      handle.x = proposedPoint.x;
+      handle.y = proposedPoint.y;
     } else {
       eventData.currentPoints.image.x = handle.x;
       eventData.currentPoints.image.y = handle.y;
     }
   } else if (handle.index === 1) {
     // If long-axis end point is moved
-    result = perpendicularBothFixedRight(eventData, data);
+    result = perpendicularBothFixedRight(proposedPoint, data);
     if (result) {
-      handle.x = eventData.currentPoints.image.x;
-      handle.y = eventData.currentPoints.image.y;
+      handle.x = proposedPoint.x;
+      handle.y = proposedPoint.y;
     } else {
       eventData.currentPoints.image.x = handle.x;
       eventData.currentPoints.image.y = handle.y;
@@ -53,8 +57,8 @@ export default function(handle, eventData, data) {
       y: data.handles.perpendicularEnd.y,
     };
     perpendicularLine.end = {
-      x: eventData.currentPoints.image.x,
-      y: eventData.currentPoints.image.y,
+      x: proposedPoint.x,
+      y: proposedPoint.y,
     };
 
     intersection = external.cornerstoneMath.lineSegment.intersectLine(
@@ -89,7 +93,7 @@ export default function(handle, eventData, data) {
     movedPoint = false;
 
     if (!outOfBounds) {
-      movedPoint = perpendicularLeftFixedPoint(eventData, data);
+      movedPoint = perpendicularLeftFixedPoint(proposedPoint, data);
 
       if (!movedPoint) {
         eventData.currentPoints.image.x = data.handles.perpendicularStart.x;
@@ -114,8 +118,8 @@ export default function(handle, eventData, data) {
       y: data.handles.perpendicularStart.y,
     };
     perpendicularLine.end = {
-      x: eventData.currentPoints.image.x,
-      y: eventData.currentPoints.image.y,
+      x: proposedPoint.x,
+      y: proposedPoint.y,
     };
 
     intersection = external.cornerstoneMath.lineSegment.intersectLine(
@@ -150,7 +154,7 @@ export default function(handle, eventData, data) {
     movedPoint = false;
 
     if (!outOfBounds) {
-      movedPoint = perpendicularRightFixedPoint(eventData, data);
+      movedPoint = perpendicularRightFixedPoint(proposedPoint, data);
 
       if (!movedPoint) {
         eventData.currentPoints.image.x = data.handles.perpendicularEnd.x;

--- a/src/tools/annotation/bidirectionalTool/moveHandle/touchMoveHandle.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/touchMoveHandle.js
@@ -34,7 +34,7 @@ export default function(
       handle.x = eventData.currentPoints.image.x + distanceFromTool.x;
       handle.y = eventData.currentPoints.image.y + distanceFromTool.y;
     } else {
-      setHandlesPosition(handle, eventData, data);
+      setHandlesPosition(handle, eventData, data, distanceFromTool);
     }
 
     if (preventHandleOutsideImage) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Updates logic for movement of bidirectional tool handles, so that they don't snap to the location of the pointer that grabbed them


* **What is the current behavior?** (You can also link to an open issue here)
- When you move the bidirectional tool's handles, the handle snaps to the mouse / finger location which makes it very hard to use on touch devices


* **What is the new behavior (if this is a feature change)?**
- The original displacement between the pointer and the handle is maintained while the handle is moved.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- No


* **Other information**:
