### PR TITLE
Fix/normalize browser scroll events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,10 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
-          name: Install JUnit coverage reporter
-          command: npm install --save-dev jest-junit
-      - run:
           name: Jest Tests && Coverage Report
           environment:
             JEST_JUNIT_OUTPUT: reports/junit/js-test-results.xml
-          command: npm run test:unit -- --ci --reporters=default --reporters=jest-junit
+          command: npm run test:unit -- --coverage --coverageReporters=text-lcov
       # Store our test results + Output
       - store_test_results:
           path: reports/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ defaults: &defaults
     - image: circleci/node:latest
 
 jobs:
-
   # Run on successful merge/commit to vNext
   test-merge:
     <<: *defaults
@@ -14,8 +13,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
       - run: npm install
       - save_cache:
           paths:
@@ -37,7 +36,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths: .
-  
+
   # Note: We do not expose project environment variables
   # to pull requests from forks (security reasons). This
   # job should never rely on such an environment variable.
@@ -47,18 +46,21 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
       - run: npm install
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
+          name: Install JUnit coverage reporter
+          command: npm install --save-dev jest-junit
+      - run:
           name: Jest Tests && Coverage Report
           environment:
             JEST_JUNIT_OUTPUT: reports/junit/js-test-results.xml
-          command: npm run test:unit -- --coverage --coverageReporters=text-lcov
+          command: npm run test:unit -- --ci --reporters=default --reporters=jest-junit
       # Store our test results + Output
       - store_test_results:
           path: reports/junit

--- a/src/__mocks__/externalModules.js
+++ b/src/__mocks__/externalModules.js
@@ -1,8 +1,16 @@
 export default {
   cornerstone: {
+    getEnabledElement: jest.fn().mockImplementation(() => ({
+      image: jest.fn(),
+    })),
+    getViewport: jest.fn(),
     imageCache: {
       getImageLoadObject: jest.fn(),
     },
+    pageToPixel: jest.fn().mockImplementation(() => ({
+      x: 0,
+      y: 0,
+    })),
     pixelToCanvas: jest.fn(),
   },
 };

--- a/src/__mocks__/externalModules.js
+++ b/src/__mocks__/externalModules.js
@@ -12,5 +12,6 @@ export default {
       y: 0,
     })),
     pixelToCanvas: jest.fn(),
+    setViewport: jest.fn(),
   },
 };

--- a/src/eventDispatchers/mouseToolEventDispatcher.js
+++ b/src/eventDispatchers/mouseToolEventDispatcher.js
@@ -21,6 +21,7 @@ import {
  * - onImageRendered: redraw visible tool data
  * @private
  * @param {*} element
+ * @returns {undefined}
  */
 const enable = function(element) {
   element.addEventListener(EVENTS.MOUSE_CLICK, mouseClick);

--- a/src/eventListeners/index.js
+++ b/src/eventListeners/index.js
@@ -1,5 +1,5 @@
 import mouseEventListeners from './mouseEventListeners.js';
-import mouseWheelEventListeners from './mouseWheelEventListeners.js';
+import wheelEventListener from './wheelEventListener.js';
 import touchEventListeners from './touchEventListeners.js';
 
-export { mouseEventListeners, mouseWheelEventListeners, touchEventListeners };
+export { mouseEventListeners, wheelEventListener, touchEventListeners };

--- a/src/eventListeners/internals/normalizeWheel.js
+++ b/src/eventListeners/internals/normalizeWheel.js
@@ -3,6 +3,14 @@ const PIXEL_STEP = 10;
 const LINE_HEIGHT = 40;
 const PAGE_HEIGHT = 800;
 
+/**
+ *
+ *
+ * @private
+ * @function normalizeWheel
+ * @param {WheelEvent} event
+ * @returns {Object} { spinX, spinY, pixlX, pixelY }
+ */
 export default function(event) {
   let spinX = 0,
     spinY = 0,

--- a/src/eventListeners/internals/normalizeWheel.js
+++ b/src/eventListeners/internals/normalizeWheel.js
@@ -1,0 +1,119 @@
+const useHasFeature =
+  document.implementation &&
+  document.implementation.hasFeature &&
+  document.implementation.hasFeature('', '') !== true;
+
+// Reasonable defaults
+const PIXEL_STEP = 10;
+const LINE_HEIGHT = 40;
+const PAGE_HEIGHT = 800;
+
+/**
+ * As of today, there are 2 DOM event types you can listen to:
+ *
+ *   'wheel'                -- Chrome(31+), FF(17+), IE(9+)
+ *   'mousewheel'           -- Chrome, IE(6+), Opera, Safari
+ *
+ * So what to do?  The is the best:
+ *
+ *   normalizeWheel.getEventType();
+ */
+const normalizeWheel = function(event) {
+  let sX = 0,
+    sY = 0, // SpinX, spinY
+    pX = 0,
+    pY = 0; // PixelX, pixelY
+
+  // Legacy
+  if ('detail' in event) {
+    sY = event.detail;
+  }
+  if ('wheelDelta' in event) {
+    sY = -event.wheelDelta / 120;
+  }
+  if ('wheelDeltaY' in event) {
+    sY = -event.wheelDeltaY / 120;
+  }
+  if ('wheelDeltaX' in event) {
+    sX = -event.wheelDeltaX / 120;
+  }
+
+  // Side scrolling on FF with DOMMouseScroll
+  if ('axis' in event && event.axis === event.HORIZONTAL_AXIS) {
+    sX = sY;
+    sY = 0;
+  }
+
+  pX = sX * PIXEL_STEP;
+  pY = sY * PIXEL_STEP;
+
+  if ('deltaY' in event) {
+    pY = event.deltaY;
+  }
+  if ('deltaX' in event) {
+    pX = event.deltaX;
+  }
+
+  if ((pX || pY) && event.deltaMode) {
+    if (event.deltaMode === 1) {
+      // Delta in LINE units
+      pX *= LINE_HEIGHT;
+      pY *= LINE_HEIGHT;
+    } else {
+      // Delta in PAGE units
+      pX *= PAGE_HEIGHT;
+      pY *= PAGE_HEIGHT;
+    }
+  }
+
+  // Fall-back if spin cannot be determined
+  if (pX && !sX) {
+    sX = pX < 1 ? -1 : 1;
+  }
+  if (pY && !sY) {
+    sY = pY < 1 ? -1 : 1;
+  }
+
+  return {
+    spinX: sX,
+    spinY: sY,
+    pixelX: pX,
+    pixelY: pY,
+  };
+};
+
+const getEventType = function() {
+  return _isWheelEventSupported() ? 'wheel' : 'mousewheel';
+};
+
+export default {
+  normalizeWheel,
+  getEventType,
+};
+
+/**
+ * Checks if the weheel event is supported
+ *
+ * @private
+ * @returns {boolean} True if the event is supported.
+ * @license Modernizr 3.0.0pre (Custom Build) | MIT
+ */
+function _isWheelEventSupported() {
+  const eventName = 'onwheel';
+  let isSupported = eventName in document;
+
+  // 2nd Check
+  if (!isSupported) {
+    const element = document.createElement('div');
+
+    element.setAttribute(eventName, 'return;');
+    isSupported = typeof element[eventName] === 'function';
+  }
+
+  // 3rd check
+  if (!isSupported && useHasFeature) {
+    isSupported = document.implementation.hasFeature('Events.wheel', '3.0');
+  }
+
+  return isSupported;
+}

--- a/src/eventListeners/internals/normalizeWheel.js
+++ b/src/eventListeners/internals/normalizeWheel.js
@@ -4,7 +4,8 @@ const LINE_HEIGHT = 40;
 const PAGE_HEIGHT = 800;
 
 /**
- *
+ * Normalizes wheel events and provides properties that are more
+ * consistent and helpful across different browsers
  *
  * @private
  * @function normalizeWheel

--- a/src/eventListeners/internals/normalizeWheel.js
+++ b/src/eventListeners/internals/normalizeWheel.js
@@ -1,119 +1,62 @@
-const useHasFeature =
-  document.implementation &&
-  document.implementation.hasFeature &&
-  document.implementation.hasFeature('', '') !== true;
-
 // Reasonable defaults
 const PIXEL_STEP = 10;
 const LINE_HEIGHT = 40;
 const PAGE_HEIGHT = 800;
 
-/**
- * As of today, there are 2 DOM event types you can listen to:
- *
- *   'wheel'                -- Chrome(31+), FF(17+), IE(9+)
- *   'mousewheel'           -- Chrome, IE(6+), Opera, Safari
- *
- * So what to do?  The is the best:
- *
- *   normalizeWheel.getEventType();
- */
-const normalizeWheel = function(event) {
-  let sX = 0,
-    sY = 0, // SpinX, spinY
-    pX = 0,
-    pY = 0; // PixelX, pixelY
+export default function(event) {
+  let spinX = 0,
+    spinY = 0,
+    pixelX = 0,
+    pixelY = 0;
 
   // Legacy
   if ('detail' in event) {
-    sY = event.detail;
+    spinY = event.detail;
   }
   if ('wheelDelta' in event) {
-    sY = -event.wheelDelta / 120;
+    spinY = -event.wheelDelta / 120;
   }
   if ('wheelDeltaY' in event) {
-    sY = -event.wheelDeltaY / 120;
+    spinY = -event.wheelDeltaY / 120;
   }
   if ('wheelDeltaX' in event) {
-    sX = -event.wheelDeltaX / 120;
+    spinX = -event.wheelDeltaX / 120;
   }
 
-  // Side scrolling on FF with DOMMouseScroll
-  if ('axis' in event && event.axis === event.HORIZONTAL_AXIS) {
-    sX = sY;
-    sY = 0;
-  }
-
-  pX = sX * PIXEL_STEP;
-  pY = sY * PIXEL_STEP;
+  pixelX = spinX * PIXEL_STEP;
+  pixelY = spinY * PIXEL_STEP;
 
   if ('deltaY' in event) {
-    pY = event.deltaY;
+    pixelY = event.deltaY;
   }
   if ('deltaX' in event) {
-    pX = event.deltaX;
+    pixelX = event.deltaX;
   }
 
-  if ((pX || pY) && event.deltaMode) {
+  if ((pixelX || pixelY) && event.deltaMode) {
     if (event.deltaMode === 1) {
       // Delta in LINE units
-      pX *= LINE_HEIGHT;
-      pY *= LINE_HEIGHT;
+      pixelX *= LINE_HEIGHT;
+      pixelY *= LINE_HEIGHT;
     } else {
       // Delta in PAGE units
-      pX *= PAGE_HEIGHT;
-      pY *= PAGE_HEIGHT;
+      pixelX *= PAGE_HEIGHT;
+      pixelY *= PAGE_HEIGHT;
     }
   }
 
   // Fall-back if spin cannot be determined
-  if (pX && !sX) {
-    sX = pX < 1 ? -1 : 1;
+  if (pixelX && !spinX) {
+    spinX = pixelX < 1 ? -1 : 1;
   }
-  if (pY && !sY) {
-    sY = pY < 1 ? -1 : 1;
+  if (pixelY && !spinY) {
+    spinY = pixelY < 1 ? -1 : 1;
   }
 
   return {
-    spinX: sX,
-    spinY: sY,
-    pixelX: pX,
-    pixelY: pY,
+    spinX,
+    spinY,
+    pixelX,
+    pixelY,
   };
-};
-
-const getEventType = function() {
-  return _isWheelEventSupported() ? 'wheel' : 'mousewheel';
-};
-
-export default {
-  normalizeWheel,
-  getEventType,
-};
-
-/**
- * Checks if the weheel event is supported
- *
- * @private
- * @returns {boolean} True if the event is supported.
- * @license Modernizr 3.0.0pre (Custom Build) | MIT
- */
-function _isWheelEventSupported() {
-  const eventName = 'onwheel';
-  let isSupported = eventName in document;
-
-  // 2nd Check
-  if (!isSupported) {
-    const element = document.createElement('div');
-
-    element.setAttribute(eventName, 'return;');
-    isSupported = typeof element[eventName] === 'function';
-  }
-
-  // 3rd check
-  if (!isSupported && useHasFeature) {
-    isSupported = document.implementation.hasFeature('Events.wheel', '3.0');
-  }
-
-  return isSupported;
 }

--- a/src/eventListeners/internals/normalizeWheel.test.js
+++ b/src/eventListeners/internals/normalizeWheel.test.js
@@ -1,0 +1,20 @@
+// SUT
+import normalizeWheel from './normalizeWheel.js';
+
+describe('internals/normalizeWheel.js', () => {
+  it('returns { spinX, spinY, pixelX, pixelY }', () => {
+    // Setup
+    const expectedReturn = {
+      spinX: 0,
+      spinY: 0,
+      pixelX: 0,
+      pixelY: 0,
+    };
+
+    // SUT
+    const result = normalizeWheel({});
+
+    // Assert
+    expect(result).toMatchObject(expectedReturn);
+  });
+});

--- a/src/eventListeners/mouseWheelEventListeners.js
+++ b/src/eventListeners/mouseWheelEventListeners.js
@@ -1,10 +1,16 @@
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import triggerEvent from '../util/triggerEvent.js';
+import nm from './internals/normalizeWheel.js';
 
 function mouseWheel(e) {
   const element = e.currentTarget;
   const enabledElement = external.cornerstone.getEnabledElement(element);
+
+  console.debug(`mouseWheel`);
+  const NORMALIZED = nm.normalizeWheel(e);
+
+  console.debug(NORMALIZED);
 
   if (!enabledElement.image) {
     return;
@@ -15,13 +21,13 @@ function mouseWheel(e) {
   // Mac os x mavericks system when middle mouse button dragging.
   // I couldn't find any info about this so this might break other systems
   // Webkit hack
-  if (e.type === 'mousewheel' && e.wheelDeltaY === 0) {
-    return;
-  }
-  // Firefox hack
-  if (e.type === 'DOMMouseScroll' && e.axis === 1) {
-    return;
-  }
+  // If (e.type === 'mousewheel' && e.wheelDeltaY === 0) {
+  //   Return;
+  // }
+  // // Firefox hack
+  // If (e.type === 'DOMMouseScroll' && e.axis === 1) {
+  //   Return;
+  // }
 
   e.preventDefault();
 
@@ -70,21 +76,13 @@ function mouseWheel(e) {
   triggerEvent(element, EVENTS.MOUSE_WHEEL, mouseWheelData);
 }
 
-const mouseWheelEvents = ['mousewheel', 'DOMMouseScroll'];
-
 function enable(element) {
-  // Prevent handlers from being attached multiple times
   disable(element);
-
-  mouseWheelEvents.forEach(eventType => {
-    element.addEventListener(eventType, mouseWheel, { passive: false });
-  });
+  element.addEventListener('wheel', mouseWheel, { passive: false });
 }
 
 function disable(element) {
-  mouseWheelEvents.forEach(eventType => {
-    element.removeEventListener(eventType, mouseWheel);
-  });
+  element.removeEventListener('wheel', mouseWheel, { passive: false });
 }
 
 export default {

--- a/src/eventListeners/mouseWheelEventListeners.js
+++ b/src/eventListeners/mouseWheelEventListeners.js
@@ -1,75 +1,45 @@
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import triggerEvent from '../util/triggerEvent.js';
-import nm from './internals/normalizeWheel.js';
+import normalizeWheel from './internals/normalizeWheel.js';
 
-function mouseWheel(e) {
-  const element = e.currentTarget;
+/**
+ *
+ *
+ * @param {WheelEvent} evt
+ * @returns {undefined}
+ */
+function mouseWheel(evt) {
+  const element = evt.currentTarget;
   const enabledElement = external.cornerstone.getEnabledElement(element);
-
-  console.debug(`mouseWheel`);
-  console.log(e);
-  const NORMALIZED = nm.normalizeWheel(e);
-
-  console.debug(NORMALIZED);
 
   if (!enabledElement.image) {
     return;
   }
 
-  // !!!HACK/NOTE/WARNING!!!
-  // For some reason I am getting mousewheel and DOMMouseScroll events on my
-  // Mac os x mavericks system when middle mouse button dragging.
-  // I couldn't find any info about this so this might break other systems
-  // Webkit hack
-  // If (e.type === 'mousewheel' && e.wheelDeltaY === 0) {
-  //   Return;
-  // }
-  // // Firefox hack
-  // If (e.type === 'DOMMouseScroll' && e.axis === 1) {
-  //   Return;
-  // }
+  evt.preventDefault();
 
-  e.preventDefault();
-
-  let x;
-  let y;
-
-  if (e.pageX !== undefined && e.pageY !== undefined) {
-    x = e.pageX;
-    y = e.pageY;
-  } else {
-    // IE9 & IE10
-    x = e.x;
-    y = e.y;
-  }
-
-  const startingCoords = external.cornerstone.pageToPixel(element, x, y);
-
-  e = window.event && window.event.wheelDelta ? window.event : e; // Old IE support
-
-  let wheelDelta;
-
-  if (e.wheelDelta) {
-    wheelDelta = e.wheelDelta;
-  } else if (e.deltaY) {
-    wheelDelta = -e.deltaY;
-  } else if (e.detail) {
-    wheelDelta = -e.detail;
-  } else {
-    wheelDelta = e.wheelDelta;
-  }
-
-  const direction = wheelDelta < 0 ? -1 : 1;
+  const { pageX, pageY } = evt;
+  const startingCoords = external.cornerstone.pageToPixel(
+    element,
+    pageX,
+    pageY
+  );
+  const { spinX, spinY, pixelX, pixelY } = normalizeWheel(evt);
+  const direction = spinY < 0 ? -1 : 1;
 
   const mouseWheelData = {
     element,
     viewport: external.cornerstone.getViewport(element),
-    detail: e,
+    detail: evt,
     image: enabledElement.image,
     direction,
-    pageX: x,
-    pageY: y,
+    spinX,
+    spinY,
+    pixelX,
+    pixelY,
+    pageX,
+    pageY,
     imageX: startingCoords.x,
     imageY: startingCoords.y,
   };

--- a/src/eventListeners/mouseWheelEventListeners.js
+++ b/src/eventListeners/mouseWheelEventListeners.js
@@ -8,6 +8,7 @@ function mouseWheel(e) {
   const enabledElement = external.cornerstone.getEnabledElement(element);
 
   console.debug(`mouseWheel`);
+  console.log(e);
   const NORMALIZED = nm.normalizeWheel(e);
 
   console.debug(NORMALIZED);

--- a/src/eventListeners/wheelEventListener.js
+++ b/src/eventListeners/wheelEventListener.js
@@ -1,3 +1,8 @@
+/**
+ * Internal module used to turn on listening, handling, and normalizing of the
+ * native `wheel` event
+ */
+
 import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import triggerEvent from '../util/triggerEvent.js';
@@ -5,11 +10,12 @@ import normalizeWheel from './internals/normalizeWheel.js';
 
 /**
  *
- *
+ * @private
+ * @function wheelEventHandler
  * @param {WheelEvent} evt
  * @returns {undefined}
  */
-function mouseWheel(evt) {
+function wheelEventHandler(evt) {
   const element = evt.currentTarget;
   const enabledElement = external.cornerstone.getEnabledElement(element);
 
@@ -47,13 +53,29 @@ function mouseWheel(evt) {
   triggerEvent(element, EVENTS.MOUSE_WHEEL, mouseWheelData);
 }
 
+/**
+ * Listens for the wheel event, and handles it. Handled event
+ * will be "normalized" and re-emitted as `EVENTS.MOUSE_WHEEL`
+ *
+ * @private
+ * @param {HTMLElement} element
+ * @returns {undefined}
+ */
 function enable(element) {
   disable(element);
-  element.addEventListener('wheel', mouseWheel, { passive: false });
+  element.addEventListener('wheel', wheelEventHandler, { passive: false });
 }
 
+/**
+ * Removes listener and handler for wheel event. `EVENTS.MOUSE_WHEEL`
+ * will no longer be emitted.
+ *
+ * @private
+ * @param {HTMLElement} element
+ * @returns {undefined}
+ */
 function disable(element) {
-  element.removeEventListener('wheel', mouseWheel, { passive: false });
+  element.removeEventListener('wheel', wheelEventHandler, { passive: false });
 }
 
 export default {

--- a/src/eventListeners/wheelEventListener.test.js
+++ b/src/eventListeners/wheelEventListener.test.js
@@ -1,0 +1,109 @@
+// SUT
+import wheelEventListener from './wheelEventListener.js';
+
+// Setup
+import external from './../externalModules.js';
+
+jest.mock('./../externalModules.js');
+
+describe('eventListeners/wheelEventListener.js', () => {
+  test('calling enable adds an event listener for native `wheel` event', () => {
+    // Setup
+    const element = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    // SUT
+    wheelEventListener.enable(element);
+
+    // Assert
+    expect(element.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(element.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('calling disable removes an event listener for native `wheel` event', () => {
+    // Setup
+    const element = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    // SUT
+    wheelEventListener.disable(element);
+
+    // Assert
+    expect(element.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits an `cornerstonetoolsmousewheel` event when enabled element is scrolled', done => {
+    // Setup
+    const localElement = document.createElement('div');
+
+    // Assert
+    localElement.addEventListener('cornerstonetoolsmousewheel', evt => {
+      expect(true).toBe(true);
+      done();
+    });
+
+    // SUT
+    wheelEventListener.enable(localElement);
+    localElement.dispatchEvent(new Event('wheel'));
+  });
+
+  test('calling enable multiple times does not duplicate listener', done => {
+    // Setup
+    const localElement = document.createElement('div');
+    const scrollHandler = jest.fn();
+
+    localElement.addEventListener('cornerstonetoolsmousewheel', evt => {
+      scrollHandler();
+    });
+    wheelEventListener.enable(localElement);
+    wheelEventListener.enable(localElement);
+    wheelEventListener.enable(localElement);
+
+    // Fire Away!
+    localElement.dispatchEvent(new Event('wheel'));
+
+    // Assert
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate
+    setImmediate(() => {
+      expect(scrollHandler).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  test('the `cornerstonetoolsmousewheel` event contains expected properties', done => {
+    // Setup
+    const localElement = document.createElement('div');
+    const expectedEvtDetailKeys = [
+      'element',
+      'detail', // Original event
+      'viewport',
+      'image',
+      'direction',
+      'spinX',
+      'spinY',
+      'pixelX',
+      'pixelY',
+      'pageX',
+      'pageY',
+      'imageX',
+      'imageY',
+    ];
+
+    wheelEventListener.enable(localElement);
+
+    // Assert
+    localElement.addEventListener('cornerstonetoolsmousewheel', evt => {
+      expect(Object.keys(evt.detail).sort()).toEqual(
+        expectedEvtDetailKeys.sort()
+      );
+      done();
+    });
+
+    // Fire Away!
+    localElement.dispatchEvent(new Event('wheel'));
+  });
+});

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -1,6 +1,6 @@
 import {
   mouseEventListeners,
-  mouseWheelEventListeners,
+  wheelEventListener,
   touchEventListeners,
 } from '../../eventListeners/index.js';
 import {
@@ -55,7 +55,7 @@ export default function(elementEnabledEvt) {
   // Mouse
   if (store.modules.globalConfiguration.state.mouseEnabled) {
     mouseEventListeners.enable(enabledElement);
-    mouseWheelEventListeners.enable(enabledElement);
+    wheelEventListener.enable(enabledElement);
     mouseToolEventDispatcher.enable(enabledElement);
   }
 

--- a/src/store/internals/removeEnabledElement.js
+++ b/src/store/internals/removeEnabledElement.js
@@ -1,6 +1,6 @@
 import {
   mouseEventListeners,
-  mouseWheelEventListeners,
+  wheelEventListener,
   touchEventListeners,
 } from '../../eventListeners/index.js';
 import {
@@ -41,7 +41,7 @@ export default function(elementDisabledEvt) {
   // Mouse
   if (store.modules.globalConfiguration.state.mouseEnabled) {
     mouseEventListeners.disable(enabledElement);
-    mouseWheelEventListeners.disable(enabledElement);
+    wheelEventListener.disable(enabledElement);
     mouseToolEventDispatcher.disable(enabledElement);
   }
 

--- a/src/tools/ZoomMouseWheelTool.js
+++ b/src/tools/ZoomMouseWheelTool.js
@@ -31,14 +31,11 @@ export default class ZoomMouseWheelTool extends BaseTool {
   }
 
   mouseWheelCallback(evt) {
-    const { element, viewport, direction, spinY } = evt.detail;
+    const { element, viewport, spinY } = evt.detail;
     const { invert, maxScale, minScale } = this.configuration;
-    const ticks = invert ? direction / 4 : -direction / 4;
+    const ticks = invert ? spinY / 4 : -spinY / 4;
 
-    console.log(ticks);
-    console.log(spinY);
-
-    const updatedViewport = changeViewportScale(viewport, ticks * spinY, {
+    const updatedViewport = changeViewportScale(viewport, ticks, {
       maxScale,
       minScale,
     });

--- a/src/tools/ZoomMouseWheelTool.js
+++ b/src/tools/ZoomMouseWheelTool.js
@@ -31,11 +31,14 @@ export default class ZoomMouseWheelTool extends BaseTool {
   }
 
   mouseWheelCallback(evt) {
-    const { element, viewport, direction } = evt.detail;
+    const { element, viewport, direction, spinY } = evt.detail;
     const { invert, maxScale, minScale } = this.configuration;
-    const ticks = (invert ? direction / 4 : -direction / 4) * evt.spinY;
+    const ticks = invert ? direction / 4 : -direction / 4;
 
-    const updatedViewport = changeViewportScale(viewport, ticks, {
+    console.log(ticks);
+    console.log(spinY);
+
+    const updatedViewport = changeViewportScale(viewport, ticks * spinY, {
       maxScale,
       minScale,
     });

--- a/src/tools/ZoomMouseWheelTool.js
+++ b/src/tools/ZoomMouseWheelTool.js
@@ -1,8 +1,6 @@
 import external from './../externalModules.js';
 import BaseTool from './base/BaseTool.js';
-import zoomUtils from '../util/zoom/index.js';
-
-const { changeViewportScale } = zoomUtils;
+import { changeViewportScale } from '../util/zoom/index.js';
 
 /**
  * @public

--- a/src/tools/ZoomMouseWheelTool.js
+++ b/src/tools/ZoomMouseWheelTool.js
@@ -33,7 +33,8 @@ export default class ZoomMouseWheelTool extends BaseTool {
   mouseWheelCallback(evt) {
     const { element, viewport, direction } = evt.detail;
     const { invert, maxScale, minScale } = this.configuration;
-    const ticks = invert ? direction / 4 : -direction / 4;
+    const ticks = (invert ? direction / 4 : -direction / 4) * evt.spinY;
+
     const updatedViewport = changeViewportScale(viewport, ticks, {
       maxScale,
       minScale,

--- a/src/tools/ZoomMouseWheelTool.test.js
+++ b/src/tools/ZoomMouseWheelTool.test.js
@@ -1,0 +1,50 @@
+// SUT
+import ZoomMouseWheelTool from './ZoomMouseWheelTool.js';
+
+// Setup
+import external from './../externalModules.js';
+
+jest.mock('./../externalModules.js');
+
+describe('tools/ZoomMouseWheelTool.js', () => {
+  describe('configuration', () => {
+    // TODO: Updates min/max/invert when provided in configuration
+  });
+
+  describe('mouseWheelCallback', () => {
+    it('has a mouseWheelCallback', () => {
+      // SUT
+      const tool = new ZoomMouseWheelTool();
+
+      // Assert
+      expect(tool.mouseWheelCallback).not.toEqual(undefined);
+    });
+
+    // Should these live on, and only on, a `changeViewportScale` test?
+    // TODO: Cannot scale lower than minScale
+    // TODO: Cannot scale larger than maxScale
+    // TODO: Inverts scale when invert is true
+    // TODO: the viewport to zoom out when the event's spinY is negative
+    // TODO: the viewport to zoom in when the event's spinY is positive
+
+    it('sets an updated viewport', () => {
+      // Setup
+      const tool = new ZoomMouseWheelTool();
+      const fakeEvent = {
+        detail: {
+          element: '',
+          viewport: {
+            scale: 1,
+          },
+          spinY: -1,
+        },
+      };
+
+      // SUT
+      tool.mouseWheelCallback(fakeEvent);
+
+      // Assert
+      expect(external.cornerstone.setViewport).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/util/zoom/changeViewportScale.js
+++ b/src/util/zoom/changeViewportScale.js
@@ -1,7 +1,8 @@
 /**
  * Changes the scale of the viewport.
- * @export @public @method
- * @name changeViewportScale
+ *
+ * @private
+ * @function changeViewportScale
  *
  * @param {Object} viewport The viewport to scale.
  * @param {number} ticks The change in magnifcation factor.

--- a/src/util/zoom/index.js
+++ b/src/util/zoom/index.js
@@ -1,6 +1,10 @@
 import changeViewportScale from './changeViewportScale.js';
 import correctShift from './correctShift.js';
 
+// Named
+export { changeViewportScale, correctShift };
+
+// Default
 export default {
   changeViewportScale,
   correctShift,


### PR DESCRIPTION
closes https://github.com/cornerstonejs/cornerstoneTools/pull/644
closes https://github.com/cornerstonejs/cornerstoneTools/issues/643

@talkdirty hit the nail on the head. Lots of resources are showing that all browsers we officially support use the `wheel` event, while the others have been deprecated. There are some slight differences in the implementation across browsers, but most issues are around the scroll speed/delta:

MDN: https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser

FB Solution: https://github.com/facebookarchive/fixed-data-table/blob/master/src/vendor_upstream/dom/normalizeWheel.js

Circa 2015 Solution: https://stackoverflow.com/a/26067800/1867984


### Test Before Merging:

Looking for consistent direction, and for the event to be picked up 👍 

- [x] IE 11
- [x] FireFox
- [x] Chrome
- [x] Android Mobile
- [x] Safari Mobile

### Notes:

- Because this "drops" support for IE ~9 and a few very old browser versions, we _may_ not want to port this to `v2`. Up for debate.
- Using `spinY`, I was able to add slightly better mousewheel scaling support

### TODO:

Unit tests for the listener, normalize fn, and zoomMouseWheelTool