### PR TITLE
Store the angle value into angle toolState

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -109,6 +109,9 @@ function onImageRendered (e) {
       angle *= (180 / Math.PI);
 
       const rAngle = roundToDecimal(angle, 2);
+
+      data.rAngle = rAngle;
+
       const str = '00B0'; // Degrees symbol
       const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16));
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The value `rAngle` was added to angle toolState.

* **What is the current behavior?** (You can also link to an open issue here)

Linked issue: https://github.com/cornerstonejs/cornerstoneTools/issues/703

> cornerstoneTools.getToolState(element,'length') -- returns the calculated length value
>
> ![image](https://user-images.githubusercontent.com/1905961/49408292-d77d1080-f742-11e8-8412-3df6bbb6402e.png)
> 
> But the same doesnt work for 'angle' -- Does not return the calculated value.
> 
> It would be great, if we could add this. Its just one line change needed, that I have done locally now. But would be good if its added to a release.
> 
> ![image](https://user-images.githubusercontent.com/1905961/49408318-ecf23a80-f742-11e8-9962-4209ac636b4b.png)


* **What is the new behavior (if this is a feature change)?**

`cornerstoneTools.getToolState(element, 'angle')` will return the `rAngle` value.

<img width="413" alt="screen shot 2018-12-03 at 9 42 10 pm" src="https://user-images.githubusercontent.com/1905961/49408692-77876980-f744-11e8-82ab-57bc69e9b427.png">


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:

It's already implemented on `vNext` branch:

https://github.com/cornerstonejs/cornerstoneTools/blob/90dcd97a98e95669df315c83a6966acc26ba9586/src/tools/annotation/AngleTool.js#L192

---

@algates90 FYI