### PR TITLE
Adds a filter to Eraser mouse events

### DIFF
--- a/src/imageTools/eraser.js
+++ b/src/imageTools/eraser.js
@@ -1,8 +1,9 @@
 import * as cornerstoneTools from '../index.js';
 import external from '../externalModules.js';
 import EVENTS from '../events.js';
-import { setToolOptions } from '../toolOptions.js';
+import { setToolOptions, getToolOptions } from '../toolOptions.js';
 import simpleTouchTool from './simpleTouchTool.js';
+import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 
 const toolType = 'eraser';
 let configuration = {
@@ -23,8 +24,14 @@ function populateSupportedTools () {
 function deleteNearbyMeasurement (mouseEventData) {
   const coords = mouseEventData.detail.currentPoints.canvas;
   const element = mouseEventData.detail.element;
+  const { mouseButtonMask } = getToolOptions(toolType, element);
+  const { which: buttonClicked } = mouseEventData.detail;
   let foundDataToDelete = false;
   let imageNeedsUpdate = false;
+
+  if (!isMouseButtonEnabled(buttonClicked, mouseButtonMask)) {
+    return;
+  }
 
   Object.entries(configuration.supportedTools).forEach(function ([toolName, tool]) {
     const toolState = cornerstoneTools.getToolState(element, toolName);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`Bugfix` -- a filter was added to the eraser tool. This filter is necessary because it's causing a bug when trying to assign LMB to length (for example) and RMB to eraser.

<img src="https://user-images.githubusercontent.com/1905961/49740190-d97f2c00-fc7a-11e8-8769-a3c3014c050a.gif" width="420" />

* **What is the current behavior?** (You can also link to an open issue here)

**Linked issue**: https://github.com/cornerstonejs/cornerstoneTools/issues/695
**Codepen**: https://codepen.io/anon/pen/eQMpxx

* **What is the new behavior (if this is a feature change)?**

A filter was added to eraser tool event, avoiding it to be triggered when it shouldn't.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:

**FYI**:  @dannyrb, @swederik , @PunyFlash :)