### PR TITLE
Fix flickering of brush canvas.

### DIFF
--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -42,9 +42,6 @@ export default function(evt) {
   const enabledElement = external.cornerstone.getEnabledElement(element);
   const maxSegmentations = BaseBrushTool.getNumberOfColors();
 
-  // Clear the element's cache
-  setters.clearImageBitmapCacheForElement(enabledElement.uuid);
-
   // Invalidate the segmentation bitmap such that it gets redrawn.
   for (let i = 0; i < maxSegmentations; i++) {
     toolData.data[i].invalidated = true;


### PR DESCRIPTION
The brush layer would previously flicker when quickly scrolling through a large image. This was due to clearing the brush layer cache on a new image. This change makes it so that the previous mask is rendered until the new mask is loaded (typically ~1 frame). This lag isn't noticeable, and it much more visually pleasing then the flickering that occurred previously.