### PR TITLE
vNext - Correctly transform brush canvas

### DIFF
--- a/src/drawing/index.js
+++ b/src/drawing/index.js
@@ -31,6 +31,8 @@ import fillTextLines from './fillTextLines.js';
 import getNewContext from './getNewContext.js';
 import path from './path.js';
 import setShadow from './setShadow.js';
+import transformCanvasContext from './transformCanvasContext.js';
+import resetCanvasContextTransform from './resetCanvasContextTransform.js';
 
 // Named exports
 export {
@@ -52,4 +54,6 @@ export {
   getNewContext,
   path,
   setShadow,
+  transformCanvasContext,
+  resetCanvasContextTransform,
 };

--- a/src/drawing/resetCanvasContextTransform.js
+++ b/src/drawing/resetCanvasContextTransform.js
@@ -1,0 +1,14 @@
+/**
+ * Resets the canvas {@link CanvasRenderingContext2D|context} transform to the
+ * {@link https://www.w3.org/TR/2dcontext/#transformations|identity transform}.
+ *
+ * @public
+ * @function resetCanvasContextTransform
+ * @memberof Drawing
+ *
+ * @param {CanvasRenderingContext2D} context - context you wish to transform
+ * @returns null
+ */
+export default function(context) {
+  context.setTransform(1, 0, 0, 1, 0, 0);
+}

--- a/src/drawing/transformCanvasContext.js
+++ b/src/drawing/transformCanvasContext.js
@@ -1,0 +1,39 @@
+/**
+ * Transform the canvas {@link CanvasRenderingContext2D|context} such that it
+ * coincides with the orientation of the viewport.
+ *
+ * @public
+ * @function transformCanvasContext
+ * @memberof Drawing
+ *
+ * @param {CanvasRenderingContext2D} context - Context you wish to transform.
+ * @param {HTMLCanvasElement} canvas - Canvas the context relates to.
+ * @param {*} viewport - The viewport you wish to map on to.
+ * @returns null
+ */
+export default function(context, canvas, viewport) {
+  if (!(viewport.vflip || viewport.vflip || viewport.rotation)) {
+    return;
+  }
+
+  const translation = {
+    x: canvas.width / 2 + viewport.translation.x * viewport.scale,
+    y: canvas.height / 2 + viewport.translation.y * viewport.scale,
+  };
+
+  context.translate(translation.x, translation.y);
+
+  if (viewport.rotation) {
+    context.rotate((viewport.rotation * Math.PI) / 180);
+  }
+
+  if (viewport.vflip) {
+    context.scale(1, -1);
+  }
+
+  if (viewport.hflip) {
+    context.scale(-1, 1);
+  }
+
+  context.translate(-translation.x, -translation.y);
+}

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -4,6 +4,10 @@ import { getToolState, addToolState } from '../stateManagement/toolState.js';
 import external from '../externalModules.js';
 import BaseBrushTool from './../tools/base/BaseBrushTool.js';
 import { getNewContext } from '../drawing/index.js';
+import {
+  resetCanvasContextTransform,
+  transformCanvasContext,
+} from '../drawing/index.js';
 
 /* Safari and Edge polyfill for createImageBitmap
  * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
@@ -205,6 +209,12 @@ function _drawImageBitmap(evt, imageBitmap, alwaysVisible) {
     x: 0,
     y: 0,
   });
+
+  const canvasTopRight = external.cornerstone.pixelToCanvas(eventData.element, {
+    x: eventData.image.width,
+    y: 0,
+  });
+
   const canvasBottomRight = external.cornerstone.pixelToCanvas(
     eventData.element,
     {
@@ -212,19 +222,44 @@ function _drawImageBitmap(evt, imageBitmap, alwaysVisible) {
       y: eventData.image.height,
     }
   );
-  const canvasWidth = canvasBottomRight.x - canvasTopLeft.x;
-  const canvasHeight = canvasBottomRight.y - canvasTopLeft.y;
+
+  const cornerstoneCanvasWidth = external.cornerstoneMath.point.distance(
+    canvasTopLeft,
+    canvasTopRight
+  );
+  const cornerstoneCanvasHeight = external.cornerstoneMath.point.distance(
+    canvasTopRight,
+    canvasBottomRight
+  );
+
+  const canvas = eventData.canvasContext.canvas;
+  const viewport = eventData.viewport;
 
   context.imageSmoothingEnabled = false;
   context.globalAlpha = getLayerAlpha(alwaysVisible);
+
+  transformCanvasContext(context, canvas, viewport);
+
+  const canvasViewportTranslation = {
+    x: viewport.translation.x * viewport.scale,
+    y: viewport.translation.y * viewport.scale,
+  };
+
+  console.log(viewport);
+
   context.drawImage(
     imageBitmap,
-    canvasTopLeft.x,
-    canvasTopLeft.y,
-    canvasWidth,
-    canvasHeight
+    canvas.width / 2 - cornerstoneCanvasWidth / 2 + canvasViewportTranslation.x,
+    canvas.height / 2 -
+      cornerstoneCanvasHeight / 2 +
+      canvasViewportTranslation.y,
+    cornerstoneCanvasWidth,
+    cornerstoneCanvasHeight
   );
+
   context.globalAlpha = 1.0;
+
+  resetCanvasContextTransform(context);
 }
 
 function getLayerAlpha(alwaysVisible) {

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -245,8 +245,6 @@ function _drawImageBitmap(evt, imageBitmap, alwaysVisible) {
     y: viewport.translation.y * viewport.scale,
   };
 
-  console.log(viewport);
-
   context.drawImage(
     imageBitmap,
     canvas.width / 2 - cornerstoneCanvasWidth / 2 + canvasViewportTranslation.x,

--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -156,6 +156,7 @@ export default class EllipticalRoiTool extends BaseAnnotationTool {
 
     // We have tool data for this element - iterate over each one and draw it
     const context = getNewContext(eventData.canvasContext.canvas);
+
     const { image, element } = eventData;
 
     const lineWidth = toolStyle.getToolWidth();

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -40,6 +40,7 @@ export default class BrushTool extends BaseBrushTool {
    */
   renderBrush(evt) {
     const eventData = evt.detail;
+    const viewport = eventData.viewport;
 
     let mousePosition;
 
@@ -74,16 +75,9 @@ export default class BrushTool extends BaseBrushTool {
     context.setTransform(1, 0, 0, 1, 0, 0);
 
     const { cornerstone } = external;
+
+    const circleRadius = radius * viewport.scale;
     const mouseCoordsCanvas = cornerstone.pixelToCanvas(element, mousePosition);
-    const canvasTopLeft = cornerstone.pixelToCanvas(element, {
-      x: 0,
-      y: 0,
-    });
-    const radiusCanvas = cornerstone.pixelToCanvas(element, {
-      x: radius,
-      y: 0,
-    });
-    const circleRadius = Math.abs(radiusCanvas.x - canvasTopLeft.x);
 
     context.beginPath();
     context.strokeStyle = color;


### PR DESCRIPTION
This PR solves (in part) #579 . This PR makes it such that the brush mask is correctly orientated in relation to the `cornerstone` canvas, should the `viewport` be rotated or flipped. This works for arbitrary rotations, not just 90 degree rotations. The image can still be drawn on whilst in an arbitrarily transformed state.

This PR does not address the issues that the ellipse or rectangle tools exhibit when rotated by a non 90-degree rotations.