### PR TITLE
Fix broken cobbs angle

### DIFF
--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -7,7 +7,7 @@ import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
-import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
+import { getNewContext, draw, setShadow, drawLines } from '../util/drawing.js';
 
 const toolType = 'angle';
 
@@ -90,7 +90,8 @@ function onImageRendered (e) {
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);
 
-      drawJoinedLines(context, eventData.element, data.handles.end, [data.handles.start, data.handles.end2], { color });
+      let lines = [ { start: data.handles.start, end: data.handles.end } , { start: data.handles.start2, end: data.handles.end2 } ];
+      drawLines(context, eventData.element, lines , { color });
 
       // Draw the handles
       drawHandles(context, eventData, data.handles);

--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -90,7 +90,7 @@ function onImageRendered (e) {
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);
 
-      let lines = [ { start: data.handles.start, end: data.handles.end } , { start: data.handles.start2, end: data.handles.end2 } ];
+      const lines = [ { start: data.handles.start, end: data.handles.end } , { start: data.handles.start2, end: data.handles.end2 } ];
       drawLines(context, eventData.element, lines , { color });
 
       // Draw the handles

--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -90,8 +90,15 @@ function onImageRendered (e) {
       // Differentiate the color of activation tool
       const color = toolColors.getColorIfActive(data);
 
-      const lines = [ { start: data.handles.start, end: data.handles.end } , { start: data.handles.start2, end: data.handles.end2 } ];
-      drawLines(context, eventData.element, lines , { color });
+      const lines = [{
+        start: data.handles.start,
+        end: data.handles.end
+      }, {
+        start: data.handles.start2,
+        end: data.handles.end2
+      }];
+
+      drawLines(context, eventData.element, lines, { color });
 
       // Draw the handles
       drawHandles(context, eventData, data.handles);


### PR DESCRIPTION
solves issue https://github.com/cornerstonejs/cornerstoneTools/issues/762

The recent version of `angleTool.js` changed to use `drawJoinedLines` which is wrong for cobbs angle (where the lines  are not joined).
This PR uses `drawLines` instead which gives the desired result.

