### PR TITLE
Store initial measurementData in tool state

### DIFF
--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -20,6 +20,7 @@ function getElementToolStateManager (element) {
 function addToolState (element, toolType, measurementData) {
   const toolStateManager = getElementToolStateManager(element);
 
+  if (!measurementData.initial) measurementData.initial = JSON.parse(JSON.stringify(measurementData));
   toolStateManager.add(element, toolType, measurementData);
 
   const eventType = EVENTS.MEASUREMENT_ADDED;

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -20,7 +20,9 @@ function getElementToolStateManager (element) {
 function addToolState (element, toolType, measurementData) {
   const toolStateManager = getElementToolStateManager(element);
 
-  if (!measurementData.initial) measurementData.initial = JSON.parse(JSON.stringify(measurementData));
+  if (measurementData.initial === undefined) {
+    measurementData.initial = JSON.parse(JSON.stringify(measurementData));
+  }
   toolStateManager.add(element, toolType, measurementData);
 
   const eventType = EVENTS.MEASUREMENT_ADDED;


### PR DESCRIPTION
Sore a _copy_ of the initial measurementData in the tool state that can later be used to compare with the current state.

A scenario where this is useful is to solve the current issue where users can create 'dud' annotations (ie length or angle) by just doing a click. Below is a function that can be associated with a mouseup event on the element that uses this PR to  detect and remove such annotations:

```
function cleanEmptyTools(element) {
	const handlesEqual = (h1, h2) => {
		if (h1.start && (!h2.start || h1.start.x!==h2.start.x || h1.start.y!==h2.start.y)) return false;
		if (h1.end && (!h2.end || h1.end.x!==h2.end.x || h1.end.y!==h2.end.y)) return false;
		if (h1.start2 && (!h2.start2 || h1.start2.x!==h2.start2.x || h1.start2.y!==h2.start2.y)) return false;
		if (h1.end2 && (!h2.end2 || h1.end2.x!==h2.end2.x || h1.end2.y!==h2.end2.y)) return false;
		return true;
	}
	
	const toolsState = T.globalImageIdSpecificToolStateManager.toolState;
	let enabledElement = null;
	try { enabledElement = cornerstone.getEnabledElement(element); } catch (e) { return; }
	if (!enabledElement || !enabledElement.image) return;
	const imageId = enabledElement.image.imageId;
	if (!imageId || !toolsState.hasOwnProperty(imageId)) return;
	const imageIdToolState = toolsState[enabledElement.image.imageId];
	
	let imageNeedsUpdate=false;
	Object.keys(imageIdToolState).forEach(toolType => {
		let toolData = imageIdToolState[toolType].data;
		toolData.forEach((data, index) => {
			if (!data.initial) return;

			var remove=false;
			if ((toolType==='length' || toolType==='angle') && handlesEqual(data.handles, data.initial.handles)) remove=true;
			
			if (remove) {
				toolData.splice(index, 1);
				imageNeedsUpdate=true;
			}
		});
	});

	if (imageNeedsUpdate) cornerstone.updateImage(element); 
}
```

(above code only shows handling 'dud' length and angle but can easily be extended for all annotations)