### PR TITLE
vNext - Fix store.getters.enabledElementByUID.

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,9 @@
       });
     });
 
+    console.log(cornerstone.getEnabledElement(elements[0]).uuid);
+    console.log(cornerstoneTools.store);
+
     // Iterate over all tool-category links
     const toolCategoryLinks = document.querySelectorAll(
       'ul.tool-category-list a'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,7 @@
 // Modules
 import brush from './modules/brushModule.js';
 import globalConfiguration from './modules/globalConfigurationModule.js';
+import external from '../externalModules.js';
 
 export const state = {
   // Global
@@ -29,8 +30,10 @@ export const getters = {
       tool.supportedInteractionTypes.includes('Touch')
     ),
   enabledElementByUID: enabledElementUID =>
-    state.enabledElements.filter(
-      enabledElement => enabledElement.uuid === enabledElementUID
+    state.enabledElements.find(
+      element =>
+        external.cornerstone.getEnabledElement(element).uuid ===
+        enabledElementUID
     ),
 };
 


### PR DESCRIPTION
This fixes the `getEnabledElementByUID` getter in the store. It was originally checking the DOM elements for the `cornerstone` uuid, whereas it should have been checking the `cornerstone` `enabledElement`.