### PR TITLE
Elliptical touch-up

### DIFF
--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -90,6 +90,7 @@ function _dragHandler(toolName, annotation, options = {}, evt) {
   const { x, y } = evt.detail.deltaPoints.image;
 
   annotation.active = true;
+  annotation.invalidated = true;
 
   const handleKeys = Object.keys(annotation.handles);
 

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -28,13 +28,14 @@ const _upOrEndEvents = {
 
 /**
  * Move the provided handle
+ *
  * @public
  * @method moveHandle
  * @memberof Manipulators
  *
  * @param {*} evtDetail
  * @param {*} toolName
- * @param {*} toolData
+ * @param {*} annotation
  * @param {*} handle
  * @param {*} [options={}]
  * @param {Boolean}  [options.deleteIfHandleOutsideImage]
@@ -46,7 +47,7 @@ const _upOrEndEvents = {
 export default function(
   evtDetail,
   toolName,
-  toolData,
+  annotation,
   handle,
   options = {},
   interactionType = 'mouse'
@@ -64,7 +65,7 @@ export default function(
   const dragHandler = _dragHandler.bind(
     this,
     toolName,
-    toolData,
+    annotation,
     handle,
     options,
     interactionType
@@ -74,7 +75,7 @@ export default function(
     _upOrEndHandler(
       toolName,
       evtDetail,
-      toolData,
+      annotation,
       handle,
       options,
       interactionType,
@@ -87,7 +88,7 @@ export default function(
   };
 
   handle.active = true;
-  toolData.active = true;
+  annotation.active = true;
   state.isToolLocked = true;
 
   // Add Event Listeners
@@ -126,7 +127,7 @@ export default function(
 
 function _dragHandler(
   toolName,
-  toolData,
+  annotation,
   handle,
   options,
   interactionType,
@@ -141,14 +142,13 @@ function _dragHandler(
     interactionType === 'touch' ? page.y + fingerOffset : page.y
   );
 
-  if (handle.hasMoved === false) {
-    handle.hasMoved = true;
-  }
-
   runAnimation.value = false;
   handle.active = true;
+  handle.hasMoved = true;
   handle.x = targetLocation.x;
   handle.y = targetLocation.y;
+  // TODO: A way to not flip this for textboxes on annotations
+  annotation.invalidated = true;
 
   if (options.preventHandleOutsideImage) {
     clipToBox(handle, image);
@@ -160,7 +160,7 @@ function _dragHandler(
   const modifiedEventData = {
     toolName,
     element,
-    measurementData: toolData,
+    measurementData: annotation,
   };
 
   triggerEvent(element, eventType, modifiedEventData);
@@ -181,6 +181,7 @@ function _upOrEndHandler(
 
   handle.active = false;
   annotation.active = false;
+  // TODO: A way to not flip this for textboxes on annotations
   annotation.invalidated = true;
   state.isToolLocked = false;
   runAnimation.value = false;

--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -292,6 +292,13 @@ function _updateCachedStats(image, element, data, modality, pixelSpacing) {
   data.invalidated = false;
 }
 
+/**
+ *
+ *
+ * @param {*} startHandle
+ * @param {*} endHandle
+ * @returns
+ */
 function _findTextBoxAnchorPoints(startHandle, endHandle) {
   const { left, top, width, height } = _getEllipseImageCoordinates(
     startHandle,

--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -1,5 +1,6 @@
 import external from './../../externalModules.js';
 import BaseAnnotationTool from '../base/BaseAnnotationTool.js';
+
 // State
 import { getToolState } from './../../stateManagement/toolState.js';
 import toolStyle from './../../stateManagement/toolStyle.js';
@@ -97,10 +98,7 @@ export default class EllipticalRoiTool extends BaseAnnotationTool {
    * @param {*} coords
    * @returns {Boolean}
    */
-  pointNearTool(element, data, coords) {
-    // TODO: How should we handle touch? for mouse, distance is 15 for touch its 25
-    const distance = 15;
-
+  pointNearTool(element, data, coords, interactionType) {
     const hasStartAndEndHandles =
       data && data.handles && data.handles.start && data.handles.end;
     const validParameters = hasStartAndEndHandles;
@@ -115,6 +113,7 @@ export default class EllipticalRoiTool extends BaseAnnotationTool {
       return false;
     }
 
+    const distance = interactionType === 'mouse' ? 15 : 25;
     const startCanvas = external.cornerstone.pixelToCanvas(
       element,
       data.handles.start

--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -4,22 +4,25 @@ import BaseAnnotationTool from '../base/BaseAnnotationTool.js';
 import { getToolState } from './../../stateManagement/toolState.js';
 import toolStyle from './../../stateManagement/toolStyle.js';
 import toolColors from './../../stateManagement/toolColors.js';
+
 // Drawing
 import {
   getNewContext,
   draw,
   setShadow,
   drawEllipse,
+  drawHandles,
+  drawLinkedTextBox,
 } from './../../drawing/index.js';
-import drawLinkedTextBox from './../../drawing/drawLinkedTextBox.js';
-import drawHandles from './../../drawing/drawHandles.js';
+
+// Util
 import calculateSUV from './../../util/calculateSUV.js';
-//
+import {
+  pointInEllipse,
+  calculateEllipseStatistics,
+} from './../../util/ellipse/index.js';
 import numbersWithCommas from './../../util/numbersWithCommas.js';
-
-import ellipseUtils from './../../util/ellipse/index.js';
-
-const { pointInEllipse, calculateEllipseStatistics } = ellipseUtils;
+import throttle from './../../util/throttle.js';
 
 /**
  * @public

--- a/src/util/calculateSUV.test.js
+++ b/src/util/calculateSUV.test.js
@@ -5,32 +5,7 @@ import calculateSUV from './calculateSUV.js';
 jest.mock('./../externalModules.js', () => ({
   cornerstone: {
     metaData: {
-      get: jest
-        .fn()
-        .mockReturnValueOnce({
-          patientWeight: 1,
-        })
-        .mockReturnValueOnce({
-          modality: 'PT',
-          seriesTime: {
-            fractionalSeconds: 0,
-            seconds: 0,
-            minutes: 0,
-            hours: 0,
-          },
-        })
-        .mockReturnValueOnce({
-          radiopharmaceuticalInfo: {
-            radiopharmaceuticalStartTime: {
-              fractionalSeconds: 0,
-              seconds: 0,
-              minutes: 0,
-              hours: 0,
-            },
-            radionuclideTotalDose: 1,
-            radionuclideHalfLife: 1,
-          },
-        }),
+      get: jest.fn(),
     },
   },
 }));
@@ -41,27 +16,65 @@ const image = {
   intercept: 1,
 };
 
+const patientStub = {
+  patientWeight: 1,
+};
+
+const generalStub = {
+  modality: 'PT',
+  seriesTime: {
+    fractionalSeconds: 0,
+    seconds: 0,
+    minutes: 0,
+    hours: 0,
+  },
+};
+const petStub = {
+  radiopharmaceuticalInfo: {
+    radiopharmaceuticalStartTime: {
+      fractionalSeconds: 0,
+      seconds: 0,
+      minutes: 0,
+      hours: 0,
+    },
+    radionuclideTotalDose: 1,
+    radionuclideHalfLife: 1,
+  },
+};
+
 describe('calculateSUV.js', () => {
   it('calculates SUV by scaling the pixel value by default', () => {
     // Setup
     const pixelValue = 10;
 
+    external.cornerstone.metaData.get = jest
+      .fn()
+      .mockReturnValueOnce(patientStub)
+      .mockReturnValueOnce(generalStub)
+      .mockReturnValueOnce(petStub);
+
     //
     const result = calculateSUV(image, pixelValue);
 
     // Assert
-    expect(result).toBe(1100);
+    expect(result).toBe(11000);
   });
-});
 
-it('does not rescale the pixel value when skipRescale is true', () => {
-  // Setup
-  const pixelValue = 10;
-  const skipRescale = true;
+  it('does not rescale the pixel value when skipRescale is true', () => {
+    // Setup
+    const pixelValue = 10;
+    const skipRescale = true;
 
-  //
-  const result = calculateSUV(image, pixelValue, skipRescale);
+    external.cornerstone.metaData.get = jest
+      .fn()
+      .mockReturnValueOnce(patientStub)
+      .mockReturnValueOnce(generalStub)
+      .mockReturnValueOnce(petStub);
 
-  // Assert
-  expect(result).toBe(1000);
+    //
+    const result = calculateSUV(image, pixelValue, skipRescale);
+
+    // Assert
+    expect(result).toBe(10000);
+  });
 });

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -1,0 +1,211 @@
+import isObject from './isObject.js';
+
+/**
+ * Creates a debounced function that delays invoking `func` until after `wait`
+ * milliseconds have elapsed since the last time the debounced function was
+ * invoked, or until the next browser frame is drawn. The debounced function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * debounced function. Subsequent calls to the debounced function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the debounced function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * If `wait` is omitted in an environment with `requestAnimationFrame`, `func`
+ * invocation will be deferred until the next frame is drawn (typically about
+ * 16ms).
+ *
+ * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
+ * for details over the differences between `debounce` and `throttle`.
+ *
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to debounce.
+ * @param {number} [wait=0]
+ *  The number of milliseconds to delay; if omitted, `requestAnimationFrame` is
+ *  used (if available).
+ * @param {Object} [options={}] The options object.
+ * @param {boolean} [options.leading=false]
+ *  Specify invoking on the leading edge of the timeout.
+ * @param {number} [options.maxWait]
+ *  The maximum time `func` is allowed to be delayed before it's invoked.
+ * @param {boolean} [options.trailing=true]
+ *  Specify invoking on the trailing edge of the timeout.
+ * @returns {Function} Returns the new debounced function.
+ * @example
+ *
+ * // Avoid costly calculations while the window size is in flux.
+ * jQuery(window).on('resize', debounce(calculateLayout, 150))
+ *
+ * // Invoke `sendMail` when clicked, debouncing subsequent calls.
+ * jQuery(element).on('click', debounce(sendMail, 300, {
+ *   'leading': true,
+ *   'trailing': false
+ * }))
+ *
+ * // Ensure `batchLog` is invoked once after 1 second of debounced calls.
+ * const debounced = debounce(batchLog, 250, { 'maxWait': 1000 })
+ * const source = new EventSource('/stream')
+ * jQuery(source).on('message', debounced)
+ *
+ * // Cancel the trailing debounced invocation.
+ * jQuery(window).on('popstate', debounced.cancel)
+ *
+ * // Check for pending invocations.
+ * const status = debounced.pending() ? "Pending..." : "Ready"
+ */
+function debounce(func, wait, options) {
+  let lastArgs, lastThis, maxWait, result, timerId, lastCallTime;
+
+  let lastInvokeTime = 0;
+  let leading = false;
+  let maxing = false;
+  let trailing = true;
+
+  // Bypass `requestAnimationFrame` by explicitly setting `wait=0`.
+  const useRAF =
+    !wait && wait !== 0 && typeof window.requestAnimationFrame === 'function';
+
+  if (typeof func != 'function') {
+    throw new TypeError('Expected a function');
+  }
+  wait = +wait || 0;
+  if (isObject(options)) {
+    leading = !!options.leading;
+    maxing = 'maxWait' in options;
+    maxWait = maxing ? Math.max(+options.maxWait || 0, wait) : maxWait;
+    trailing = 'trailing' in options ? !!options.trailing : trailing;
+  }
+
+  function invokeFunc(time) {
+    const args = lastArgs;
+    const thisArg = lastThis;
+
+    lastArgs = lastThis = undefined;
+    lastInvokeTime = time;
+    result = func.apply(thisArg, args);
+    return result;
+  }
+
+  function startTimer(pendingFunc, wait) {
+    if (useRAF) {
+      return window.requestAnimationFrame(pendingFunc);
+    }
+    return setTimeout(pendingFunc, wait);
+  }
+
+  function cancelTimer(id) {
+    if (useRAF) {
+      return window.cancelAnimationFrame(id);
+    }
+    clearTimeout(id);
+  }
+
+  function leadingEdge(time) {
+    // Reset any `maxWait` timer.
+    lastInvokeTime = time;
+    // Start the timer for the trailing edge.
+    timerId = startTimer(timerExpired, wait);
+    // Invoke the leading edge.
+    return leading ? invokeFunc(time) : result;
+  }
+
+  function remainingWait(time) {
+    const timeSinceLastCall = time - lastCallTime;
+    const timeSinceLastInvoke = time - lastInvokeTime;
+    const timeWaiting = wait - timeSinceLastCall;
+
+    return maxing
+      ? Math.min(timeWaiting, maxWait - timeSinceLastInvoke)
+      : timeWaiting;
+  }
+
+  function shouldInvoke(time) {
+    const timeSinceLastCall = time - lastCallTime;
+    const timeSinceLastInvoke = time - lastInvokeTime;
+
+    // Either this is the first call, activity has stopped and we're at the
+    // trailing edge, the system time has gone backwards and we're treating
+    // it as the trailing edge, or we've hit the `maxWait` limit.
+    return (
+      lastCallTime === undefined ||
+      timeSinceLastCall >= wait ||
+      timeSinceLastCall < 0 ||
+      (maxing && timeSinceLastInvoke >= maxWait)
+    );
+  }
+
+  function timerExpired() {
+    const time = Date.now();
+    if (shouldInvoke(time)) {
+      return trailingEdge(time);
+    }
+    // Restart the timer.
+    timerId = startTimer(timerExpired, remainingWait(time));
+  }
+
+  function trailingEdge(time) {
+    timerId = undefined;
+
+    // Only invoke if we have `lastArgs` which means `func` has been
+    // debounced at least once.
+    if (trailing && lastArgs) {
+      return invokeFunc(time);
+    }
+    lastArgs = lastThis = undefined;
+    return result;
+  }
+
+  function cancel() {
+    if (timerId !== undefined) {
+      cancelTimer(timerId);
+    }
+    lastInvokeTime = 0;
+    lastArgs = lastCallTime = lastThis = timerId = undefined;
+  }
+
+  function flush() {
+    return timerId === undefined ? result : trailingEdge(Date.now());
+  }
+
+  function pending() {
+    return timerId !== undefined;
+  }
+
+  function debounced(...args) {
+    const time = Date.now();
+    const isInvoking = shouldInvoke(time);
+
+    lastArgs = args;
+    lastThis = this;
+    lastCallTime = time;
+
+    if (isInvoking) {
+      if (timerId === undefined) {
+        return leadingEdge(lastCallTime);
+      }
+      if (maxing) {
+        // Handle invocations in a tight loop.
+        timerId = startTimer(timerExpired, wait);
+        return invokeFunc(lastCallTime);
+      }
+    }
+    if (timerId === undefined) {
+      timerId = startTimer(timerExpired, wait);
+    }
+    return result;
+  }
+  debounced.cancel = cancel;
+  debounced.flush = flush;
+  debounced.pending = pending;
+  return debounced;
+}
+
+export default debounce;

--- a/src/util/ellipse/index.js
+++ b/src/util/ellipse/index.js
@@ -1,6 +1,10 @@
 import calculateEllipseStatistics from './calculateEllipseStatistics.js';
 import pointInEllipse from './pointInEllipse.js';
 
+// Named
+export { calculateEllipseStatistics, pointInEllipse };
+
+// Default
 export default {
   calculateEllipseStatistics,
   pointInEllipse,

--- a/src/util/isObject.js
+++ b/src/util/isObject.js
@@ -1,0 +1,29 @@
+/**
+ * Checks if `value` is the
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
+ * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * isObject({})
+ * // => true
+ *
+ * isObject([1, 2, 3])
+ * // => true
+ *
+ * isObject(Function)
+ * // => true
+ *
+ * isObject(null)
+ * // => false
+ */
+function isObject(value) {
+  const type = typeof value;
+  return value != null && (type == 'object' || type == 'function');
+}
+
+export default isObject;

--- a/src/util/throttle.js
+++ b/src/util/throttle.js
@@ -1,0 +1,70 @@
+import debounce from './debounce.js';
+import isObject from './isObject.js';
+
+/**
+ * Creates a throttled function that only invokes `func` at most once per
+ * every `wait` milliseconds (or once per browser frame). The throttled function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * throttled function. Subsequent calls to the throttled function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the throttled function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * If `wait` is omitted in an environment with `requestAnimationFrame`, `func`
+ * invocation will be deferred until the next frame is drawn (typically about
+ * 16ms).
+ *
+ * See [David Corbacho's article](https://css-tricks.com/debouncing-throttling-explained-examples/)
+ * for details over the differences between `throttle` and `debounce`.
+ *
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to throttle.
+ * @param {number} [wait=0]
+ *  The number of milliseconds to throttle invocations to; if omitted,
+ *  `requestAnimationFrame` is used (if available).
+ * @param {Object} [options={}] The options object.
+ * @param {boolean} [options.leading=true]
+ *  Specify invoking on the leading edge of the timeout.
+ * @param {boolean} [options.trailing=true]
+ *  Specify invoking on the trailing edge of the timeout.
+ * @returns {Function} Returns the new throttled function.
+ * @example
+ *
+ * // Avoid excessively updating the position while scrolling.
+ * jQuery(window).on('scroll', throttle(updatePosition, 100))
+ *
+ * // Invoke `renewToken` when the click event is fired, but not more than once every 5 minutes.
+ * const throttled = throttle(renewToken, 300000, { 'trailing': false })
+ * jQuery(element).on('click', throttled)
+ *
+ * // Cancel the trailing throttled invocation.
+ * jQuery(window).on('popstate', throttled.cancel)
+ */
+function throttle(func, wait, options) {
+  let leading = true;
+  let trailing = true;
+
+  if (typeof func !== 'function') {
+    throw new TypeError('Expected a function');
+  }
+  if (isObject(options)) {
+    leading = 'leading' in options ? !!options.leading : leading;
+    trailing = 'trailing' in options ? !!options.trailing : trailing;
+  }
+  return debounce(func, wait, {
+    leading,
+    trailing,
+    maxWait: wait,
+  });
+}
+
+export default throttle;


### PR DESCRIPTION
## Elliptical ROI Enhancements and Fixes

#### Problem

- ROI calculations were not populated on first placement
- Calculations were only invalidated on `upHandler` for `moveAll` or `moveHandle`
- Misc. performance and code smell issues

#### Solution

- Update `moveAllHandles`, `moveHandle` and `moveNewHandle` to invalidate annotation data when appropriate
- Break `EllipticalRoi` code into smaller, composable methods
- Add calculation throttling (`110 ms`) to improve performance
- Slipped in the ability to toggle on additional stats about the ellipse
- Slipped in the ability to toggle `HU` as a unit for `CT` images

#### Potential Future Enhancements

- Set throttling w/ configuration
- Set unit as `mm` or `cm`
- Configurable `manipulator` to not invalidate when only a textbox has been moved
- Update documentation
- More unit tests <3


#### Default Use

![2019-01-29_10-51-17](https://user-images.githubusercontent.com/5797588/51920980-78d7ba00-23b4-11e9-8b66-d6481471ecdf.gif)


#### Side-by-side mean & stdDev

![image](https://user-images.githubusercontent.com/5797588/51932795-e5ab7e00-23cd-11e9-9e4c-d4eadc5b20a3.png)


#### `showMinMax: true`

![image](https://user-images.githubusercontent.com/5797588/51932839-fe1b9880-23cd-11e9-8372-bb98e958d057.png)

