### PR TITLE
Fix freehand tool doesn't fire MEASUREMENT_MODIFIED event #774 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,10 +86,7 @@ module.exports = {
       }
     ],*/
     //'line-comment-position': 'warn',
-    'linebreak-style': [
-      'warn',
-      'unix'
-    ],
+    'linebreak-style': 0,
     'lines-around-comment': 'warn',
     'lines-around-directive': 'warn',
     //'max-depth': 'warn',

--- a/examples/freehandRoi/index.html
+++ b/examples/freehandRoi/index.html
@@ -163,11 +163,16 @@
       document.getElementById('keyPressed').textContent = "Holding:" + keyName;
     }
 
+    function onModified(e) {
+        console.log(e.detail.measurementData);
+    }
+
     element.tabIndex = 0;
     element.focus();
 
     element.addEventListener("cornerstonetoolskeydown", onKeyDown);
     element.addEventListener("cornerstonetoolskeyup", onKeyUp);
+    element.addEventListener("cornerstonetoolsmeasurementmodified", onModified);
 
     cornerstoneTools.toolStyle.setToolWidth(3);
     cornerstoneTools.toolColors.setToolColor("#ffcc33");

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -279,6 +279,8 @@ function addPoint (eventData) {
 
   // Force onImageRendered to fire
   external.cornerstone.updateImage(eventData.element);
+
+  fireModifiedEvent(eventData.element, data);
 }
 
 /**
@@ -318,7 +320,18 @@ function endDrawing (eventData, handleNearby) {
   config.activePencilMode = false;
   data.canComplete = false;
 
+  const seriesModule = external.cornerstone.metaData.get('generalSeriesModule', eventData.image.imageId);
+  let modality;
+
+  if (seriesModule) {
+    modality = seriesModule.modality;
+  }
+
+  calculateStatistics(data, eventData.element, eventData.image, modality);
+
   external.cornerstone.updateImage(eventData.element);
+
+  fireModifiedEvent(eventData.element, data);
 }
 
 /**
@@ -857,93 +870,7 @@ function onImageRendered (e) {
       }
 
       // Define variables for the area and mean/standard deviation
-      let area,
-        meanStdDev,
-        meanStdDevSUV;
-
-      // Perform a check to see if the tool has been invalidated. This is to prevent
-      // Unnecessary re-calculation of the area, mean, and standard deviation if the
-      // Image is re-rendered but the tool has not moved (e.g. during a zoom)
-      if (data.invalidated === false) {
-        // If the data is not invalidated, retrieve it from the toolData
-        meanStdDev = data.meanStdDev;
-        meanStdDevSUV = data.meanStdDevSUV;
-        area = data.area;
-      } else if (!data.active) {
-        // If the data has been invalidated, and the tool is not currently active,
-        // We need to calculate it again.
-
-        // Retrieve the bounds of the ROI in image coordinates
-        const bounds = {
-          left: data.handles[0].x,
-          right: data.handles[0].x,
-          bottom: data.handles[0].y,
-          top: data.handles[0].x
-        };
-
-        for (let i = 0; i < data.handles.length; i++) {
-          bounds.left = Math.min(bounds.left, data.handles[i].x);
-          bounds.right = Math.max(bounds.right, data.handles[i].x);
-          bounds.bottom = Math.min(bounds.bottom, data.handles[i].y);
-          bounds.top = Math.max(bounds.top, data.handles[i].y);
-        }
-
-        const polyBoundingBox = {
-          left: bounds.left,
-          top: bounds.bottom,
-          width: Math.abs(bounds.right - bounds.left),
-          height: Math.abs(bounds.top - bounds.bottom)
-        };
-
-        // Store the bounding box information for the text box
-        data.polyBoundingBox = polyBoundingBox;
-
-        // First, make sure this is not a color image, since no mean / standard
-        // Deviation will be calculated for color images.
-        if (!image.color) {
-          // Retrieve the array of pixels that the ROI bounds cover
-          const pixels = cornerstone.getPixels(element, polyBoundingBox.left, polyBoundingBox.top, polyBoundingBox.width, polyBoundingBox.height);
-
-          // Calculate the mean & standard deviation from the pixels and the object shape
-          meanStdDev = calculateFreehandStatistics(pixels, polyBoundingBox, data.handles);
-
-          if (modality === 'PT') {
-            // If the image is from a PET scan, use the DICOM tags to
-            // Calculate the SUV from the mean and standard deviation.
-
-            // Note that because we are using modality pixel values from getPixels, and
-            // The calculateSUV routine also rescales to modality pixel values, we are first
-            // Returning the values to storedPixel values before calcuating SUV with them.
-            // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
-            meanStdDevSUV = {
-              mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
-              stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
-            };
-          }
-
-          // If the mean and standard deviation values are sane, store them for later retrieval
-          if (meanStdDev && !isNaN(meanStdDev.mean)) {
-            data.meanStdDev = meanStdDev;
-            data.meanStdDevSUV = meanStdDevSUV;
-          }
-        }
-
-        // Retrieve the pixel spacing values, and if they are not
-        // Real non-zero values, set them to 1
-        const columnPixelSpacing = image.columnPixelSpacing || 1;
-        const rowPixelSpacing = image.rowPixelSpacing || 1;
-        const scaling = columnPixelSpacing * rowPixelSpacing;
-
-        area = freeHandArea(data.handles, scaling);
-
-        // If the area value is sane, store it for later retrieval
-        if (!isNaN(area)) {
-          data.area = area;
-        }
-
-        // Set the invalidated flag to false so that this data won't automatically be recalculated
-        data.invalidated = false;
-      }
+      calculateStatistics(data, element, image, modality);
 
       // Only render text if polygon ROI has been completed and freehand 'shiftKey' mode was not used:
       if (data.polyBoundingBox && !data.textBox.freehand) {
@@ -1022,6 +949,98 @@ function onImageRendered (e) {
   }
 }
 
+function calculateStatistics(data, element, image, modality) {
+  const cornerstone = external.cornerstone;
+
+  // Define variables for the area and mean/standard deviation
+  let area,
+    meanStdDev,
+    meanStdDevSUV;
+
+  // Perform a check to see if the tool has been invalidated. This is to prevent
+  // Unnecessary re-calculation of the area, mean, and standard deviation if the
+  // Image is re-rendered but the tool has not moved (e.g. during a zoom)
+  if (data.invalidated === false) {
+    // If the data is not invalidated, retrieve it from the toolData
+    meanStdDev = data.meanStdDev;
+    meanStdDevSUV = data.meanStdDevSUV;
+    area = data.area;
+  } else if (!data.active) {
+    // If the data has been invalidated, and the tool is not currently active,
+    // We need to calculate it again.
+
+    // Retrieve the bounds of the ROI in image coordinates
+    const bounds = {
+      left: data.handles[0].x,
+      right: data.handles[0].x,
+      bottom: data.handles[0].y,
+      top: data.handles[0].x
+    };
+
+    for (let i = 0; i < data.handles.length; i++) {
+      bounds.left = Math.min(bounds.left, data.handles[i].x);
+      bounds.right = Math.max(bounds.right, data.handles[i].x);
+      bounds.bottom = Math.min(bounds.bottom, data.handles[i].y);
+      bounds.top = Math.max(bounds.top, data.handles[i].y);
+    }
+
+    const polyBoundingBox = {
+      left: bounds.left,
+      top: bounds.bottom,
+      width: Math.abs(bounds.right - bounds.left),
+      height: Math.abs(bounds.top - bounds.bottom)
+    };
+
+    // Store the bounding box information for the text box
+    data.polyBoundingBox = polyBoundingBox;
+
+    // First, make sure this is not a color image, since no mean / standard
+    // Deviation will be calculated for color images.
+    if (!image.color) {
+      // Retrieve the array of pixels that the ROI bounds cover
+      const pixels = cornerstone.getPixels(element, polyBoundingBox.left, polyBoundingBox.top, polyBoundingBox.width, polyBoundingBox.height);
+
+      // Calculate the mean & standard deviation from the pixels and the object shape
+      meanStdDev = calculateFreehandStatistics(pixels, polyBoundingBox, data.handles);
+
+      if (modality === 'PT') {
+        // If the image is from a PET scan, use the DICOM tags to
+        // Calculate the SUV from the mean and standard deviation.
+
+        // Note that because we are using modality pixel values from getPixels, and
+        // The calculateSUV routine also rescales to modality pixel values, we are first
+        // Returning the values to storedPixel values before calcuating SUV with them.
+        // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+        meanStdDevSUV = {
+          mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
+          stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
+        };
+      }
+
+      // If the mean and standard deviation values are sane, store them for later retrieval
+      if (meanStdDev && !isNaN(meanStdDev.mean)) {
+        data.meanStdDev = meanStdDev;
+        data.meanStdDevSUV = meanStdDevSUV;
+      }
+    }
+
+    // Retrieve the pixel spacing values, and if they are not
+    // Real non-zero values, set them to 1
+    const columnPixelSpacing = image.columnPixelSpacing || 1;
+    const rowPixelSpacing = image.rowPixelSpacing || 1;
+    const scaling = columnPixelSpacing * rowPixelSpacing;
+
+    area = freeHandArea(data.handles, scaling);
+
+    // If the area value is sane, store it for later retrieval
+    if (!isNaN(area)) {
+      data.area = area;
+    }
+
+    // Set the invalidated flag to false so that this data won't automatically be recalculated
+    data.invalidated = false;
+  }
+}
 // /////// END IMAGE RENDERING ///////
 /**
 * Attaches event listeners to the element such that is is visible.
@@ -1131,6 +1150,22 @@ function closeToolIfDrawing(element) {
 
     endDrawing(element, lastHandlePlaced);
   }
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementmodified event on provided element
+ * @param {any} element which freehand data has been modified
+ * @param {any} data the measurment data
+ */
+function fireModifiedEvent (element, data) {
+  const eventType = EVENTS.MEASUREMENT_MODIFIED;
+  const modifiedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, modifiedEventData);
 }
 
 /**


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
Freehand example updated to show the feature.
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix freehand tool doesn't fire MEASUREMENT_MODIFIED event #774 and include area statistics on completion.

* **What is the current behavior?** (You can also link to an open issue here)
The cornerstonetoolsmeasurementmodified is not fired from the freehand tool

* **What is the new behavior (if this is a feature change)?**
The cornerstonetoolsmeasurementmodified gets fired and when drawing completed the event will contain the measurement data

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
