### PR TITLE
Fix saving and loading the freehand moust tool. Issue # 775 for v3

### DIFF
--- a/examples/freehand/index.html
+++ b/examples/freehand/index.html
@@ -20,10 +20,13 @@
 			</ul>
 
 			<!-- Select Active Tool -->
-			<ul class="tool-category active" data-tool-category="tools">
-				<li><a href="#" data-tool="FreehandMouse">FreehandMouse</a></li>
-				<li><a href="#" data-tool="FreehandSculpterMouse">FreehandSculpterMouse</a></li>
-			</ul>
+      <ul class="tool-category active" data-tool-category="tools">
+        <li><a href="#" data-tool="FreehandMouse">FreehandMouse</a></li>
+        <li><a href="#" data-tool="FreehandSculpterMouse">FreehandSculpterMouse</a></li>
+        <li><a href="#" id="saveToolState">Save Freehand</a></li>
+        <li><a href="#" id="clearToolState">Clear Freehand</a></li>
+        <li><a href="#" id="loadToolState">Load Freehand State</a></li>
+      </ul>
 			<ul class="tool-category" data-tool-category="mousewheel">
 				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a></li>
 				<li><a href="#" data-tool="ZoomMouseWheel" data-tool-type="wheel">ZoomMouseWheel</a></li>
@@ -478,7 +481,42 @@
 		freehandSculpterTool.hoverCursorFadeDistance = realValue;
 	});
 
+  const saveToolStateButton = document.getElementById('saveToolState');
+  const clearToolStateButton = document.getElementById('clearToolState');
+  const loadToolStateButton = document.getElementById('loadToolState');
+  let toolState = null;
 
+  saveToolStateButton.addEventListener('click', event => {
+		const toolStateString = JSON.stringify(cornerstoneTools.getToolState(element, freehandTool.name));
+
+		if (toolStateString) {
+			toolState = JSON.parse(toolStateString);
+			alert("saved");
+		} else {
+			alert("nothing to save!");
+		}
+  });
+
+  clearToolStateButton.addEventListener('click', event => {
+    cornerstoneTools.clearToolState(element, freehandTool.name);
+
+    cornerstone.updateImage(element);
+  });
+
+  loadToolStateButton.addEventListener('click', event => {
+    if (toolState) {
+      cornerstoneTools.clearToolState(element, freehandTool.name);
+
+      toolState.data.forEach((data) => {
+        cornerstoneTools.addToolState(element, freehandTool.name, data);
+      })
+
+			cornerstone.updateImage(element);
+			alert('loaded');
+    } else {
+			alert ('Nothing has been saved!');
+		}
+  });
 
 </script>
 

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -52,6 +52,16 @@ export default class FreehandSculpterMouseTool extends BaseTool {
       return false;
     }
 
+    const element = eventData.element;
+    const config = this.configuration;
+
+    const toolState = getToolState(element, this.referencedToolName);
+    const data = toolState.data[config.currentTool];
+
+    if (!data) {
+      return false;
+    }
+
     if (this._active) {
       const context = eventData.canvasContext.canvas.getContext('2d');
       const options = {
@@ -121,7 +131,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
       return;
     }
 
-    const dataHandles = toolState.data[config.currentTool].handles.dataHandles;
+    const dataHandles = toolState.data[config.currentTool].handles.points;
 
     // Set the mouseLocation handle
     this._getMouseLocation(eventData);

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -121,7 +121,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
       return;
     }
 
-    const dataHandles = toolState.data[config.currentTool].handles;
+    const dataHandles = toolState.data[config.currentTool].handles.dataHandles;
 
     // Set the mouseLocation handle
     this._getMouseLocation(eventData);

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -214,22 +214,16 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
       return;
     }
 
-    const image = eventData.image;
-    const element = eventData.element;
+    const { image, element } = eventData;
     const config = this.configuration;
     const seriesModule = external.cornerstone.metaData.get(
       'generalSeriesModule',
       image.imageId
     );
-    let modality;
-
-    if (seriesModule) {
-      modality = seriesModule.modality;
-    }
+    const modality = seriesModule ? seriesModule.modality : null;
 
     // We have tool data for this element - iterate over each one and draw it
     const context = getNewContext(eventData.canvasContext.canvas);
-
     const lineWidth = toolStyle.getToolWidth();
 
     for (let i = 0; i < toolState.data.length; i++) {

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -729,11 +729,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     dataHandles[currentHandle].x = config.mouseLocation.handles.start.x;
     dataHandles[currentHandle].y = config.mouseLocation.handles.start.y;
 
-    if (currentHandle === 0) {
-      handleIndex = dataHandles.length - 1;
-    } else {
-      handleIndex = currentHandle - 1;
-    }
+    handleIndex = this._getPrevHandleIndex(currentHandle, dataHandles);
 
     if (currentHandle >= 0) {
       const lastLineIndex = dataHandles[handleIndex].lines.length - 1;
@@ -745,6 +741,19 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
 
     // Update the image
     external.cornerstone.updateImage(eventData.element);
+  }
+
+  /**
+   * Returns the previous handle to the current one.
+   * @param {Number} currentHandle - the current handle index
+   * @param {Array} dataHandles - the handles Array of the freehand data
+   */
+  _getPrevHandleIndex (currentHandle, dataHandles) {
+    if (currentHandle === 0) {
+      return dataHandles.length - 1;
+    } else {
+      return currentHandle - 1;
+    }
   }
 
   /**


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
Updated freehand example
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes the issue described here:
Freehand handles not closed after loading state data #775

Also, another issue has been fixed that is caused by mixing the freehand "handles" as an Array type and an Object type at the same time causing the serialization of the handles array to lose the object data fields "textBox", "start"... once serialized.

The "handles" has been changed to be an object which contains a separate field called "dataHandles" of type Array.

Finally, although the freehand now can be saved/loaded successfully, the save using JSON.serialize will fail if the sculpture tool is applied on the freehand because of circular object dependency. However, this is best handled as a separate issue.

* **What is the current behavior?** (You can also link to an open issue here)
Saving/loading the freehand allow the last handle to be moved seperately from the start handle as described here #775 

Also, once loaded, the text box doesn't show up and you can't draw any more freehand because of debugger errors. 

* **What is the new behavior (if this is a feature change)?**
Freehand can be saved/loaded successfully and text box rendered.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
