### PR TITLE
Protect against `null` viewport pixelSpacing

### DIFF
--- a/src/tools/OverlayTool.js
+++ b/src/tools/OverlayTool.js
@@ -59,12 +59,16 @@ export default class OverlayTool extends BaseTool {
     ) || { overlays: [] };
     const overlays = overlaysMeta.overlays;
 
+    const viewportPixelSpacing = {
+      column: viewport.displayedArea.columnPixelSpacing || 1,
+      row: viewport.displayedArea.rowPixelSpacing || 1,
+    };
     const imageWidth =
       Math.abs(viewport.displayedArea.brhc.x - viewport.displayedArea.tlhc.x) *
-      viewport.displayedArea.columnPixelSpacing;
+      viewportPixelSpacing.column;
     const imageHeight =
       Math.abs(viewport.displayedArea.brhc.y - viewport.displayedArea.tlhc.y) *
-      viewport.displayedArea.rowPixelSpacing;
+      viewportPixelSpacing.row;
 
     context.save();
 


### PR DESCRIPTION
Our `viewport` pixel spacings can be null, which results in a `0` width/height for the `layerCanvas`, which causes an exception.

We can either bail out early, or assume a `1:1` pixelSpacing in  this situation