### PR TITLE
feat: Updates the freehand suite to use spacing in image coords.

### DIFF
--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -568,12 +568,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
     points[previousIndex].lines.pop();
     points[previousIndex].lines.push(points[insertIndex]);
 
-    // Add the line from the inserted handle to the handle after
-    if (insertIndex === points.length - 1) {
-      points[insertIndex].lines.push(points[0]);
-    } else {
-      points[insertIndex].lines.push(points[insertIndex + 1]);
-    }
+    freehandUtils.addLine(points, insertIndex);
   }
 
   /**

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -382,33 +382,6 @@ export default class FreehandSculpterMouseTool extends BaseTool {
   }
 
   /**
-   * _getImageToCanvasSpacingModifier - Returns the scaling modifier from
-   * image to canvas.
-   *
-   *
-   * @param {Object} eventData - Data object associated with the event.
-   * @returns {Number}           The scaling modifier.
-   */
-  /*
-  _getImageToCanvasSpacingModifier(eventData) {
-    const image = eventData.image;
-    const element = eventData.element;
-
-    const topLeftCanvas = external.cornerstone.pixelToCanvas(element, {
-      x: 0,
-      y: 0,
-    });
-
-    const bottomRightCanvas = external.cornerstone.pixelToCanvas(element, {
-      x: image.columns,
-      y: image.rows,
-    });
-
-    return (bottomRightCanvas.x - topLeftCanvas.x) / image.columns;
-  }
-  */
-
-  /**
    * Pushes the points radially away from the mouse if they are
    * contained within the circle defined by the freehandSculpter's toolSize and
    * the mouse position.

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -102,10 +102,9 @@ export default class FreehandSculpterMouseTool extends BaseTool {
 
     if (config.currentTool === null) {
       this._selectFreehandTool(eventData);
-      this._initialiseSculpting(eventData);
-    } else {
-      this._initialiseSculpting(eventData);
     }
+
+    this._initialiseSculpting(eventData);
 
     external.cornerstone.updateImage(eventData.element);
 

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -904,7 +904,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     const mousePoint = config.mouseLocation.handles.start;
 
     const handleFurtherThanMinimumSpacing = handle =>
-      this._isDistanceLargerThanSpacingCanvas(element, handle, mousePoint);
+      this._isDistanceLargerThanSpacing(element, handle, mousePoint);
 
     if (points.every(handleFurtherThanMinimumSpacing)) {
       this._addPoint(eventData);
@@ -1156,9 +1156,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
 
     // Compare with all other handles appart from the last one
     for (let i = 1; i < points.length - 1; i++) {
-      if (
-        this._isDistanceSmallerThanSpacingCanvas(element, points[i], mousePoint)
-      ) {
+      if (this._isDistanceSmallerThanSpacing(element, points[i], mousePoint)) {
         return true;
       }
     }
@@ -1177,10 +1175,13 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    *                              allowed canvas spacing.
    */
   _isDistanceSmallerThanCompleteSpacingCanvas(element, p1, p2) {
-    return this._compareDistanceToSpacingCanvas(
+    const p1Canvas = external.cornerstone.pixelToCanvas(element, p1);
+    const p2Canvas = external.cornerstone.pixelToCanvas(element, p2);
+
+    return this._compareDistanceToSpacing(
       element,
-      p1,
-      p2,
+      p1Canvas,
+      p2Canvas,
       '<',
       this.configuration.completeHandleRadius
     );
@@ -1196,10 +1197,10 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {boolean}            True if the distance is smaller than the
    *                              allowed canvas spacing.
    */
-  _isDistanceSmallerThanSpacingCanvas(element, p1, p2) {
+  _isDistanceSmallerThanSpacing(element, p1, p2) {
     const config = this.configuration;
 
-    return this._compareDistanceToSpacingCanvas(element, p1, p2, '<');
+    return this._compareDistanceToSpacing(element, p1, p2, '<');
   }
 
   /**
@@ -1212,10 +1213,10 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {boolean}            True if the distance is smaller than the
    *                              allowed canvas spacing.
    */
-  _isDistanceLargerThanSpacingCanvas(element, p1, p2) {
+  _isDistanceLargerThanSpacing(element, p1, p2) {
     const config = this.configuration;
 
-    return this._compareDistanceToSpacingCanvas(element, p1, p2, '>');
+    return this._compareDistanceToSpacing(element, p1, p2, '>');
   }
 
   /**
@@ -1229,27 +1230,18 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {boolean}            True if the distance is smaller than the
    *                              allowed canvas spacing.
    */
-  _compareDistanceToSpacingCanvas(
+  _compareDistanceToSpacing(
     element,
     p1,
     p2,
     comparison = '>',
     spacing = this.configuration.spacing
   ) {
-    const p1Canvas = external.cornerstone.pixelToCanvas(element, p1);
-    const p2Canvas = external.cornerstone.pixelToCanvas(element, p2);
-
-    let result;
-
     if (comparison === '>') {
-      result =
-        external.cornerstoneMath.point.distance(p1Canvas, p2Canvas) > spacing;
-    } else {
-      result =
-        external.cornerstoneMath.point.distance(p1Canvas, p2Canvas) < spacing;
+      return external.cornerstoneMath.point.distance(p1, p2) > spacing;
     }
 
-    return result;
+    return external.cornerstoneMath.point.distance(p1, p2) < spacing;
   }
 
   /**

--- a/src/util/freehand/addLine.js
+++ b/src/util/freehand/addLine.js
@@ -1,0 +1,15 @@
+/**
+ * AddLine - Adds a line to a specifc index of a freehand tool points array.
+ *
+ * @param  {Object[]} points      The array of points.
+ * @param  {Number} insertIndex The index to insert the line.
+ * @returns {Null}             description
+ */
+export default function(points, insertIndex) {
+  // Add the line from the inserted handle to the handle after
+  if (insertIndex === points.length - 1) {
+    points[insertIndex].lines.push(points[0]);
+  } else {
+    points[insertIndex].lines.push(points[insertIndex + 1]);
+  }
+}

--- a/src/util/freehand/index.js
+++ b/src/util/freehand/index.js
@@ -6,6 +6,7 @@ import freehandIntersect from './freehandIntersect.js';
 import FreehandLineFinder from './FreehandLineFinder.js';
 import insertOrDelete from './insertOrDelete.js';
 import pointInFreehand from './pointInFreehand.js';
+import addLine from './addLine.js';
 
 export default {
   calculateFreehandStatistics,
@@ -16,4 +17,5 @@ export default {
   FreehandLineFinder,
   insertOrDelete,
   pointInFreehand,
+  addLine,
 };

--- a/src/util/freehand/insertOrDelete.js
+++ b/src/util/freehand/insertOrDelete.js
@@ -2,6 +2,7 @@ import FreehandLineFinder from './FreehandLineFinder.js';
 import FreehandHandleData from './FreehandHandleData.js';
 import { getToolState } from '../../stateManagement/toolState.js';
 import external from '../../externalModules.js';
+import addLine from './addLine.js';
 
 /**
  * Inserts or deletes a point from a freehand tool.
@@ -117,12 +118,7 @@ function _insertPoint(eventData, insertInfo) {
   points[insertIndex - 1].lines.pop();
   points[insertIndex - 1].lines.push(eventData.currentPoints.image);
 
-  // Add the line from the inserted handle to the handle after
-  if (insertIndex === points.length - 1) {
-    points[insertIndex].lines.push(points[0]);
-  } else {
-    points[insertIndex].lines.push(points[insertIndex + 1]);
-  }
+  addLine(points, insertIndex);
 
   data.active = true;
   data.highlight = true;


### PR DESCRIPTION
The FreehandMouseTool and `FreehandMouseSculpterTool` now use spacing based on image coordinates, rather than the canvas. Thus the `FreehandMouseSculpterTool` no longer adds a load of points if zoom right in and sculpt.

Additionally new points are only added to the region being sculpted. This improves performance and reduces the number of superfluous points.