### PR TITLE
Allocate labelmap memory on demand rather than on image load.

### DIFF
--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -61,28 +61,15 @@ export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
   const maxSegmentations = BaseBrushTool.getNumberOfColors();
-  let toolData = getToolState(
+  const activeSegIndex = store.modules.brush.state.drawColorId;
+
+  const toolData = getToolState(
     element,
     BaseBrushTool.getReferencedToolDataName()
   );
 
   if (!toolData) {
-    // Make toolData array as big as max number of segmentations.
-    for (let i = 0; i < maxSegmentations; i++) {
-      addToolState(element, BaseBrushTool.getReferencedToolDataName(), {});
-    }
-
-    toolData = getToolState(element, BaseBrushTool.getReferencedToolDataName());
-
-    // TEMP: HACK: Create first pixel data such that the tool has some data and the brush
-    // Cursor can be rendered. Can be replaced once we have a mechanism for SVG cursors.
-    const newPixelData = new Uint8ClampedArray(
-      eventData.image.width * eventData.image.height
-    );
-
-    toolData.data[0].pixelData = newPixelData;
-
-    toolData = getToolState(element, BaseBrushTool.getReferencedToolDataName());
+    return;
   }
 
   const enabledElement = external.cornerstone.getEnabledElement(element);

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -14,31 +14,17 @@ const { setters } = store.modules.brush;
 export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
+  const activeSegIndex = store.modules.brush.state.drawColorId;
   let toolData = getToolState(
     element,
     BaseBrushTool.getReferencedToolDataName()
   );
 
   if (!toolData) {
-    // Make toolData array as big as max number of segmentations.
-    const maxSegmentations = BaseBrushTool.getNumberOfColors();
-
-    for (let i = 0; i < maxSegmentations; i++) {
-      addToolState(element, BaseBrushTool.getReferencedToolDataName(), {});
-    }
-
-    toolData = getToolState(element, BaseBrushTool.getReferencedToolDataName());
-
-    // TEMP: HACK: Create first pixel data such that the tool has some data and the brush
-    // Cursor can be rendered. Can be replaced once we have a mechanism for SVG cursors.
-    const newPixelData = new Uint8ClampedArray(
-      eventData.image.width * eventData.image.height
-    );
-
-    toolData.data[0].pixelData = newPixelData;
-
+    addToolState(element, BaseBrushTool.getReferencedToolDataName(), {});
     toolData = getToolState(element, BaseBrushTool.getReferencedToolDataName());
   }
+
   const enabledElement = external.cornerstone.getEnabledElement(element);
   const maxSegmentations = BaseBrushTool.getNumberOfColors();
 

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -430,6 +430,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {null}
    */
   static invalidateBrushOnEnabledElement(enabledElementUID) {
+    /** WIP **/
     const element = store.getters.enabledElementByUID(enabledElementUID);
 
     const stackToolState = getToolState(element, 'stack');
@@ -451,15 +452,6 @@ class BaseBrushTool extends BaseTool {
     };
 
     const toolState = globalImageIdSpecificToolStateManager.saveToolState();
-
-    // TODO -> Put this elsewhere
-    /*
-    const buffer = new ArrayBuffer(dim.xyz);
-
-    const unit8View = new Uint8Array(buffer);
-
-    console.log(unit8View.length);
-    */
 
     for (let i = 0; i < imageIds.length; i++) {
       const imageId = imageIds[i];
@@ -484,6 +476,7 @@ class BaseBrushTool extends BaseTool {
    * @return {type}  description
    */
   static getDataAsVolume(enabledElementUID) {
+    /** WIP **/
     const element = store.getters.enabledElementByUID(enabledElementUID);
 
     const stackToolState = getToolState(element, 'stack');

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -1,6 +1,9 @@
 import external from './../../externalModules.js';
 import BaseBrushTool from './../base/BaseBrushTool.js';
-import { getToolState } from './../../stateManagement/toolState.js';
+import {
+  getToolState,
+  addToolState,
+} from './../../stateManagement/toolState.js';
 import store from './../../store/index.js';
 import brushUtils from './../../util/brush/index.js';
 import EVENTS from '../../events';
@@ -118,7 +121,19 @@ function _overlappingStrategy(evt, configuration) {
   const element = eventData.element;
   const { rows, columns } = eventData.image;
   const { x, y } = eventData.currentPoints.image;
-  const toolState = getToolState(element, configuration.referencedToolData);
+  let toolState = getToolState(
+    element,
+    BaseBrushTool.getReferencedToolDataName()
+  );
+
+  if (!toolState) {
+    addToolState(element, BaseBrushTool.getReferencedToolDataName(), {});
+    toolState = getToolState(
+      element,
+      BaseBrushTool.getReferencedToolDataName()
+    );
+  }
+
   const toolData = toolState.data;
 
   if (x < 0 || x > columns || y < 0 || y > rows) {
@@ -136,7 +151,20 @@ function _nonOverlappingStrategy(evt, configuration) {
   const element = eventData.element;
   const { rows, columns } = eventData.image;
   const { x, y } = eventData.currentPoints.image;
-  const toolState = getToolState(element, configuration.referencedToolData);
+
+  let toolState = getToolState(
+    element,
+    BaseBrushTool.getReferencedToolDataName()
+  );
+
+  if (!toolState) {
+    addToolState(element, BaseBrushTool.getReferencedToolDataName(), {});
+    toolState = getToolState(
+      element,
+      BaseBrushTool.getReferencedToolDataName()
+    );
+  }
+
   const toolData = toolState.data;
   const segmentationIndex = state.drawColorId;
 

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -32,8 +32,6 @@ export default class BrushTool extends BaseBrushTool {
     super(initialConfiguration);
 
     this.initialConfiguration = initialConfiguration;
-
-    console.log(this);
   }
 
   /**


### PR DESCRIPTION
re #834

Now labelmaps are only added to the slice when they are drawn. If you try to erase a labelmap that doesn't exist it now doesn't insert a blank one. This improves performance when stack scrolling through a new set of images, as the memory for the labelmaps is now only allocated when you begin drawing.