### PR TITLE
Feature/event dispatch locking changes

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/mouseDown.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDown.js
@@ -6,6 +6,7 @@ import getToolsWithMoveableHandles from '../../store/getToolsWithMoveableHandles
 import { findHandleDataNearImagePoint } from '../../util/findAndMoveHelpers.js';
 import getInteractiveToolsForElement from './../../store/getInteractiveToolsForElement.js';
 import getToolsWithDataForElement from './../../store/getToolsWithDataForElement.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 /**
  * MouseDown is called before MouseDownActivate. If MouseDown
@@ -34,13 +35,17 @@ export default function(evt) {
 
   // ACTIVE TOOL W/ PRE CALLBACK?
   // Note: In theory, this should only ever be a single tool.
-  const activeTools = activeAndPassiveTools.filter(
+  let activeTools = activeAndPassiveTools.filter(
     tool =>
       tool.mode === 'active' &&
       Array.isArray(tool.options.mouseButtonMask) &&
       tool.options.mouseButtonMask.includes(eventData.buttons) &&
       tool.options.isMouseActive
   );
+
+  if (state.isMultiPartToolActive) {
+    activeTools = filterToolsUseableWithMultiPartTools(activeTools);
+  }
 
   // If any tools are active, check if they have a special reason for dealing with the event.
   if (activeTools.length > 0) {
@@ -60,6 +65,11 @@ export default function(evt) {
         return;
       }
     }
+  }
+
+  if (state.isMultiPartToolActive) {
+    // Don't fire events to Annotation Tools during a multi part loop.
+    return;
   }
 
   // Annotation tool specific

--- a/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
@@ -2,6 +2,7 @@ import addNewMeasurement from './addNewMeasurement.js';
 import { getters, state } from './../../store/index.js';
 import getActiveToolsForElement from './../../store/getActiveToolsForElement.js';
 import BaseAnnotationTool from './../../tools/base/BaseAnnotationTool.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 // Todo: We could simplify this if we only allow one active
 // Tool per mouse button mask?
@@ -24,6 +25,10 @@ export default function(evt) {
       tool.options.isMouseActive
   );
 
+  if (state.isMultiPartToolActive) {
+    tools = filterToolsUseableWithMultiPartTools(tools);
+  }
+
   if (tools.length === 0) {
     return;
   }
@@ -36,6 +41,10 @@ export default function(evt) {
     if (consumedEvent) {
       return;
     }
+  }
+
+  if (state.isMultiPartToolActive) {
+    return;
   }
 
   // Note: custom `addNewMeasurement` will need to prevent event bubbling

--- a/src/eventDispatchers/mouseEventHandlers/mouseDrag.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDrag.js
@@ -1,5 +1,6 @@
 import { getters, state } from './../../store/index.js';
 import getActiveToolsForElement from './../../store/getActiveToolsForElement.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 // Tools like wwwc. Non-annotation tools w/ specific
 // Down + mouse behavior
@@ -24,6 +25,10 @@ export default function(evt) {
       tool.options.isMouseActive
   );
   tools = tools.filter(tool => typeof tool.mouseDragCallback === 'function');
+
+  if (state.isMultiPartToolActive) {
+    tools = filterToolsUseableWithMultiPartTools(tools);
+  }
 
   if (tools.length === 0) {
     return;

--- a/src/eventDispatchers/mouseEventHandlers/mouseMove.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseMove.js
@@ -12,7 +12,7 @@ import getToolsWithDataForElement from './../../store/getToolsWithDataForElement
  * @param {*} evt
  */
 export default function(evt) {
-  if (state.isToolLocked) {
+  if (state.isToolLocked || state.isMultiPartToolActive) {
     return;
   }
 

--- a/src/eventDispatchers/shared/customCallbackHandler.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.js
@@ -1,5 +1,6 @@
 import { state } from './../../store/index.js';
 import getActiveToolsForElement from './../../store/getActiveToolsForElement.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 export default function(handlerType, customFunction, evt) {
   if (state.isToolLocked) {
@@ -16,6 +17,10 @@ export default function(handlerType, customFunction, evt) {
   tools = getActiveToolsForElement(element, tools, handlerType);
   // Tool has expected callback custom function
   tools = tools.filter(tool => typeof tool[customFunction] === 'function');
+
+  if (state.isMultiPartToolActive) {
+    tools = filterToolsUseableWithMultiPartTools(tools);
+  }
 
   if (tools.length === 0) {
     return false;

--- a/src/eventDispatchers/shared/customCallbackHandler.test.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.test.js
@@ -5,6 +5,7 @@ import getActiveToolsForElement from './../../store/getActiveToolsForElement.js'
 jest.mock('./../../store/index.js', () => ({
   state: {
     isToolLocked: false,
+    isMultiPartToolActive: false,
     tools: [
       {
         aDifferentCustomFunctionName: jest.fn(),

--- a/src/eventDispatchers/shared/customCallbackHandler.test.js
+++ b/src/eventDispatchers/shared/customCallbackHandler.test.js
@@ -28,6 +28,9 @@ jest.mock('./../../store/index.js', () => ({
 }));
 
 jest.mock('./../../store/getActiveToolsForElement.js', () => jest.fn());
+jest.mock('./../../store/filterToolsUsableWithMultiPartTools.js', () =>
+  jest.fn()
+);
 
 describe('eventDispatchers/customCallbackHandler.js', () => {
   const firstToolWithCustomFunction = state.tools[1];
@@ -40,6 +43,7 @@ describe('eventDispatchers/customCallbackHandler.js', () => {
 
   beforeEach(() => {
     state.isToolLocked = false;
+    state.isMultiPartToolActive = false;
 
     jest.resetAllMocks();
     jest.clearAllMocks();

--- a/src/eventDispatchers/touchEventHandlers/multiTouchDrag.js
+++ b/src/eventDispatchers/touchEventHandlers/multiTouchDrag.js
@@ -1,5 +1,6 @@
 import { state } from '../../store/index.js';
 import getActiveToolsForElement from '../../store/getActiveToolsForElement.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 export default function(evt) {
   if (state.isToolLocked) {
@@ -20,6 +21,10 @@ export default function(evt) {
       typeof tool.multiTouchDragCallback === 'function' &&
       numPointers === tool.configuration.touchPointers
   );
+
+  if (state.isMultiPartToolActive) {
+    tools = filterToolsUseableWithMultiPartTools(tools);
+  }
 
   if (tools.length === 0) {
     return false;

--- a/src/eventDispatchers/touchEventHandlers/tap.js
+++ b/src/eventDispatchers/touchEventHandlers/tap.js
@@ -12,7 +12,7 @@ import { moveHandle, moveAllHandles } from '../../manipulators/index.js';
 import deactivateAllToolInstances from './shared/deactivateAllToolInstances.js';
 
 export default function(evt) {
-  if (state.isToolLocked) {
+  if (state.isToolLocked || state.isMultiPartToolActive) {
     return;
   }
 

--- a/src/eventDispatchers/touchEventHandlers/touchStart.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStart.js
@@ -1,11 +1,11 @@
 // State
 import { getters, state } from '../../store/index.js';
-// Import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
 import { findHandleDataNearImagePoint } from '../../util/findAndMoveHelpers.js';
 import getToolsWithMoveableHandles from '../../store/getToolsWithMoveableHandles.js';
 import { getToolState } from './../../stateManagement/toolState.js';
 import getInteractiveToolsForElement from './../../store/getInteractiveToolsForElement.js';
 import getToolsWithDataForElement from './../../store/getToolsWithDataForElement.js';
+import filterToolsUseableWithMultiPartTools from './../../store/filterToolsUsableWithMultiPartTools.js';
 
 export default function(evt) {
   if (state.isToolLocked) {
@@ -21,9 +21,13 @@ export default function(evt) {
     getters.touchTools()
   );
 
-  const activeTools = activeAndPassiveTools.filter(
+  let activeTools = activeAndPassiveTools.filter(
     tool => tool.mode === 'active' && tool.options.isTouchActive
   );
+
+  if (state.isMultiPartToolActive) {
+    activeTools = filterToolsUseableWithMultiPartTools(activeTools);
+  }
 
   // If any tools are active, check if they have a special reason for dealing with the event.
   if (activeTools.length > 0) {

--- a/src/eventDispatchers/touchEventHandlers/touchStartActive.js
+++ b/src/eventDispatchers/touchEventHandlers/touchStartActive.js
@@ -5,7 +5,7 @@ import addNewMeasurement from './addNewMeasurement.js';
 import BaseAnnotationTool from './../../tools/base/BaseAnnotationTool.js';
 
 export default function(evt) {
-  if (state.isToolLocked) {
+  if (state.isToolLocked || state.isMultiPartToolActive) {
     return;
   }
 

--- a/src/store/filterToolsUsableWithMultiPartTools.js
+++ b/src/store/filterToolsUsableWithMultiPartTools.js
@@ -1,0 +1,21 @@
+import BaseAnnotationTool from '../tools/base/BaseAnnotationTool.js';
+import BaseBrushTool from '../tools/base/BaseBrushTool.js';
+
+/**
+ * Filters an array of tools, returning only tools which are active or passive.
+ * @export
+ * @public
+ * @method
+ * @name filterToolsUseableWithMultiPartTools
+ *
+ * @param  {Object[]} tools      The input tool array.
+ * @returns {Object[]}            The filtered array.
+ */
+export default function(tools) {
+  return tools.filter(
+    tool =>
+      !tool.isMultiPartTool &&
+      !(tool instanceof BaseAnnotationTool) &&
+      !(tool instanceof BaseBrushTool)
+  );
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,6 +11,7 @@ export const state = {
   enabledElements: [],
   tools: [],
   isToolLocked: false,
+  activeMultiPartTool: null,
   mousePositionImage: {},
   // Settings
   clickProximity: 6,

--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -35,6 +35,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
     super(initialConfiguration);
 
     this.hasCursor = true;
+    this.isMultiPartTool = true;
     this.initialConfiguration = initialConfiguration;
     this.referencedToolName = initialConfiguration.referencedToolName;
 
@@ -153,7 +154,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
 
     this._active = false;
 
-    state.isToolLocked = false;
+    state.isMultiPartToolActive = false;
 
     this._getMouseLocation(eventData);
     this._invalidateToolData(eventData);
@@ -335,7 +336,7 @@ export default class FreehandSculpterMouseTool extends BaseTool {
     this._active = true;
 
     // Interupt event dispatcher
-    state.isToolLocked = true;
+    state.isMultiPartToolActive = true;
 
     this._configureToolSize(eventData);
     this._getMouseLocation(eventData);

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -52,6 +52,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     super(initialConfiguration);
 
     this.initialConfiguration = initialConfiguration;
+    this.isMultiPartTool = true;
 
     this._drawing = false;
     this._dragging = false;
@@ -569,7 +570,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     this._activateModify(element);
 
     // Interupt eventDispatchers
-    state.isToolLocked = true;
+    state.isMultiPartToolActive = true;
 
     preventPropagation(evt);
   }
@@ -624,6 +625,11 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingMouseDragCallback(evt) {
     const eventData = evt.detail;
+
+    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+      return;
+    }
+
     const toolState = getToolState(eventData.element, this.name);
 
     const config = this.configuration;
@@ -649,13 +655,18 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _drawingMouseUpCallback(evt) {
+    const eventData = evt.detail;
+
+    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+      return;
+    }
+
     if (!this._dragging) {
       return;
     }
 
     this._dragging = false;
 
-    const eventData = evt.detail;
     const element = eventData.element;
 
     const config = this.configuration;
@@ -683,6 +694,11 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingMouseDownCallback(evt) {
     const eventData = evt.detail;
+
+    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+      return;
+    }
+
     const element = eventData.element;
     const coords = eventData.currentPoints.canvas;
 
@@ -715,6 +731,11 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _editMouseDragCallback(evt) {
     const eventData = evt.detail;
+
+    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+      return;
+    }
+
     const toolState = getToolState(eventData.element, this.name);
 
     const config = this.configuration;
@@ -771,6 +792,11 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _editMouseUpCallback(evt) {
     const eventData = evt.detail;
+
+    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+      return;
+    }
+
     const element = eventData.element;
     const toolState = getToolState(eventData.element, this.name);
 
@@ -779,7 +805,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     this._dropHandle(eventData, toolState);
     this._endDrawing(element);
 
-    state.isToolLocked = false;
+    state.isMultiPartToolActive = false;
 
     external.cornerstone.updateImage(eventData.element);
   }
@@ -837,7 +863,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     const config = this.configuration;
 
     // Block event distpatcher whilst drawing
-    state.isToolLocked = true;
+    state.isMultiPartToolActive = true;
 
     this._referencedElement = element;
 
@@ -949,7 +975,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
 
     if (this._drawing) {
       this._drawing = false;
-      state.isToolLocked = false;
+      state.isMultiPartToolActive = false;
       this._deactivateDraw(element);
     }
 


### PR DESCRIPTION
feat(Event Dispatchers): Can now use non-annotation tools during a multi-part tool's loop.
    
Added a new flag, isMultiPartTool to tools, and a global state trigger you may set called isMultiPartToolActive. If this is true, only non-annotation tools may be used whilst you are in a multi-part tool's event loop.
    
re #833