### PR TITLE
Add measurement completed event #787

### DIFF
--- a/examples/allImageTools/index.html
+++ b/examples/allImageTools/index.html
@@ -44,7 +44,7 @@
             </div>
             <br/>
         </div>
-        <div class="col-xs-10">
+        <div class="col-xs-7">
             <div style="width:512px;height:512px;position:relative;display:inline-block;color:white;"
                  oncontextmenu="return false"
                  class='cornerstone-enabled-image'
@@ -66,6 +66,14 @@
                 <div id="mrbottomleft" style="position: absolute;bottom:3px; left:3px">
                     WW/WC:
                 </div>
+            </div>
+        </div>
+        <div class="col-xs-3">
+            <div class="h3">Tool Events:</div>
+            <div style="float:left;
+            overflow-y: auto;
+            height: 512px;">
+                <ul id="logger"></ul>
             </div>
         </div>
     </div>
@@ -122,7 +130,68 @@
         document.getElementById('mrbottomright').textContent = "Zoom: " + viewport.scale.toFixed(2);
     };
 
+    function onMeasurementadded (e){
+        document.getElementById('logger').innerHTML = "";
+        const node = document.createElement('li');
+        const textnode = document.createTextNode(`Added ${e.detail.toolType}`);
+        node.appendChild(textnode); 
+        document.getElementById('logger').appendChild(node);
+    }
+    
+    function onMeasurementModified (e){
+        const node = document.createElement('li');
+        const textnode = document.createTextNode("Modified");
+        const elem = document.getElementById('logger');
+        
+        node.appendChild(textnode); 
+        elem.appendChild(node);
+        elem.parentElement.scrollTop = elem.parentElement.scrollHeight;
+    }
+
+    function onMeasurementRemoved (e) {
+        const node = document.createElement('li');
+        const textnode = document.createTextNode("Removed");
+        const elem = document.getElementById('logger');
+        
+        node.appendChild(textnode); 
+        elem.appendChild(node);
+        elem.parentElement.scrollTop = elem.parentElement.scrollHeight;
+    }
+
+    function onMeasurementCompleted (e) {
+        const node = document.createElement('li');
+        const displayValue = getMeasurementDisplayValue(e.detail);
+        const textnode = document.createTextNode(`Completed: ${displayValue}`);
+        const elem = document.getElementById('logger');
+        
+        node.appendChild(textnode); 
+        elem.appendChild(node);
+        elem.parentElement.scrollTop = elem.parentElement.scrollHeight;
+    }
+
+    function getMeasurementDisplayValue(measurement) {
+        const measurementData = measurement.measurementData;
+
+        if (measurementData.area) {
+            return `Area = ${measurementData.area} ${measurementData.unit}`;
+        } else if (measurementData.length) {
+            return `Length = ${measurementData.length} ${measurementData.unit}`;
+        } else if (measurementData.rAngle){
+            return `Angle = ${measurementData.rAngle} ${measurementData.unit}`;
+        } else if (measurementData.text || measurementData.str) {
+            return `${measurementData.str}, ${measurementData.text}`;
+        } 
+        else {
+            return '';
+        }
+    }
+
     element.addEventListener('cornerstoneimagerendered', onImageRendered);
+
+    element.addEventListener('cornerstonetoolsmeasurementadded', onMeasurementadded);
+    element.addEventListener('cornerstonetoolsmeasurementmodified', onMeasurementModified);
+    element.addEventListener('cornerstonemeasurementremoved', onMeasurementRemoved);
+    element.addEventListener('cornerstonemeasurementcompleted', onMeasurementCompleted);
 
     var imageId = 'example://1';
 

--- a/src/events.js
+++ b/src/events.js
@@ -33,6 +33,7 @@ const EVENTS = {
   MEASUREMENT_ADDED: 'cornerstonetoolsmeasurementadded',
   MEASUREMENT_MODIFIED: 'cornerstonetoolsmeasurementmodified',
   MEASUREMENT_REMOVED: 'cornerstonemeasurementremoved',
+  MEASUREMENT_COMPLETED: 'cornerstonemeasurementcompleted',
   TOOL_DEACTIVATED: 'cornerstonetoolstooldeactivated',
   CLIP_STOPPED: 'cornerstonetoolsclipstopped',
   STACK_SCROLL: 'cornerstonestackscroll', // Should be renamed

--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -1,3 +1,4 @@
+import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -8,6 +9,8 @@ import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { getNewContext, draw, setShadow, drawLines } from '../util/drawing.js';
+import triggerEvent from '../util/triggerEvent.js';
+import getColRowPixelSpacing from '../util/getColRowPixelSpacing.js';
 
 const toolType = 'angle';
 
@@ -103,22 +106,13 @@ function onImageRendered (e) {
       // Draw the handles
       drawHandles(context, eventData, data.handles);
 
-      // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
-      // Where lines cross to measure angle. For now it will show smallest angle.
-      const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
-      const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
-      const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * columnPixelSpacing;
-      const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * rowPixelSpacing;
-      const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * columnPixelSpacing;
-      const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * rowPixelSpacing;
+      calcualteAngle(data, eventData.image);
 
-      let angle = Math.acos(Math.abs(((dx1 * dx2) + (dy1 * dy2)) / (Math.sqrt((dx1 * dx1) + (dy1 * dy1)) * Math.sqrt((dx2 * dx2) + (dy2 * dy2)))));
-
-      angle *= (180 / Math.PI);
-
-      const rAngle = roundToDecimal(angle, 2);
+      const rAngle = data.rAngle;
       const str = '00B0'; // Degrees symbol
-      const text = rAngle.toString() + String.fromCharCode(parseInt(str, 16));
+
+      data.unit = String.fromCharCode(parseInt(str, 16));
+      const text = rAngle.toString() + data.unit;
 
       const handleStartCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.start2);
       const handleEndCanvas = cornerstone.pixelToCanvas(eventData.element, data.handles.end2);
@@ -132,19 +126,66 @@ function onImageRendered (e) {
 }
 // /////// END IMAGE RENDERING ///////
 
+function calcualteAngle (data, image) {
+  // Need to work on correct angle to measure.  This is a cobb angle and we need to determine
+  // Where lines cross to measure angle. For now it will show smallest angle.
+  let { rowPixelSpacing, colPixelSpacing } = getColRowPixelSpacing(image);
+
+  rowPixelSpacing = rowPixelSpacing || 1;
+  colPixelSpacing = colPixelSpacing || 1;
+
+  const dx1 = (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) * colPixelSpacing;
+  const dy1 = (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) * rowPixelSpacing;
+  const dx2 = (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) * colPixelSpacing;
+  const dy2 = (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) * rowPixelSpacing;
+
+  let angle = Math.acos(Math.abs(((dx1 * dx2) + (dy1 * dy2)) / (Math.sqrt((dx1 * dx1) + (dy1 * dy1)) * Math.sqrt((dx2 * dx2) + (dy2 * dy2)))));
+
+  angle *= (180 / Math.PI);
+
+  data.rAngle = roundToDecimal(angle, 2);
+}
+
+function onHandleDoneMove (element, data) {
+  const image = external.cornerstone.getImage(element);
+
+  calcualteAngle(data, image);
+
+  fireCompleted(element, data);
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementcompleted event on provided element
+ * @param {any} element which freehand data has been completed
+ * @param {any} data the measurment data
+ * @return {void}
+ */
+function fireCompleted (element, data) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}
+
 // Module exports
 const angle = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
   pointNearTool,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 const angleTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
   pointNearTool,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 export {

--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -9,7 +8,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import lineSegDistance from '../util/lineSegDistance.js';
 import { getNewContext, draw, setShadow, drawLines } from '../util/drawing.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import getColRowPixelSpacing from '../util/getColRowPixelSpacing.js';
 
 const toolType = 'angle';
@@ -151,24 +150,7 @@ function onHandleDoneMove (element, data) {
 
   calcualteAngle(data, image);
 
-  fireCompleted(element, data);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementcompleted event on provided element
- * @param {any} element which freehand data has been completed
- * @param {any} data the measurment data
- * @return {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 // Module exports

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -89,12 +89,14 @@ function addNewMeasurement (mouseEventData) {
     if (anyHandlesOutsideImage(mouseEventData, measurementData.handles)) {
       // Delete the measurement
       removeToolState(element, toolType, measurementData);
-    }
+    } else {
+      const config = arrowAnnotate.getConfiguration();
 
-    const config = arrowAnnotate.getConfiguration();
+      if (measurementData.text === undefined) {
+        config.getTextCallback(doneChangingTextCallback);
+      }
 
-    if (measurementData.text === undefined) {
-      config.getTextCallback(doneChangingTextCallback);
+      onHandleDoneMove(element, measurementData);
     }
 
     cornerstone.updateImage(element);
@@ -294,18 +296,20 @@ function addNewMeasurementTouch (touchEventData) {
   cornerstone.updateImage(element);
 
   moveNewHandleTouch(touchEventData, toolType, measurementData, measurementData.handles.end, function () {
-    cornerstone.updateImage(element);
-
     if (anyHandlesOutsideImage(touchEventData, measurementData.handles)) {
       // Delete the measurement
       removeToolState(element, toolType, measurementData);
+    } else {
+      const config = arrowAnnotate.getConfiguration();
+
+      if (measurementData.text === undefined) {
+        config.getTextCallback(doneChangingTextCallback);
+      }
+
+      onHandleDoneMove(element, measurementData);
     }
 
-    const config = arrowAnnotate.getConfiguration();
-
-    if (measurementData.text === undefined) {
-      config.getTextCallback(doneChangingTextCallback);
-    }
+    cornerstone.updateImage(element);
   });
 }
 
@@ -426,13 +430,35 @@ function pressCallback (e) {
   e.stopPropagation();
 }
 
+function onHandleDoneMove (element, data) {
+  fireCompleted(element, data);
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementcompleted event on provided element
+ * @param {any} element which freehand data has been completed
+ * @param {any} data the measurment data
+ * @return {void}
+ */
+function fireCompleted (element, data) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}
+
 const arrowAnnotate = mouseButtonTool({
   addNewMeasurement,
   createNewMeasurement,
   onImageRendered,
   pointNearTool,
   toolType,
-  mouseDoubleClickCallback: doubleClickCallback
+  mouseDoubleClickCallback: doubleClickCallback,
+  onHandleDoneMove
 });
 
 arrowAnnotate.setConfiguration(configuration);
@@ -443,7 +469,8 @@ const arrowAnnotateTouch = touchTool({
   onImageRendered,
   pointNearTool,
   toolType,
-  pressCallback
+  pressCallback,
+  onHandleDoneMove
 });
 
 export { arrowAnnotate, arrowAnnotateTouch };

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -20,6 +20,7 @@ import lineSegDistance from '../util/lineSegDistance.js';
 import { getNewContext, draw, setShadow } from '../util/drawing.js';
 import { textBoxWidth } from '../util/drawTextBox.js';
 import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 
 const toolType = 'arrowAnnotate';
 
@@ -431,24 +432,7 @@ function pressCallback (e) {
 }
 
 function onHandleDoneMove (element, data) {
-  fireCompleted(element, data);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementcompleted event on provided element
- * @param {any} element which freehand data has been completed
- * @param {any} data the measurment data
- * @return {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 const arrowAnnotate = mouseButtonTool({

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -8,7 +7,7 @@ import drawHandles from '../manipulators/drawHandles.js';
 import pointInEllipse from '../util/pointInEllipse.js';
 import calculateEllipseStatistics from '../util/calculateEllipseStatistics.js';
 import calculateSUV from '../util/calculateSUV.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import { drawEllipse, getNewContext, draw, setShadow } from '../util/drawing.js';
@@ -352,24 +351,7 @@ function onHandleDoneMove (element, data) {
 
   calculateStatistics(data, element, image, modality, rowPixelSpacing, colPixelSpacing);
 
-  fireCompleted(element, data);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementmodified event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @return {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 // Module exports

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -1,3 +1,4 @@
+import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -7,9 +8,11 @@ import drawHandles from '../manipulators/drawHandles.js';
 import pointInEllipse from '../util/pointInEllipse.js';
 import calculateEllipseStatistics from '../util/calculateEllipseStatistics.js';
 import calculateSUV from '../util/calculateSUV.js';
+import triggerEvent from '../util/triggerEvent.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import { drawEllipse, getNewContext, draw, setShadow } from '../util/drawing.js';
+import getColRowPixelSpacing from '../util/getColRowPixelSpacing.js';
 
 const toolType = 'ellipticalRoi';
 
@@ -116,18 +119,8 @@ function onImageRendered (e) {
   const lineWidth = toolStyle.getToolWidth();
   const config = ellipticalRoi.getConfiguration();
   const seriesModule = cornerstone.metaData.get('generalSeriesModule', image.imageId);
-  const imagePlane = cornerstone.metaData.get('imagePlaneModule', image.imageId);
   let modality;
-  let rowPixelSpacing;
-  let colPixelSpacing;
-
-  if (imagePlane) {
-    rowPixelSpacing = imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing;
-    colPixelSpacing = imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing;
-  } else {
-    rowPixelSpacing = image.rowPixelSpacing;
-    colPixelSpacing = image.columnPixelSpacing;
-  }
+  const { rowPixelSpacing, colPixelSpacing } = getColRowPixelSpacing(eventData.image);
 
   if (seriesModule) {
     modality = seriesModule.modality;
@@ -173,71 +166,7 @@ function onImageRendered (e) {
         drawHandles(context, eventData, data.handles, color);
       }
 
-      // Define variables for the area and mean/standard deviation
-      let area,
-        meanStdDev,
-        meanStdDevSUV;
-
-      // Perform a check to see if the tool has been invalidated. This is to prevent
-      // Unnecessary re-calculation of the area, mean, and standard deviation if the
-      // Image is re-rendered but the tool has not moved (e.g. during a zoom)
-      if (data.invalidated === false) {
-        // If the data is not invalidated, retrieve it from the toolData
-        meanStdDev = data.meanStdDev;
-        meanStdDevSUV = data.meanStdDevSUV;
-        area = data.area;
-      } else {
-        // If the data has been invalidated, we need to calculate it again
-
-        // Retrieve the bounds of the ellipse in image coordinates
-        const ellipse = {
-          left: Math.round(Math.min(data.handles.start.x, data.handles.end.x)),
-          top: Math.round(Math.min(data.handles.start.y, data.handles.end.y)),
-          width: Math.round(Math.abs(data.handles.start.x - data.handles.end.x)),
-          height: Math.round(Math.abs(data.handles.start.y - data.handles.end.y))
-        };
-
-        // First, make sure this is not a color image, since no mean / standard
-        // Deviation will be calculated for color images.
-        if (!image.color) {
-          // Retrieve the array of pixels that the ellipse bounds cover
-          const pixels = cornerstone.getPixels(element, ellipse.left, ellipse.top, ellipse.width, ellipse.height);
-
-          // Calculate the mean & standard deviation from the pixels and the ellipse details
-          meanStdDev = calculateEllipseStatistics(pixels, ellipse);
-
-          if (modality === 'PT') {
-            // If the image is from a PET scan, use the DICOM tags to
-            // Calculate the SUV from the mean and standard deviation.
-
-            // Note that because we are using modality pixel values from getPixels, and
-            // The calculateSUV routine also rescales to modality pixel values, we are first
-            // Returning the values to storedPixel values before calcuating SUV with them.
-            // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
-            meanStdDevSUV = {
-              mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
-              stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
-            };
-          }
-
-          // If the mean and standard deviation values are sane, store them for later retrieval
-          if (meanStdDev && !isNaN(meanStdDev.mean)) {
-            data.meanStdDev = meanStdDev;
-            data.meanStdDevSUV = meanStdDevSUV;
-          }
-        }
-
-        // Calculate the image area from the ellipse dimensions and pixel spacing
-        area = Math.PI * (ellipse.width * (colPixelSpacing || 1) / 2) * (ellipse.height * (rowPixelSpacing || 1) / 2);
-
-        // If the area value is sane, store it for later retrieval
-        if (!isNaN(area)) {
-          data.area = area;
-        }
-
-        // Set the invalidated flag to false so that this data won't automatically be recalculated
-        data.invalidated = false;
-      }
+      calculateStatistics(data, element, image, modality, rowPixelSpacing, colPixelSpacing);
 
       // If the textbox has not been moved by the user, it should be displayed on the right-most
       // Side of the tool.
@@ -337,19 +266,127 @@ function onImageRendered (e) {
 }
 // /////// END IMAGE RENDERING ///////
 
+function calculateStatistics (data, element, image, modality, rowPixelSpacing, colPixelSpacing) {
+  const cornerstone = external.cornerstone;
+  // Define variables for the area and mean/standard deviation
+  let area,
+    meanStdDev,
+    meanStdDevSUV;
+
+  // Perform a check to see if the tool has been invalidated. This is to prevent
+  // Unnecessary re-calculation of the area, mean, and standard deviation if the
+  // Image is re-rendered but the tool has not moved (e.g. during a zoom)
+  if (data.invalidated === false) {
+    // If the data is not invalidated, retrieve it from the toolData
+    meanStdDev = data.meanStdDev;
+    meanStdDevSUV = data.meanStdDevSUV;
+    area = data.area;
+  } else {
+    // If the data has been invalidated, we need to calculate it again
+
+    // Retrieve the bounds of the ellipse in image coordinates
+    const ellipse = {
+      left: Math.round(Math.min(data.handles.start.x, data.handles.end.x)),
+      top: Math.round(Math.min(data.handles.start.y, data.handles.end.y)),
+      width: Math.round(Math.abs(data.handles.start.x - data.handles.end.x)),
+      height: Math.round(Math.abs(data.handles.start.y - data.handles.end.y))
+    };
+
+    // First, make sure this is not a color image, since no mean / standard
+    // Deviation will be calculated for color images.
+    if (!image.color) {
+      // Retrieve the array of pixels that the ellipse bounds cover
+      const pixels = cornerstone.getPixels(element, ellipse.left, ellipse.top, ellipse.width, ellipse.height);
+
+      // Calculate the mean & standard deviation from the pixels and the ellipse details
+      meanStdDev = calculateEllipseStatistics(pixels, ellipse);
+
+      if (modality === 'PT') {
+        // If the image is from a PET scan, use the DICOM tags to
+        // Calculate the SUV from the mean and standard deviation.
+
+        // Note that because we are using modality pixel values from getPixels, and
+        // The calculateSUV routine also rescales to modality pixel values, we are first
+        // Returning the values to storedPixel values before calcuating SUV with them.
+        // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+        meanStdDevSUV = {
+          mean: calculateSUV(image, (meanStdDev.mean - image.intercept) / image.slope),
+          stdDev: calculateSUV(image, (meanStdDev.stdDev - image.intercept) / image.slope)
+        };
+      }
+
+      // If the mean and standard deviation values are sane, store them for later retrieval
+      if (meanStdDev && !isNaN(meanStdDev.mean)) {
+        data.meanStdDev = meanStdDev;
+        data.meanStdDevSUV = meanStdDevSUV;
+      }
+    }
+
+    // Calculate the image area from the ellipse dimensions and pixel spacing
+    area = Math.PI * (ellipse.width * (colPixelSpacing || 1) / 2) * (ellipse.height * (rowPixelSpacing || 1) / 2);
+
+    // If the area value is sane, store it for later retrieval
+    if (!isNaN(area)) {
+      data.area = area;
+
+      data.unit = `mm${String.fromCharCode(178)}`;
+      if (!rowPixelSpacing || !colPixelSpacing) {
+        data.unit = `pixels${String.fromCharCode(178)}`;
+      }
+    }
+
+    // Set the invalidated flag to false so that this data won't automatically be recalculated
+    data.invalidated = false;
+  }
+}
+
+function onHandleDoneMove (element, data) {
+  const image = external.cornerstone.getImage(element);
+  const seriesModule = external.cornerstone.metaData.get('generalSeriesModule', image.imageId);
+  let modality;
+  const { rowPixelSpacing, colPixelSpacing } = getColRowPixelSpacing(image);
+
+  if (seriesModule) {
+    modality = seriesModule.modality;
+  }
+
+  calculateStatistics(data, element, image, modality, rowPixelSpacing, colPixelSpacing);
+
+  fireCompleted(element, data);
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementmodified event on provided element
+ * @param {any} element which freehand data has been modified
+ * @param {any} data the measurment data
+ * @return {void}
+ */
+function fireCompleted (element, data) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}
+
 // Module exports
 const ellipticalRoi = mouseButtonTool({
   createNewMeasurement,
   onImageRendered,
   pointNearTool,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 const ellipticalRoiTouch = touchTool({
   createNewMeasurement,
   onImageRendered,
   pointNearTool: pointNearToolTouch,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 export { ellipticalRoi, ellipticalRoiTouch };

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -7,6 +7,7 @@ import handleActivator from '../manipulators/handleActivator.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 import calculateSUV from '../util/calculateSUV.js';
 import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { addToolState, getToolState, removeToolState } from '../stateManagement/toolState.js';
@@ -344,7 +345,7 @@ function endDrawing (eventData, handleNearby) {
 
     calculateStatistics(data, eventData.element, eventData.image, modality, rowPixelSpacing, colPixelSpacing);
 
-    fireCompleted(eventData.element, data);
+    triggerMeasurementCompletedEvent(eventData.element, data, toolType);
   }
 
   external.cornerstone.updateImage(eventData.element);
@@ -1200,23 +1201,6 @@ function fireModifiedEvent (element, data) {
   };
 
   triggerEvent(element, eventType, modifiedEventData);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementcompleted event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @returns {void}
-*/
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
 }
 
 /**

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -1,3 +1,5 @@
+import EVENTS from '../events.js';
+import triggerEvent from '../util/triggerEvent.js';
 import external from '../externalModules.js';
 import mouseButtonRectangleTool from './mouseButtonRectangleTool.js';
 import touchTool from './touchTool.js';
@@ -135,6 +137,27 @@ function onImageRendered (e) {
 }
 // /////// END IMAGE RENDERING ///////
 
+function onHandleDoneMove ( element, data) {
+  fireCompleted(element, data);
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementmodified event on provided element
+ * @param {any} element which freehand data has been modified
+ * @param {any} data the measurment data
+ * @returns {void}
+ */
+function fireCompleted (element, data) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}
+
 // Module exports
 const preventHandleOutsideImage = true;
 
@@ -143,7 +166,8 @@ const highlight = mouseButtonRectangleTool({
   onImageRendered,
   pointNearTool,
   pointInsideRect,
-  toolType
+  toolType,
+  onHandleDoneMove
 }, preventHandleOutsideImage);
 
 const highlightTouch = touchTool({
@@ -151,7 +175,8 @@ const highlightTouch = touchTool({
   onImageRendered,
   pointNearTool,
   pointInsideRect,
-  toolType
+  toolType,
+  onHandleDoneMove
 }, preventHandleOutsideImage);
 
 export {

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -1,5 +1,4 @@
-import EVENTS from '../events.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import external from '../externalModules.js';
 import mouseButtonRectangleTool from './mouseButtonRectangleTool.js';
 import touchTool from './touchTool.js';
@@ -137,25 +136,8 @@ function onImageRendered (e) {
 }
 // /////// END IMAGE RENDERING ///////
 
-function onHandleDoneMove ( element, data) {
-  fireCompleted(element, data);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementmodified event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @returns {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
+function onHandleDoneMove (element, data) {
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 // Module exports

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -1,8 +1,7 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
@@ -63,24 +62,7 @@ function onHandleDoneMove (element, data) {
 
   calculateLength(data, rowPixelSpacing, colPixelSpacing);
 
-  fireCompleted(element, data);
-}
-
-/**
- * Fire cornerstonetoolsmeasurementmodified event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @returns {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 // /////// BEGIN IMAGE RENDERING ///////

--- a/src/imageTools/mouseButtonRectangleTool.js
+++ b/src/imageTools/mouseButtonRectangleTool.js
@@ -34,6 +34,8 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
       if (anyHandlesOutsideImage(mouseEventData, measurementData.handles)) {
         // Delete the measurement
         removeToolState(mouseEventData.element, toolType, measurementData);
+      } else if(mouseToolInterface.onHandleDoneMove) {
+        mouseToolInterface.onHandleDoneMove(element, measurementData);
       }
 
       element.addEventListener(EVENTS.MOUSE_MOVE, mouseMoveCallback);
@@ -108,6 +110,8 @@ export default function (mouseToolInterface, preventHandleOutsideImage) {
       if (anyHandlesOutsideImage(eventData, data.handles)) {
         // Delete the measurement
         removeToolState(eventData.element, toolType, data);
+      } else if(mouseToolInterface.onHandleDoneMove) {
+        mouseToolInterface.onHandleDoneMove(element, data);
       }
 
       cornerstone.updateImage(eventData.element);

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -93,6 +93,8 @@ export default function (mouseToolInterface) {
       if (anyHandlesOutsideImage(eventData, data.handles)) {
         // Delete the measurement
         removeToolState(element, toolType, data);
+      } else if(mouseToolInterface.onHandleDoneMove) {
+        mouseToolInterface.onHandleDoneMove(element, data);
       }
 
       external.cornerstone.updateImage(element);
@@ -217,6 +219,8 @@ export default function (mouseToolInterface) {
       if (anyHandlesOutsideImage(mouseEventData, measurementData.handles)) {
         // Delete the measurement
         removeToolState(element, toolType, measurementData);
+      } else if(mouseToolInterface.onHandleDoneMove) {
+        mouseToolInterface.onHandleDoneMove(element, measurementData);
       }
 
       element.addEventListener(EVENTS.MOUSE_MOVE, mouseMove);

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -1,5 +1,4 @@
-import EVENTS from '../events.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -106,7 +105,7 @@ function onHandleDoneMove (element, data) {
 
   calculateDisplayData(data, element, image);
 
-  fireCompleted(element, data);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 function calculateDisplayData (data, element, image) {
@@ -134,23 +133,6 @@ function calculateDisplayData (data, element, image) {
       }
     }
   }
-}
-
-/**
- * Fire cornerstonetoolsmeasurementmodified event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @returns {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
 }
 
 // Module exports

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -1,4 +1,3 @@
-import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
@@ -6,7 +5,7 @@ import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import calculateSUV from '../util/calculateSUV.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import drawLinkedTextBox from '../util/drawLinkedTextBox.js';
 import { getNewContext, draw, setShadow, drawRect } from '../util/drawing.js';
@@ -294,7 +293,7 @@ function onHandleDoneMove (element, data) {
 
   calculateStatistics(data, element, image, modality, rowPixelSpacing, colPixelSpacing);
 
-  fireCompleted(element, data);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 function calculateStatistics (data, element, image, modality, rowPixelSpacing, colPixelSpacing) {
@@ -370,23 +369,6 @@ function calculateStatistics (data, element, image, modality, rowPixelSpacing, c
     // Set the invalidated flag to false so that this data won't automatically be recalculated
     data.invalidated = false;
   }
-}
-
-/**
- * Fire cornerstonetoolsmeasurementmodified event on provided element
- * @param {any} element which freehand data has been modified
- * @param {any} data the measurment data
- * @returns {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
 }
 
 // Module exports

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -14,7 +14,7 @@ import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
 import { textBoxWidth } from '../util/drawTextBox.js';
-import triggerEvent from '../util/triggerEvent.js';
+import triggerMeasurementCompletedEvent from '../util/triggerMeasurementCompletedEvent.js';
 import getColRowPixelSpacing from '../util/getColRowPixelSpacing.js';
 
 
@@ -279,7 +279,7 @@ function onHandleDoneMove (element, data) {
 
   calcualteAngle(data, image);
 
-  fireCompleted(element, data);
+  triggerMeasurementCompletedEvent(element, data, toolType);
 }
 
 function calcualteAngle (data, image) {
@@ -315,23 +315,6 @@ function calcualteAngle (data, image) {
 
   data.rAngle = roundToDecimal(angle, 2);
 
-}
-
-/**
- * Fire cornerstonetoolsmeasurementcompleted event on provided element
- * @param {any} element which freehand data has been completed
- * @param {any} data the measurment data
- * @returns {void}
- */
-function fireCompleted (element, data) {
-  const eventType = EVENTS.MEASUREMENT_COMPLETED;
-  const completedEventData = {
-    toolType,
-    element,
-    measurementData: data
-  };
-
-  triggerEvent(element, eventType, completedEventData);
 }
 
 const simpleAngle = mouseButtonTool({

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -14,6 +14,8 @@ import lineSegDistance from '../util/lineSegDistance.js';
 import { addToolState, removeToolState, getToolState } from '../stateManagement/toolState.js';
 import { getNewContext, draw, setShadow, drawJoinedLines } from '../util/drawing.js';
 import { textBoxWidth } from '../util/drawTextBox.js';
+import triggerEvent from '../util/triggerEvent.js';
+import getColRowPixelSpacing from '../util/getColRowPixelSpacing.js';
 
 
 const toolType = 'simpleAngle';
@@ -116,38 +118,10 @@ function onImageRendered (e) {
 
       drawHandles(context, eventData, data.handles, color, handleOptions);
 
-      // Default to isotropic pixel size, update suffix to reflect this
-      const columnPixelSpacing = eventData.image.columnPixelSpacing || 1;
-      const rowPixelSpacing = eventData.image.rowPixelSpacing || 1;
-
-      const sideA = {
-        x: (Math.ceil(data.handles.middle.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
-        y: (Math.ceil(data.handles.middle.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
-      };
-
-      const sideB = {
-        x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.middle.x)) * columnPixelSpacing,
-        y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.middle.y)) * rowPixelSpacing
-      };
-
-      const sideC = {
-        x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.start.x)) * columnPixelSpacing,
-        y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
-      };
-
-      const sideALength = length(sideA);
-      const sideBLength = length(sideB);
-      const sideCLength = length(sideC);
-
-      // Cosine law
-      let angle = Math.acos((Math.pow(sideALength, 2) + Math.pow(sideBLength, 2) - Math.pow(sideCLength, 2)) / (2 * sideALength * sideBLength));
-
-      angle *= (180 / Math.PI);
-
-      data.rAngle = roundToDecimal(angle, 2);
+      calcualteAngle(data, eventData.image);
 
       if (data.rAngle) {
-        const text = textBoxText(data, eventData.image.rowPixelSpacing, eventData.image.columnPixelSpacing);
+        const text = textBoxText(data, eventData.image);
 
         const distance = 15;
 
@@ -184,11 +158,14 @@ function onImageRendered (e) {
     });
   }
 
-  function textBoxText (data, rowPixelSpacing, columnPixelSpacing) {
-    const suffix = (!rowPixelSpacing || !columnPixelSpacing) ? ' (isotropic)' : '';
+  function textBoxText (data, image) {
+    const { rowPixelSpacing, colPixelSpacing } = getColRowPixelSpacing(image);
+    const suffix = (!rowPixelSpacing || !colPixelSpacing) ? ' (isotropic)' : '';
     const str = '00B0'; // Degrees symbol
 
-    return data.rAngle.toString() + String.fromCharCode(parseInt(str, 16)) + suffix;
+    data.unit = String.fromCharCode(parseInt(str, 16)) + suffix;
+
+    return data.rAngle.toString() + data.unit;
   }
 
   function textBoxAnchorPoints (handles) {
@@ -237,6 +214,8 @@ function addNewMeasurement (mouseEventData) {
       if (anyHandlesOutsideImage(mouseEventData, measurementData.handles)) {
         // Delete the measurement
         removeToolState(element, toolType, measurementData);
+      } else {
+        onHandleDoneMove(element, measurementData);
       }
 
       element.addEventListener(EVENTS.MOUSE_MOVE, simpleAngle.mouseMoveCallback);
@@ -282,6 +261,8 @@ function addNewMeasurementTouch (touchEventData) {
         // Delete the measurement
         removeToolState(element, toolType, measurementData);
         cornerstone.updateImage(element);
+      } else {
+        onHandleDoneMove(element, measurementData);
       }
 
       element.addEventListener(EVENTS.TOUCH_DRAG, simpleAngleTouch.touchMoveCallback);
@@ -292,12 +273,74 @@ function addNewMeasurementTouch (touchEventData) {
   });
 }
 
+
+function onHandleDoneMove (element, data) {
+  const image = external.cornerstone.getImage(element);
+
+  calcualteAngle(data, image);
+
+  fireCompleted(element, data);
+}
+
+function calcualteAngle (data, image) {
+  let { rowPixelSpacing, colPixelSpacing } = getColRowPixelSpacing(image);
+
+  // Default to isotropic pixel size, update suffix to reflect this
+  rowPixelSpacing = rowPixelSpacing || 1;
+  colPixelSpacing = colPixelSpacing || 1;
+
+  const sideA = {
+    x: (Math.ceil(data.handles.middle.x) - Math.ceil(data.handles.start.x)) * colPixelSpacing,
+    y: (Math.ceil(data.handles.middle.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
+  };
+
+  const sideB = {
+    x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.middle.x)) * colPixelSpacing,
+    y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.middle.y)) * rowPixelSpacing
+  };
+
+  const sideC = {
+    x: (Math.ceil(data.handles.end.x) - Math.ceil(data.handles.start.x)) * colPixelSpacing,
+    y: (Math.ceil(data.handles.end.y) - Math.ceil(data.handles.start.y)) * rowPixelSpacing
+  };
+
+  const sideALength = length(sideA);
+  const sideBLength = length(sideB);
+  const sideCLength = length(sideC);
+
+  // Cosine law
+  let angle = Math.acos((Math.pow(sideALength, 2) + Math.pow(sideBLength, 2) - Math.pow(sideCLength, 2)) / (2 * sideALength * sideBLength));
+
+  angle *= (180 / Math.PI);
+
+  data.rAngle = roundToDecimal(angle, 2);
+
+}
+
+/**
+ * Fire cornerstonetoolsmeasurementcompleted event on provided element
+ * @param {any} element which freehand data has been completed
+ * @param {any} data the measurment data
+ * @returns {void}
+ */
+function fireCompleted (element, data) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}
+
 const simpleAngle = mouseButtonTool({
   createNewMeasurement,
   addNewMeasurement,
   onImageRendered,
   pointNearTool,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 const simpleAngleTouch = touchTool({
@@ -305,7 +348,8 @@ const simpleAngleTouch = touchTool({
   addNewMeasurement: addNewMeasurementTouch,
   onImageRendered,
   pointNearTool,
-  toolType
+  toolType,
+  onHandleDoneMove
 });
 
 export {

--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -56,6 +56,8 @@ function touchTool (touchToolInterface) {
       if (anyHandlesOutsideImage(touchEventData, measurementData.handles)) {
         // Delete the measurement
         removeToolState(element, touchToolInterface.toolType, measurementData);
+      } else if(touchToolInterface.onHandleDoneMove) {
+        touchToolInterface.onHandleDoneMove (element, measurementData);
       }
 
       cornerstone.updateImage(element);
@@ -74,6 +76,8 @@ function touchTool (touchToolInterface) {
       if (anyHandlesOutsideImage(touchEventData, measurementData.handles)) {
         // Delete the measurement
         removeToolState(element, touchToolInterface.toolType, measurementData);
+      } else if(touchToolInterface.onHandleDoneMove) {
+        touchToolInterface.onHandleDoneMove (element, measurementData);
       }
 
       element.addEventListener(EVENTS.TOUCH_START_ACTIVE, touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
@@ -119,6 +123,8 @@ function touchTool (touchToolInterface) {
       if (anyHandlesOutsideImage(eventData, data.handles)) {
         // Delete the measurement
         removeToolState(element, touchToolInterface.toolType, data);
+      } else if(touchToolInterface.onHandleDoneMove) {
+        touchToolInterface.onHandleDoneMove (element, data);
       }
 
       cornerstone.updateImage(element);
@@ -195,6 +201,8 @@ function touchTool (touchToolInterface) {
       if (anyHandlesOutsideImage(eventData, data.handles)) {
         // Delete the measurement
         removeToolState(eventData.element, touchToolInterface.toolType, data);
+      } else if(touchToolInterface.onHandleDoneMove) {
+        touchToolInterface.onHandleDoneMove (element, data);
       }
 
       cornerstone.updateImage(eventData.element);

--- a/src/util/getColRowPixelSpacing.js
+++ b/src/util/getColRowPixelSpacing.js
@@ -1,0 +1,19 @@
+import external from '../externalModules.js';
+
+
+export default function (image) {
+  const imagePlane = external.cornerstone.metaData.get('imagePlaneModule', image.imageId);
+  let rowPixelSpacing;
+  let colPixelSpacing;
+
+  if (imagePlane) {
+    rowPixelSpacing = imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing;
+    colPixelSpacing = imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing;
+  } else {
+    rowPixelSpacing = image.rowPixelSpacing;
+    colPixelSpacing = image.columnPixelSpacing;
+  }
+
+  return { rowPixelSpacing,
+    colPixelSpacing };
+}

--- a/src/util/triggerMeasurementCompletedEvent.js
+++ b/src/util/triggerMeasurementCompletedEvent.js
@@ -1,0 +1,20 @@
+import EVENTS from '../events.js';
+import triggerEvent from './triggerEvent.js';
+
+/**
+ * Fire cornerstonetoolsmeasurementcompleted event on provided element
+ * @param {any} element which freehand data has been modified
+ * @param {any} data the measurment data
+ * @param {String} toolType of the measurement tool data being fired.
+ * @returns {void}
+*/
+export default function (element, data, toolType) {
+  const eventType = EVENTS.MEASUREMENT_COMPLETED;
+  const completedEventData = {
+    toolType,
+    element,
+    measurementData: data
+  };
+
+  triggerEvent(element, eventType, completedEventData);
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
Updated the example AllImageTools
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introduce a new measurement event "cornerstonemeasurementcompleted" that is fired for the following tools:
1. Angle Tool
2. Arrow Annotate
3. Elliptical ROI
4. Freehand
5. length
6. Probe
7. Rectangle ROI
8. Simple Angle
9. Angle Tool

* **What is the current behavior?** (You can also link to an open issue here)
No such event exists. No way to tell when a user completes drawing the measurement/annotation.


* **What is the new behavior (if this is a feature change)?**
1. An event "cornerstonemeasurementcompleted" is fired once the user completes drawing/moving the annotation.
2. When this event is fired, the tool data will contain any calculation that the tool will produce when drawing the image. In the past, calculating the data only happens on rendering, now it also happens before firing this event.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
![completedeventsdata2](https://user-images.githubusercontent.com/10813109/52893220-1d554c80-3168-11e9-8c98-9d3d2fbd728e.gif)



* **Other information**:
