### PR TITLE
Canceling freehand #784 in v3

### DIFF
--- a/src/eventListeners/index.js
+++ b/src/eventListeners/index.js
@@ -1,5 +1,11 @@
 import mouseEventListeners from './mouseEventListeners.js';
 import wheelEventListener from './wheelEventListener.js';
 import touchEventListeners from './touchEventListeners.js';
+import keyboardEventListeners from './keyboardEventListeners.js';
 
-export { mouseEventListeners, wheelEventListener, touchEventListeners };
+export {
+  mouseEventListeners,
+  wheelEventListener,
+  touchEventListeners,
+  keyboardEventListeners,
+};

--- a/src/eventListeners/keyboardEventListeners.js
+++ b/src/eventListeners/keyboardEventListeners.js
@@ -1,0 +1,75 @@
+import EVENTS from '../events.js';
+import external from '../externalModules.js';
+import triggerEvent from '../util/triggerEvent.js';
+
+let mouseX;
+let mouseY;
+
+function keyPress(e) {
+  const cornerstone = external.cornerstone;
+  const element = e.currentTarget;
+  const enabledElement = cornerstone.getEnabledElement(element);
+
+  if (!enabledElement.image) {
+    return;
+  }
+
+  const keyPressData = {
+    event: window.event || e, // Old IE support
+    element,
+    viewport: cornerstone.getViewport(element),
+    image: enabledElement.image,
+    currentPoints: {
+      page: {
+        x: mouseX,
+        y: mouseY,
+      },
+      image: cornerstone.pageToPixel(element, mouseX, mouseY),
+    },
+    keyCode: e.keyCode,
+    which: e.which,
+  };
+
+  keyPressData.currentPoints.canvas = cornerstone.pixelToCanvas(
+    element,
+    keyPressData.currentPoints.image
+  );
+
+  const keyPressEvents = {
+    keydown: EVENTS.KEY_DOWN,
+    keypress: EVENTS.KEY_PRESS,
+    keyup: EVENTS.KEY_UP,
+  };
+
+  triggerEvent(element, keyPressEvents[e.type], keyPressData);
+}
+
+function mouseMove(e) {
+  mouseX = e.pageX;
+  mouseY = e.pageY;
+}
+
+const keyboardEvents = ['keydown', 'keypress', 'keyup'];
+
+function enable(element) {
+  keyboardEvents.forEach(eventType => {
+    element.removeEventListener(eventType, keyPress);
+    element.addEventListener(eventType, keyPress);
+  });
+
+  element.removeEventListener('mousemove', mouseMove);
+  element.addEventListener('mousemove', mouseMove);
+}
+
+function disable(element) {
+  keyboardEvents.forEach(eventType => {
+    element.removeEventListener(eventType, keyPress);
+  });
+
+  element.removeEventListener('mousemove', mouseMove);
+}
+
+export default {
+  enable,
+  disable,
+};

--- a/src/eventListeners/keyboardEventListeners.js
+++ b/src/eventListeners/keyboardEventListeners.js
@@ -5,16 +5,12 @@ import triggerEvent from '../util/triggerEvent.js';
 let mouseX;
 let mouseY;
 
-function keyPress(e) {
-  const cornerstone = external.cornerstone;
+function getKeyPressData(e) {
   const element = e.currentTarget;
+  const cornerstone = external.cornerstone;
   const enabledElement = cornerstone.getEnabledElement(element);
 
-  if (!enabledElement.image) {
-    return;
-  }
-
-  const keyPressData = {
+  return {
     event: window.event || e, // Old IE support
     element,
     viewport: cornerstone.getViewport(element),
@@ -29,6 +25,18 @@ function keyPress(e) {
     keyCode: e.keyCode,
     which: e.which,
   };
+}
+
+function keyPress(e) {
+  const cornerstone = external.cornerstone;
+  const element = e.currentTarget;
+  const enabledElement = cornerstone.getEnabledElement(element);
+
+  if (!enabledElement.image) {
+    return;
+  }
+
+  const keyPressData = getKeyPressData(e);
 
   keyPressData.currentPoints.canvas = cornerstone.pixelToCanvas(
     element,

--- a/src/store/internals/addEnabledElement.js
+++ b/src/store/internals/addEnabledElement.js
@@ -2,6 +2,7 @@ import {
   mouseEventListeners,
   wheelEventListener,
   touchEventListeners,
+  keyboardEventListeners,
 } from '../../eventListeners/index.js';
 import {
   imageRenderedEventDispatcher,
@@ -63,6 +64,11 @@ export default function(elementEnabledEvt) {
   if (store.modules.globalConfiguration.state.touchEnabled) {
     touchEventListeners.enable(enabledElement);
     touchToolEventDispatcher.enable(enabledElement);
+  }
+
+  // Keyboard
+  if (store.modules.globalConfiguration.state.keyboardEnabled) {
+    keyboardEventListeners.enable(enabledElement);
   }
 
   // State

--- a/src/store/modules/globalConfigurationModule.js
+++ b/src/store/modules/globalConfigurationModule.js
@@ -1,6 +1,7 @@
 const state = {
   mouseEnabled: true,
   touchEnabled: true,
+  keyboardEnabled: true,
   globalToolSyncEnabled: false,
 };
 

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -822,8 +822,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingKeyDownCallback(evt) {
     const eventData = evt.detail;
+    const config = this.configuration;
 
-    if (eventData.keyCode === 27) {
+    if (eventData.keyCode === config.cancelKeyCode) {
       this._cancelDrawing(eventData.element);
     }
   }
@@ -1525,6 +1526,7 @@ function defaultFreehandConfiguration() {
     invalidColor: 'crimson',
     currentHandle: 0,
     currentTool: -1,
+    cancelKeyCode: 27,
   };
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Trying to implement a function of canceling the freehand in v3. #784 

I wrote keyboardEventListeners.js like mouseEventListeners.js by reference to keyboardInput in v2.4.x for the purpose of using EVENTS.KEY_DOWN.

* **What is the current behavior?** (You can also link to an open issue here)

There is no canceling freehand.

* **What is the new behavior (if this is a feature change)?**

Freehand will be deleted if you press ESC key. (User can modify cancel key using configuration)

