### PR TITLE
export the base tools for consumption by 3rd parties

### DIFF
--- a/docs/latest/book.json
+++ b/docs/latest/book.json
@@ -12,7 +12,7 @@
   ],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/cornerstonejs/cornerstoneTools/edit/master/docs",
+      "base": "https://github.com/cornerstonejs/cornerstoneTools/edit/master/docs/latest",
       "label": "Edit This Page"
     },
     "github": {

--- a/docs/latest/custom-tools/adding-mixins.md
+++ b/docs/latest/custom-tools/adding-mixins.md
@@ -3,17 +3,14 @@
 Next you can add any [mixins](../anatomy-of-a-tool/index.md#mixins) you wish to add the Tool. These are passed to `super`, and initialized in `BaseTool`. For our example, our Tool only makes sense in `Active` or `Disabled` modes, as it has none of its own data, and logs `'Hello cornerstoneTools!'` on click, as such we shall include the `activeOrDisabledBinaryTool` mixin:
 
 ```js
-import external from './../externalModules.js';
-import BaseTool from './../base/BaseTool.js';
+import { BaseTool } from 'cornerstone-tools';
 
 export default class HelloWorldMouseTool extends BaseTool {
-  constructor (name = 'HelloWorldMouse') {
+  constructor(name = 'HelloWorldMouse') {
     super({
       name,
       supportedInteractionTypes: ['mouse'],
-      mixins: [
-        'activeOrDisabledBinaryTool'
-      ]
+      mixins: ['activeOrDisabledBinaryTool'],
     });
   }
 }

--- a/docs/latest/custom-tools/creating-your-tool.md
+++ b/docs/latest/custom-tools/creating-your-tool.md
@@ -5,6 +5,7 @@ Once you have an appropriate base class chosen (we will use the `BaseTool` in th
 ### Class Definition
 
 By convention the class name should be in PascalCase, and suffixed with:
+
 - `Tool` - If it supports both `mouse` and `touch` input.
 - `MouseTool` - If it only supports `mouse` input.
 - `TouchTool` - If it only supports `touch` input.
@@ -12,14 +13,15 @@ By convention the class name should be in PascalCase, and suffixed with:
 For example, our example is going to support mouse, so we shall call it the `HelloWorldMouseTool`:
 
 ```js
-import external from './../externalModules.js';
-import BaseTool from './../base/BaseTool.js';
+import { BaseTool } from 'cornerstone-tools';
+// NOTE: if you're creating a tool inside the CornerstoneTools repository
+// you should import BaseTool using a relative path to `src/tools/base`.
 
 export default class HelloWorldMouseTool extends BaseTool {
-  constructor (name = 'HelloWorldMouse') {
+  constructor(name = 'HelloWorldMouse') {
     super({
       name,
-      supportedInteractionTypes: ['mouse']
+      supportedInteractionTypes: ['mouse'],
     });
   }
 }
@@ -27,13 +29,13 @@ export default class HelloWorldMouseTool extends BaseTool {
 
 The constructor must call `super()`, which passes an object to the constructor of the superclass (`BaseTool`, in this case, but the same object is passed to `BaseAnnotationTool` or `BaseBrushTool`). The object passed may have the following properties:
 
-| Property | Requirement | description |
-|----------|-------|-------------|
-| name| Mandatory | The name of the Tool. |
-| supportedInteractionTypes | Mandatory | An array of strings listing the interaction types, `mouse` and/or `touch`.|
-| [strategies](../anatomy-of-a-tool/index.md#strategies) | Optional | If your Tool has multiple strategies of operation, you may pass an array of functions for each strategy here (see the `RotateTool` for a good example).|
-| defaultStrategy | Optional | If you have multiple strategies, this one should be used by default (pass a string identical to the strategy function name). |
-| configuration | Optional | An object with configurable properties used by your Tool. It may include your Tool's sensitivity, how an annotation displays when rendered, etc. |
-| [mixins](../anatomy-of-a-tool/index.md#mixins) | Optional | An array of mixins (commonly used behaviours/functionality) to add to the Tool.|
+| Property                                               | Requirement | description                                                                                                                                             |
+| ------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name                                                   | Mandatory   | The name of the Tool.                                                                                                                                   |
+| supportedInteractionTypes                              | Mandatory   | An array of strings listing the interaction types, `mouse` and/or `touch`.                                                                              |
+| [strategies](../anatomy-of-a-tool/index.md#strategies) | Optional    | If your Tool has multiple strategies of operation, you may pass an array of functions for each strategy here (see the `RotateTool` for a good example). |
+| defaultStrategy                                        | Optional    | If you have multiple strategies, this one should be used by default (pass a string identical to the strategy function name).                            |
+| configuration                                          | Optional    | An object with configurable properties used by your Tool. It may include your Tool's sensitivity, how an annotation displays when rendered, etc.        |
+| [mixins](../anatomy-of-a-tool/index.md#mixins)         | Optional    | An array of mixins (commonly used behaviours/functionality) to add to the Tool.                                                                         |
 
 For our simple Tool we pass only the two mandatory fields to `super`. For the Tool's own constructor, it must at minimum take `name` as a parameter, and it must have a default value. By convention the default name is the same as the classname, minus the `Tool` suffix.

--- a/docs/latest/custom-tools/event-dispatcher-callbacks.md
+++ b/docs/latest/custom-tools/event-dispatcher-callbacks.md
@@ -8,28 +8,26 @@ Here we can add the meat of our Tool. Event dispatchers check for methods on Too
 For our Tool we want to log to the console on mouse click. `BaseTool` has two appropriate methods: `preMouseDownCallback` and `postMouseDownCallback`. These fire before or after other annotation data on the canvas has a chance to claim the mouse click. for our Tool we shall choose `preMouseDownCallback`, as it's always nice to say hello before doing anything else. The method can simply be defined and it shall be called when appropriate via the `mouseToolEventDispatcher`:
 
 ```js
-import BaseTool from './../base/BaseTool.js';
+import { BaseTool } from 'cornerstone-tools';
 
 export default class HelloWorldMouseTool extends BaseTool {
-  constructor (name = 'HelloWorldMouse') {
+  constructor(name = 'HelloWorldMouse') {
     super({
       name,
       supportedInteractionTypes: ['mouse'],
-      mixins: [
-        'activeOrDisabledBinaryTool'
-      ]
+      mixins: ['activeOrDisabledBinaryTool'],
     });
   }
 
-  preMouseDownCallback (evt) {
+  preMouseDownCallback(evt) {
     console.log('Hello cornerstoneTools!');
   }
 
-  activeCallback (element) {
+  activeCallback(element) {
     console.log(`Hello element ${element.uuid}!`);
   }
 
-  disabledCallback (element) {
+  disabledCallback(element) {
     console.log(`Goodbye element ${element.uuid}!`);
   }
 }

--- a/docs/latest/custom-tools/index.md
+++ b/docs/latest/custom-tools/index.md
@@ -1,6 +1,8 @@
 # Custom Tools
 
-This guide will give you an overview of creating a new Tool. This is applicable for Tools being built within the library as well as Tools for 3rd party plugins. For the specifics on setting up a Tool for a plugin, check the third party [tool](../third-party-functionality/index.md#tools) guide.
+This guide will give you an overview of creating a new Tool. This is applicable for Tools being built within the library as well as Tools for 3rd party plugins.
+
+See the [Third-Party functionality guide](../third-party-functionality/index.md) for more details on the integration and extension options available.
 
 {% include "./choosing-a-base-class.md" %}
 {% include "./creating-your-tool.md" %}

--- a/docs/latest/custom-tools/mode-change-callbacks.md
+++ b/docs/latest/custom-tools/mode-change-callbacks.md
@@ -12,25 +12,22 @@ Note that unlike a lot of the Tools, the `element` on which the Tool resides is 
 For our example Tool, this gives us more chances to log hello to the console:
 
 ```js
-import external from './../externalModules.js';
-import BaseTool from './../base/BaseTool.js';
+import { BaseTool } from 'cornerstone-tools';
 
 export default class HelloWorldMouseTool extends BaseTool {
-  constructor (name = 'HelloWorldMouse') {
+  constructor(name = 'HelloWorldMouse') {
     super({
       name,
       supportedInteractionTypes: ['mouse'],
-      mixins: [
-        'activeOrDisabledBinaryTool'
-      ]
+      mixins: ['activeOrDisabledBinaryTool'],
     });
   }
 
-  activeCallback (element) {
+  activeCallback(element) {
     console.log(`Hello element ${element.uuid}!`);
   }
 
-  disabledCallback (element) {
+  disabledCallback(element) {
     console.log(`Goodbye element ${element.uuid}!`);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,12 @@
  */
 
 import {
+  BaseAnnotationTool,
+  BaseBrushTool,
+  BaseTool,
+} from './tools/base/index.js';
+
+import {
   AngleTool,
   ArrowAnnotateTool,
   BidirectionalTool,
@@ -196,6 +202,10 @@ import { default as version } from './version.js';
 
 const cornerstoneTools = {
   // ~~~ TOOLS
+  // ~ Base Tools
+  BaseAnnotationTool,
+  BaseBrushTool,
+  BaseTool,
   // ~ Annotation Tools
   AngleTool,
   ArrowAnnotateTool,
@@ -292,6 +302,10 @@ const cornerstoneTools = {
 // Named Exports
 export {
   // ~~~ TOOLS
+  // ~ Base Tools
+  BaseAnnotationTool,
+  BaseBrushTool,
+  BaseTool,
   // ~ Annotation Tools
   AngleTool,
   ArrowAnnotateTool,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [?] The commit message follows our guidelines
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR make the BaseTool classes available (or at least more easily accessible) to external libraries.

* **What is the current behavior?** (You can also link to an open issue here)

See issue #878 

* **What is the new behavior (if this is a feature change)?**

Users can now do the following:

```js
import { BaseAnnotationTool } from 'cornerstoneTools';
class MyCustomTool extends BaseAnnotationTool {
   // ...
}
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nothing breaking. No changes required

