### PR TITLE
Bugfix in image id specific state manager

### DIFF
--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -36,12 +36,14 @@ function newImageIdSpecificToolStateManager() {
   // As modules that restore saved state
   function addImageIdSpecificToolState(element, toolType, data) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
-    // If we don't have any tool state for this imageId, add an empty object
 
-    if (
-      !enabledElement.image ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
+    // If we don't have an image for this element exit early
+    if (!enabledElement.image) {
+      return;
+    }
+
+    // If we don't have any tool state for this imageId, add an empty object
+    if (toolState.hasOwnProperty(enabledElement.image.imageId) === false) {
       toolState[enabledElement.image.imageId] = {};
     }
 

--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -36,14 +36,12 @@ function newImageIdSpecificToolStateManager() {
   // As modules that restore saved state
   function addImageIdSpecificToolState(element, toolType, data) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
-
-    // If we don't have an image for this element exit early
-    if (!enabledElement.image) {
-      return;
-    }
-
     // If we don't have any tool state for this imageId, add an empty object
-    if (toolState.hasOwnProperty(enabledElement.image.imageId) === false) {
+
+    if (
+      !enabledElement.image ||
+      toolState.hasOwnProperty(enabledElement.image.imageId) === false
+    ) {
       toolState[enabledElement.image.imageId] = {};
     }
 

--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -36,12 +36,14 @@ function newImageIdSpecificToolStateManager() {
   // As modules that restore saved state
   function addImageIdSpecificToolState(element, toolType, data) {
     const enabledImage = external.cornerstone.getEnabledElement(element);
-    // If we don't have any tool state for this imageId, add an empty object
 
-    if (
-      !enabledImage.image ||
-      toolState.hasOwnProperty(enabledImage.image.imageId) === false
-    ) {
+    // If we don't have an image for this element exit early
+    if (!enabledImage.image) {
+      return;
+    }
+
+    // If we don't have any tool state for this imageId, add an empty object
+    if (toolState.hasOwnProperty(enabledImage.image.imageId) === false) {
       toolState[enabledImage.image.imageId] = {};
     }
 

--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -35,19 +35,19 @@ function newImageIdSpecificToolStateManager() {
   // Here we add tool state, this is done by tools as well
   // As modules that restore saved state
   function addImageIdSpecificToolState(element, toolType, data) {
-    const enabledImage = external.cornerstone.getEnabledElement(element);
+    const enabledElement = external.cornerstone.getEnabledElement(element);
 
     // If we don't have an image for this element exit early
-    if (!enabledImage.image) {
+    if (!enabledElement.image) {
       return;
     }
 
     // If we don't have any tool state for this imageId, add an empty object
-    if (toolState.hasOwnProperty(enabledImage.image.imageId) === false) {
-      toolState[enabledImage.image.imageId] = {};
+    if (toolState.hasOwnProperty(enabledElement.image.imageId) === false) {
+      toolState[enabledElement.image.imageId] = {};
     }
 
-    const imageIdToolState = toolState[enabledImage.image.imageId];
+    const imageIdToolState = toolState[enabledElement.image.imageId];
 
     // If we don't have tool state for this type of tool, add an empty object
     if (imageIdToolState.hasOwnProperty(toolType) === false) {
@@ -65,17 +65,17 @@ function newImageIdSpecificToolStateManager() {
   // Here you can get state - used by tools as well as modules
   // That save state persistently
   function getImageIdSpecificToolState(element, toolType) {
-    const enabledImage = external.cornerstone.getEnabledElement(element);
+    const enabledElement = external.cornerstone.getEnabledElement(element);
     // If we don't have any tool state for this imageId, return undefined
 
     if (
-      !enabledImage.image ||
-      toolState.hasOwnProperty(enabledImage.image.imageId) === false
+      !enabledElement.image ||
+      toolState.hasOwnProperty(enabledElement.image.imageId) === false
     ) {
       return;
     }
 
-    const imageIdToolState = toolState[enabledImage.image.imageId];
+    const imageIdToolState = toolState[enabledElement.image.imageId];
 
     // If we don't have tool state for this type of tool, return undefined
     if (imageIdToolState.hasOwnProperty(toolType) === false) {
@@ -89,16 +89,16 @@ function newImageIdSpecificToolStateManager() {
 
   // Clears all tool data from this toolStateManager.
   function clearImageIdSpecificToolStateManager(element) {
-    const enabledImage = external.cornerstone.getEnabledElement(element);
+    const enabledElement = external.cornerstone.getEnabledElement(element);
 
     if (
-      !enabledImage.image ||
-      toolState.hasOwnProperty(enabledImage.image.imageId) === false
+      !enabledElement.image ||
+      toolState.hasOwnProperty(enabledElement.image.imageId) === false
     ) {
       return;
     }
 
-    delete toolState[enabledImage.image.imageId];
+    delete toolState[enabledElement.image.imageId];
   }
 
   return {

--- a/src/stateManagement/imageIdSpecificStateManager.test.js
+++ b/src/stateManagement/imageIdSpecificStateManager.test.js
@@ -1,45 +1,78 @@
-import './../externalModules.js';
+import externalModules from './../externalModules.js';
 import { newImageIdSpecificToolStateManager } from './imageIdSpecificStateManager.js';
 
 jest.mock('./../externalModules.js');
 
 describe('imageIdSpecificStateManager.add', () => {
-  it('should add data to the exiting toolState', () => {
+  it('creates the toolState and adds the data', () => {
     const stateManager = newImageIdSpecificToolStateManager();
     const toolType = 'TestTool';
-    const testElement = {};
+    const imageId = 'abc123';
+    const testElement = {
+      image: {
+        imageId,
+      },
+    };
 
-    // Setup with some intial data
-    // stateManager.restoreImageIdToolState(imageId, initialData);
-
-    stateManager.add(testElement, toolType, 'data2');
-
-    // Using "undefined" as the value here because the implementation of
-    // the externalModules mock has an image without an imageId property.
-    // There may be a better way of doing this.
-    const imageId = undefined;
+    externalModules.cornerstone.getEnabledElement.mockImplementationOnce(
+      () => testElement
+    );
+    stateManager.add(testElement, toolType, 'data1');
 
     const allToolState = stateManager.saveToolState();
 
-    expect(allToolState[imageId][toolType].data).toContain('data2');
+    expect(allToolState[imageId][toolType].data).toContain('data1');
   });
-});
 
-describe('Just the syntax', () => {
-  it('throws an error', () => {
-    const enabledElement = {};
-    const toolState = {};
+  it('adds data to the existing toolState', () => {
+    const stateManager = newImageIdSpecificToolStateManager();
+    const toolType = 'TestTool';
+    const imageId = 'abc123';
+    const testElement = {
+      image: {
+        imageId,
+      },
+    };
 
-    // --- the old implementation
-    if (
-      !enabledElement.image ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
-      toolState[enabledElement.image.imageId] = {};
-    }
+    externalModules.cornerstone.getEnabledElement.mockImplementationOnce(
+      () => testElement
+    );
 
-    const imageIdToolState = toolState[enabledElement.image.imageId];
+    // Setup with some intial data
+    stateManager.restoreImageIdToolState(imageId, {
+      [toolType]: { data: ['initialData'] },
+    });
+    // Add more data
+    stateManager.add(testElement, toolType, 'addedData');
 
-    console.log(imageIdToolState);
+    // Check the results
+    const allToolState = stateManager.saveToolState();
+
+    expect(allToolState[imageId][toolType].data).toEqual(
+      expect.arrayContaining(['initialData', 'addedData'])
+    );
+  });
+
+  describe('when the image is not yet defined', () => {
+    it('returns without adding the data', () => {
+      const stateManager = newImageIdSpecificToolStateManager();
+      const toolType = 'TestTool';
+      const imageId = 'abc123';
+      const testElement = {
+        image: undefined,
+      };
+
+      externalModules.cornerstone.getEnabledElement.mockImplementationOnce(
+        () => testElement
+      );
+
+      // Add more data
+      stateManager.add(testElement, toolType, 'testData');
+
+      // Check the results
+      const allToolState = stateManager.saveToolState();
+
+      expect(allToolState[imageId]).toBeUndefined();
+    });
   });
 });

--- a/src/stateManagement/imageIdSpecificStateManager.test.js
+++ b/src/stateManagement/imageIdSpecificStateManager.test.js
@@ -1,0 +1,45 @@
+import './../externalModules.js';
+import { newImageIdSpecificToolStateManager } from './imageIdSpecificStateManager.js';
+
+jest.mock('./../externalModules.js');
+
+describe('imageIdSpecificStateManager.add', () => {
+  it('should add data to the exiting toolState', () => {
+    const stateManager = newImageIdSpecificToolStateManager();
+    const toolType = 'TestTool';
+    const testElement = {};
+
+    // Setup with some intial data
+    // stateManager.restoreImageIdToolState(imageId, initialData);
+
+    stateManager.add(testElement, toolType, 'data2');
+
+    // Using "undefined" as the value here because the implementation of
+    // the externalModules mock has an image without an imageId property.
+    // There may be a better way of doing this.
+    const imageId = undefined;
+
+    const allToolState = stateManager.saveToolState();
+
+    expect(allToolState[imageId][toolType].data).toContain('data2');
+  });
+});
+
+describe('Just the syntax', () => {
+  it('throws an error', () => {
+    const enabledElement = {};
+    const toolState = {};
+
+    // --- the old implementation
+    if (
+      !enabledElement.image ||
+      toolState.hasOwnProperty(enabledElement.image.imageId) === false
+    ) {
+      toolState[enabledElement.image.imageId] = {};
+    }
+
+    const imageIdToolState = toolState[enabledElement.image.imageId];
+
+    console.log(imageIdToolState);
+  });
+});

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -13,7 +13,7 @@ import triggerEvent from '../util/triggerEvent.js';
  */
 function getElementToolStateManager(element) {
   const enabledElement = external.cornerstone.getEnabledElement(element);
-  // If the enabledImage has no toolStateManager, create a default one for it
+  // If the enabledElement has no toolStateManager, create a default one for it
   // NOTE: This makes state management element specific
 
   if (enabledElement.toolStateManager === undefined) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix + some clean up of variable naming in this file


* **What is the current behavior?** (You can also link to an open issue here)
Calling  `addImageIdSpecificToolState` would throw if `element.image` did not exist.


* **What is the new behavior (if this is a feature change)?**
`addImageIdSpecificToolState` will exit early if element.image does not exist.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
