### PR TITLE
Pr/set tool mode mouse button mask

### DIFF
--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -210,8 +210,8 @@ function setToolModeForElement(mode, changeEvent, element, toolName, options) {
     options.mouseButtonMask.length !== 0 &&
     Array.isArray(tool.options.mouseButtonMask)
   ) {
-    options.mouseButtonMask = options.mouseButtonMask.concat(
-      tool.options.mouseButtonMask
+    options.mouseButtonMask = Array.from(
+      new Set(options.mouseButtonMask.concat(tool.options.mouseButtonMask))
     );
   }
 

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -210,9 +210,15 @@ function setToolModeForElement(mode, changeEvent, element, toolName, options) {
     options.mouseButtonMask.length !== 0 &&
     Array.isArray(tool.options.mouseButtonMask)
   ) {
-    options.mouseButtonMask = Array.from(
-      new Set(options.mouseButtonMask.concat(tool.options.mouseButtonMask))
-    );
+    options.mouseButtonMask = options.mouseButtonMask
+      .concat(tool.options.mouseButtonMask)
+      .reduce((acc, m) => {
+        if (acc.indexOf(m) === -1) {
+          acc.push(m);
+        }
+
+        return acc;
+      }, []);
   }
 
   // Set mode & options

--- a/src/store/setToolMode.test.js
+++ b/src/store/setToolMode.test.js
@@ -1,0 +1,85 @@
+import getToolForElement from './getToolForElement.js';
+import { setToolEnabledForElement } from './setToolMode.js';
+
+jest.mock('./getToolForElement.js');
+
+describe('setToolModeForElement', () => {
+  it('sets the tool.mode to enabled', () => {
+    const mergeOptions = jest.fn();
+    const testTool = {
+      mode: undefined,
+      options: { mouseButtonMask: [] },
+      supportedInteractionTypes: ['Mouse'],
+      mergeOptions,
+    };
+
+    getToolForElement.mockImplementationOnce(() => testTool);
+
+    const toolName = 'MyTool';
+    const element = {};
+
+    setToolEnabledForElement(element, toolName);
+
+    expect(testTool.mode).toBe('enabled');
+  });
+
+  it('can set the buttonMask option', () => {
+    const mergeOptions = jest.fn();
+    const testTool = {
+      mode: undefined,
+      options: { mouseButtonMask: [] },
+      supportedInteractionTypes: ['Mouse'],
+      mergeOptions,
+    };
+
+    getToolForElement.mockImplementationOnce(() => testTool);
+
+    const toolName = 'MyTool';
+    const options = { mouseButtonMask: 1 };
+    const element = {};
+
+    setToolEnabledForElement(element, toolName, options);
+
+    expect(mergeOptions).toBeCalledWith({ mouseButtonMask: [1] });
+  });
+
+  it('merges buttonMask option with existing array', () => {
+    const mergeOptions = jest.fn();
+    const testTool = {
+      mode: undefined,
+      options: { mouseButtonMask: [2] },
+      supportedInteractionTypes: ['Mouse'],
+      mergeOptions,
+    };
+
+    getToolForElement.mockImplementationOnce(() => testTool);
+
+    const toolName = 'MyTool';
+    const options = { mouseButtonMask: 1 };
+    const element = {};
+
+    setToolEnabledForElement(element, toolName, options);
+
+    expect(mergeOptions).toBeCalledWith({ mouseButtonMask: [1, 2] });
+  });
+
+  it('does not allow deplicates mouseButtonMasks', () => {
+    const mergeOptions = jest.fn();
+    const testTool = {
+      mode: undefined,
+      options: { mouseButtonMask: [1, 2] }, // <--- start with this
+      supportedInteractionTypes: ['Mouse'],
+      mergeOptions,
+    };
+
+    getToolForElement.mockImplementation(() => testTool);
+
+    const toolName = 'MyTool';
+    const options = { mouseButtonMask: 1 }; // <-- this should not cause a duplicate
+    const element = {};
+
+    setToolEnabledForElement(element, toolName, options);
+
+    expect(mergeOptions).toBeCalledWith({ mouseButtonMask: [1, 2] });
+  });
+});

--- a/src/store/setToolMode.test.js
+++ b/src/store/setToolMode.test.js
@@ -63,23 +63,27 @@ describe('setToolModeForElement', () => {
     expect(mergeOptions).toBeCalledWith({ mouseButtonMask: [1, 2] });
   });
 
-  it('does not allow deplicates mouseButtonMasks', () => {
+  it('does not allow duplicate mouseButtonMasks', () => {
     const mergeOptions = jest.fn();
     const testTool = {
       mode: undefined,
-      options: { mouseButtonMask: [1, 2] }, // <--- start with this
+      options: { mouseButtonMask: [1, 1, 2] }, // <--- start with this
       supportedInteractionTypes: ['Mouse'],
       mergeOptions,
     };
 
-    getToolForElement.mockImplementation(() => testTool);
+    getToolForElement.mockImplementationOnce(() => testTool);
 
     const toolName = 'MyTool';
-    const options = { mouseButtonMask: 1 }; // <-- this should not cause a duplicate
+    const options = { mouseButtonMask: [2, 2, 3] }; // <-- "add" this
     const element = {};
 
     setToolEnabledForElement(element, toolName, options);
 
-    expect(mergeOptions).toBeCalledWith({ mouseButtonMask: [1, 2] });
+    const { mouseButtonMask } = mergeOptions.mock.calls[0][0];
+
+    // Note: sorting is required to because Array.from(set) can
+    // does not guarantee the order of results returned.
+    expect(mouseButtonMask.sort()).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Fixes a bug where the app can have poor performance or even crash when `setToolModeForElement` is called too many times. #898


* **What is the new behavior (if this is a feature change)?**
Within `setToolModeForElement` the `options.mouseButtonMask` array is now de-duplicated.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
~I've used `new Set()` in here. This could cause a browser compatibility problem, depending on what csTools is supporting. I've left this as the solution as it's the cleanest option but if that is a no-go I can change it to something more es2015 safe.~
On second thought, there's no reason this needs to use `Set`s. Have updated to not do that.