### PR TITLE
FreehandSculpter bug fix.

### DIFF
--- a/src/tools/FreehandSculpterMouseTool.js
+++ b/src/tools/FreehandSculpterMouseTool.js
@@ -375,6 +375,10 @@ export default class FreehandSculpterMouseTool extends BaseTool {
 
     if (config.currentTool === null) {
       this._selectFreehandTool(eventData);
+
+      if (config.currentTool === null) {
+        return;
+      }
     }
 
     this._active = true;


### PR DESCRIPTION
Fixed a bug where the `FreehandSculpterMouseTool` would break when used if there is no freehand annotation on the slice.
