### PR TITLE
WIP - makes doneMoveCallback explicitly Tool API and not user API

### DIFF
--- a/src/eventDispatchers/touchEventHandlers/tap.js
+++ b/src/eventDispatchers/touchEventHandlers/tap.js
@@ -68,23 +68,14 @@ export default function(evt) {
     moveableHandle.active = true; // Why here, but not touchStart?
     external.cornerstone.updateImage(element);
 
-    const toolOptions = Object.assign(
-      {},
-      {
-        doneMovingCallback: () => {
-          deactivateAllToolInstances(toolState);
-        },
-      },
-      firstToolWithMoveableHandles.options
-    );
-
     moveHandle(
       evt.detail,
       firstToolWithMoveableHandles.name,
       toolState.data,
       moveableHandle,
-      toolOptions,
-      'touch'
+      firstToolWithMoveableHandles.options,
+      'touch',
+      () => deactivateAllToolInstances(toolState)
     );
     evt.stopImmediatePropagation();
     evt.preventDefault();
@@ -119,23 +110,14 @@ export default function(evt) {
     firstAnnotationNearPoint.active = true;
     external.cornerstone.updateImage(element);
 
-    const toolOptions = Object.assign(
-      {},
-      {
-        doneMovingCallback: () => {
-          deactivateAllToolInstances(toolState);
-        },
-      },
-      firstToolNearPoint.options
-    );
-
     moveAllHandles(
       evt.detail,
       firstToolNearPoint.name,
       firstAnnotationNearPoint,
       null,
-      toolOptions,
-      'touch'
+      firstToolNearPoint.options,
+      'touch',
+      () => deactivateAllToolInstances(toolState)
     );
 
     evt.stopImmediatePropagation();

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -35,9 +35,9 @@ const _upOrEndEvents = {
  * @param {*}        [handle=null] - not needed by moveAllHandles, but keeps call signature the same as `moveHandle`
  * @param {Object}   [options={}]
  * @param {Boolean}  [options.deleteIfHandleOutsideImage]
- * @param {function} [options.doneMovingCallback]
  * @param {Boolean}  [options.preventHandleOutsideImage]
  * @param {string}   [interactionType=mouse]
+ * @param {function} [doneMovingCallback]
  * @returns {undefined}
  */
 export default function(
@@ -46,7 +46,8 @@ export default function(
   annotation,
   handle,
   options = {},
-  interactionType = 'mouse'
+  interactionType = 'mouse',
+  doneMovingCallback
 ) {
   // Use global defaults, unless overidden by provided options
   options = Object.assign(
@@ -69,7 +70,8 @@ export default function(
         dragHandler,
         upOrEndHandler,
       },
-      evt
+      evt,
+      doneMovingCallback
     );
   };
 
@@ -137,7 +139,8 @@ function _upOrEndHandler(
   options = {},
   interactionType,
   { dragHandler, upOrEndHandler },
-  evt
+  evt,
+  doneMovingCallback
 ) {
   const eventData = evt.detail;
   const element = evt.detail.element;
@@ -162,8 +165,8 @@ function _upOrEndHandler(
     removeToolState(element, toolName, annotation);
   }
 
-  if (typeof options.doneMovingCallback === 'function') {
-    options.doneMovingCallback();
+  if (typeof doneMovingCallback === 'function') {
+    doneMovingCallback();
   }
 
   external.cornerstone.updateImage(element);

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -5,6 +5,9 @@ import { removeToolState } from '../stateManagement/toolState.js';
 import triggerEvent from '../util/triggerEvent.js';
 import { clipToBox } from '../util/clip.js';
 import { state } from './../store/index.js';
+import { getLogger } from '../util/logger.js';
+
+const logger = getLogger('manipulators:moveAllHandles');
 
 const _dragEvents = {
   mouse: [EVENTS.MOUSE_DRAG],
@@ -163,6 +166,13 @@ function _upOrEndHandler(
     anyHandlesOutsideImage(eventData, annotation.handles)
   ) {
     removeToolState(element, toolName, annotation);
+  }
+
+  if (typeof options.doneMovingCallback === 'function') {
+    logger.warn(
+      '`options.doneMovingCallback` has been depricated. See https://github.com/cornerstonejs/cornerstoneTools/pull/915 for details.'
+    );
+    options.doneMovingCallback();
   }
 
   if (typeof doneMovingCallback === 'function') {

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -5,6 +5,9 @@ import { removeToolState } from '../stateManagement/toolState.js';
 import triggerEvent from '../util/triggerEvent.js';
 import { clipToBox } from '../util/clip.js';
 import { state } from './../store/index.js';
+import { getLogger } from '../util/logger.js';
+
+const logger = getLogger('manipulators:moveHandle');
 
 const runAnimation = {
   value: false,
@@ -210,6 +213,13 @@ function _upOrEndHandler(
     evt.detail.handlePressed = annotation;
     handle.x = image.x; // Original Event
     handle.y = image.y;
+  }
+
+  if (typeof options.doneMovingCallback === 'function') {
+    logger.warn(
+      '`options.doneMovingCallback` has been depricated. See https://github.com/cornerstonejs/cornerstoneTools/pull/915 for details.'
+    );
+    options.doneMovingCallback();
   }
 
   if (typeof doneMovingCallback === 'function') {

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -39,9 +39,9 @@ const _upOrEndEvents = {
  * @param {*} handle
  * @param {*} [options={}]
  * @param {Boolean}  [options.deleteIfHandleOutsideImage]
- * @param {function} [options.doneMovingCallback]
  * @param {Boolean}  [options.preventHandleOutsideImage]
  * @param {*} [interactionType=mouse]
+ * @param {function} doneMovingCallback
  * @returns {undefined}
  */
 export default function(
@@ -50,7 +50,8 @@ export default function(
   annotation,
   handle,
   options = {},
-  interactionType = 'mouse'
+  interactionType = 'mouse',
+  doneMovingCallback
 ) {
   // Use global defaults, unless overidden by provided options
   options = Object.assign(
@@ -83,7 +84,8 @@ export default function(
         dragHandler,
         upOrEndHandler,
       },
-      evt
+      evt,
+      doneMovingCallback
     );
   };
 
@@ -174,7 +176,8 @@ function _upOrEndHandler(
   options = {},
   interactionType,
   { dragHandler, upOrEndHandler },
-  evt
+  evt,
+  doneMovingCallback
 ) {
   const image = evtDetail.currentPoints.image;
   const element = evt.detail.element;
@@ -209,8 +212,8 @@ function _upOrEndHandler(
     handle.y = image.y;
   }
 
-  if (typeof options.doneMovingCallback === 'function') {
-    options.doneMovingCallback();
+  if (typeof doneMovingCallback === 'function') {
+    doneMovingCallback();
   }
 
   external.cornerstone.updateImage(element);

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -5,6 +5,9 @@ import { removeToolState } from '../stateManagement/toolState.js';
 import triggerEvent from '../util/triggerEvent.js';
 import { clipToBox } from '../util/clip.js';
 import { state } from './../store/index.js';
+import { getLogger } from '../util/logger.js';
+
+const logger = getLogger('manipulators:moveNewHandle');
 
 const _moveEvents = {
   mouse: [EVENTS.MOUSE_MOVE, EVENTS.MOUSE_DRAG],
@@ -171,6 +174,14 @@ function _moveEndHandler(
   if (evt.type === EVENTS.TOUCH_PINCH || evt.type === EVENTS.TOUCH_PRESS) {
     handle.active = false;
     external.cornerstone.updateImage(element);
+
+    if (typeof options.doneMovingCallback === 'function') {
+      logger.warn(
+        '`options.doneMovingCallback` has been depricated. See https://github.com/cornerstonejs/cornerstoneTools/pull/915 for details.'
+      );
+      options.doneMovingCallback();
+    }
+
     if (typeof doneMovingCallback === 'function') {
       doneMovingCallback();
     }
@@ -188,6 +199,13 @@ function _moveEndHandler(
     anyHandlesOutsideImage(evt.detail, annotation.handles)
   ) {
     removeToolState(element, toolName, annotation);
+  }
+
+  if (typeof options.doneMovingCallback === 'function') {
+    logger.warn(
+      '`options.doneMovingCallback` has been depricated. See https://github.com/cornerstonejs/cornerstoneTools/pull/915 for details.'
+    );
+    options.doneMovingCallback();
   }
 
   if (typeof doneMovingCallback === 'function') {

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -28,10 +28,10 @@ const _moveEndEvents = {
  * @param {*} handle
  * @param {*} [options={}]
  * @param {Boolean}  [options.deleteIfHandleOutsideImage]
- * @param {function} [options.doneMovingCallback]
  * @param {Boolean}  [options.preventHandleOutsideImage]
- * @param {*} [interactionType=mouse]
- * @returns {undefined}
+ * @param {string} [interactionType=mouse]
+ * @param {function} [doneMovingCallback]
+ * @returns {void}
  */
 export default function(
   evtDetail,
@@ -39,7 +39,8 @@ export default function(
   annotation,
   handle,
   options,
-  interactionType = 'mouse'
+  interactionType = 'mouse',
+  doneMovingCallback
 ) {
   // Use global defaults, unless overidden by provided options
   options = Object.assign(
@@ -76,7 +77,8 @@ export default function(
         moveHandler,
         moveEndHandler,
       },
-      evt
+      evt,
+      doneMovingCallback
     );
   };
 
@@ -135,7 +137,8 @@ function _moveEndHandler(
   options,
   interactionType,
   { moveHandler, moveEndHandler },
-  evt
+  evt,
+  doneMovingCallback
 ) {
   const { element, currentPoints } = evt.detail;
   const page = currentPoints.page;
@@ -168,8 +171,8 @@ function _moveEndHandler(
   if (evt.type === EVENTS.TOUCH_PINCH || evt.type === EVENTS.TOUCH_PRESS) {
     handle.active = false;
     external.cornerstone.updateImage(element);
-    if (typeof options.doneMovingCallback === 'function') {
-      options.doneMovingCallback();
+    if (typeof doneMovingCallback === 'function') {
+      doneMovingCallback();
     }
 
     return;
@@ -187,8 +190,8 @@ function _moveEndHandler(
     removeToolState(element, toolName, annotation);
   }
 
-  if (typeof options.doneMovingCallback === 'function') {
-    options.doneMovingCallback();
+  if (typeof doneMovingCallback === 'function') {
+    doneMovingCallback();
   }
 
   // Update Image

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -279,48 +279,35 @@ export default class AngleTool extends BaseAnnotationTool {
     addToolState(element, this.name, measurementData);
     external.cornerstone.updateImage(element);
 
-    const doneMovingEndHandleOptions = Object.assign(
-      {},
-      {
-        doneMovingCallback: () => {
-          measurementData.active = false;
-          this.preventNewMeasurement = false;
-          external.cornerstone.updateImage(element);
-        },
-      },
-      this.options
-    );
-
-    const doneMovingMiddleHandleOptions = Object.assign(
-      {},
-      {
-        doneMovingCallback: () => {
-          measurementData.active = false;
-          measurementData.handles.end.active = true;
-
-          external.cornerstone.updateImage(element);
-
-          moveNewHandle(
-            eventData,
-            this.name,
-            measurementData,
-            measurementData.handles.end,
-            doneMovingEndHandleOptions,
-            interactionType
-          );
-        },
-      },
-      this.options
-    );
-
     // Step 1, create start and second middle
     moveNewHandle(
       eventData,
       this.name,
       measurementData,
       measurementData.handles.middle,
-      doneMovingMiddleHandleOptions,
-      interactionType
+      this.options,
+      interactionType,
+      () => {
+        measurementData.active = false;
+        measurementData.handles.end.active = true;
+
+        external.cornerstone.updateImage(element);
+
+        // Step 2, create end
+        moveNewHandle(
+          eventData,
+          this.name,
+          measurementData,
+          measurementData.handles.end,
+          this.options,
+          interactionType,
+          () => {
+            measurementData.active = false;
+            this.preventNewMeasurement = false;
+            external.cornerstone.updateImage(element);
+          }
+        );
+      }
     );
   }
 }

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -241,36 +241,28 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     addToolState(element, this.name, measurementData);
     external.cornerstone.updateImage(element);
 
-    const toolOptions = Object.assign(
-      {},
-      {
-        doneMovingCallback: () => {
-          if (measurementData.text === undefined) {
-            this.configuration.getTextCallback(text => {
-              if (text) {
-                measurementData.text = text;
-              } else {
-                removeToolState(element, this.name, measurementData);
-              }
-
-              measurementData.active = false;
-              external.cornerstone.updateImage(element);
-            });
-          }
-
-          external.cornerstone.updateImage(element);
-        },
-      },
-      this.options
-    );
-
     moveNewHandle(
       evt.detail,
       this.name,
       measurementData,
       measurementData.handles.end,
-      toolOptions,
-      interactionType
+      this.options,
+      interactionType,
+      () => {
+        if (measurementData.text === undefined) {
+          this.configuration.getTextCallback(text => {
+            if (text) {
+              measurementData.text = text;
+            } else {
+              removeToolState(element, this.name, measurementData);
+            }
+
+            measurementData.active = false;
+            external.cornerstone.updateImage(element);
+          });
+        }
+        external.cornerstone.updateImage(element);
+      }
     );
   }
 

--- a/src/tools/annotation/bidirectionalTool/addNewMeasurement.js
+++ b/src/tools/annotation/bidirectionalTool/addNewMeasurement.js
@@ -36,49 +36,48 @@ export default function(evt, interactionType) {
     this.name,
     measurementData,
     end,
-    {
-      doneMovingCallback: () => {
-        const { handles, longestDiameter, shortestDiameter } = measurementData;
-        const hasHandlesOutside = anyHandlesOutsideImage(eventData, handles);
-        const longestDiameterSize = parseFloat(longestDiameter) || 0;
-        const shortestDiameterSize = parseFloat(shortestDiameter) || 0;
-        const isTooSmal = longestDiameterSize < 1 || shortestDiameterSize < 1;
-        const isTooFast = new Date().getTime() - timestamp < 150;
+    this.options,
+    interactionType,
+    () => {
+      const { handles, longestDiameter, shortestDiameter } = measurementData;
+      const hasHandlesOutside = anyHandlesOutsideImage(eventData, handles);
+      const longestDiameterSize = parseFloat(longestDiameter) || 0;
+      const shortestDiameterSize = parseFloat(shortestDiameter) || 0;
+      const isTooSmal = longestDiameterSize < 1 || shortestDiameterSize < 1;
+      const isTooFast = new Date().getTime() - timestamp < 150;
 
-        if (hasHandlesOutside || isTooSmal || isTooFast) {
-          // Delete the measurement
-          measurementData.cancelled = true;
-          removeToolState(element, this.name, measurementData);
-        } else {
-          // Set lesionMeasurementData Session
-          config.getMeasurementLocationCallback(
-            measurementData,
-            eventData,
-            doneCallback
-          );
-        }
-
-        // Perpendicular line is not connected to long-line
-        perpendicularStart.locked = false;
-
-        external.cornerstone.updateImage(element);
-
-        const modifiedEventData = {
-          toolType: this.name,
-          element,
+      if (hasHandlesOutside || isTooSmal || isTooFast) {
+        // Delete the measurement
+        measurementData.cancelled = true;
+        removeToolState(element, this.name, measurementData);
+      } else {
+        // Set lesionMeasurementData Session
+        config.getMeasurementLocationCallback(
           measurementData,
-        };
-
-        calculateLongestAndShortestDiameters(eventData, measurementData);
-
-        external.cornerstone.triggerEvent(
-          element,
-          EVENTS.MEASUREMENT_MODIFIED,
-          modifiedEventData
+          eventData,
+          doneCallback
         );
-      },
-    },
-    interactionType
+      }
+
+      // Perpendicular line is not connected to long-line
+      perpendicularStart.locked = false;
+
+      external.cornerstone.updateImage(element);
+
+      const modifiedEventData = {
+        toolType: this.name,
+        element,
+        measurementData,
+      };
+
+      calculateLongestAndShortestDiameters(eventData, measurementData);
+
+      external.cornerstone.triggerEvent(
+        element,
+        EVENTS.MEASUREMENT_MODIFIED,
+        modifiedEventData
+      );
+    }
   );
 }
 

--- a/src/tools/annotation/bidirectionalTool/handleSelectedMouseCallback.js
+++ b/src/tools/annotation/bidirectionalTool/handleSelectedMouseCallback.js
@@ -108,9 +108,9 @@ export default function(evt) {
         {
           deleteIfHandleOutsideImage: true,
           preventHandleOutsideImage: false,
-          doneMovingCallback,
         },
-        'mouse'
+        'mouse',
+        doneMovingCallback
       );
 
       preventPropagation(evt);

--- a/src/tools/annotation/bidirectionalTool/handleSelectedTouchCallback.js
+++ b/src/tools/annotation/bidirectionalTool/handleSelectedTouchCallback.js
@@ -88,9 +88,9 @@ export default function(evt) {
         {
           deleteIfHandleOutsideImage: true,
           preventHandleOutsideImage: false,
-          doneMovingCallback,
         },
-        'touch'
+        'touch',
+        doneMovingCallback
       );
 
       preventPropagation(evt);

--- a/src/util/findAndMoveHelpers.js
+++ b/src/util/findAndMoveHelpers.js
@@ -105,17 +105,6 @@ const moveAnnotation = function(
   annotation,
   interactionType = 'mouse'
 ) {
-  const toolOptions = Object.assign(
-    {},
-    {
-      doneMovingCallback: () => {
-        annotation.active = false;
-        state.isToolLocked = false;
-      },
-    },
-    tool.options
-  );
-
   annotation.active = true;
   state.isToolLocked = true;
 
@@ -124,8 +113,12 @@ const moveAnnotation = function(
     tool.name,
     annotation,
     null,
-    toolOptions,
-    interactionType
+    tool.options,
+    interactionType,
+    () => {
+      annotation.active = false;
+      state.isToolLocked = false;
+    }
   );
 
   evt.stopImmediatePropagation();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change is intended to clarify the purpose of the `doneMovingCallback` and prevent end users accidentally breaking tools.

* **What is the current behavior?** (You can also link to an open issue here)

Currently, `doneMovingCallback` is an attribute of `tool.options`. It is used by tools which need to be notified that a `move` or drag event has finished, allowing the tool to update its state.

As `tool.options` can be set when calling `setToolActive`, `doneMovingCallback` can be overridden by end users. In my opinion this is unintentional API and for most tools and users, unexpected behaviour.

If a user does set `doneMovingCallback` it will break several of the multi step tools.

* **What is the new behaviour (if this is a feature change)?**

`doneMovingCallback` is moved out of the `options` object and passed to the `moveHandle` methods as an extra function parameter. This makes using this feature as a tool developer more reliable and clarifies that the callback is intended as API for tool developers.

End users can no-longer set/override this callback. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, any tools which are not built into cornerstoneTools and which rely on this callback will need to be updated.

* **Other information**:

This PR has come out of work to add the `MEASUREMENT_COMPLETE` event #913 
