### PR TITLE
fix(freehand): Pass event data on measurement modified event of freehand tool

### DIFF
--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -1607,10 +1607,16 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @param {any} data the measurment data
    */
   fireModifiedEvent(element, data) {
+    const modifiedEventData = {
+      toolName: this.name,
+      element,
+      measurementData: data,
+    };
+
     external.cornerstone.triggerEvent(
       element,
       EVENTS.MEASUREMENT_MODIFIED,
-      data
+      modifiedEventData
     );
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Freehand passes only measurement data on measurement modified event


* **What is the new behavior (if this is a feature change)?**
Pass event data in the same format with other tools on measurement modified event for freehand


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users who already handle measurement modified event for freehand need to update the data passed

