### PR TITLE
fix(BaseBrushTool.js): prevents a crash in passiveCallback

### DIFF
--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -141,7 +141,13 @@ class BaseBrushTool extends BaseTool {
    */
   // eslint-disable-next-line no-unused-vars
   passiveCallback(evt) {
-    external.cornerstone.updateImage(this.element);
+    try {
+      external.cornerstone.updateImage(this.element);
+    } catch (error) {
+      // It is possible that the image has not been loaded
+      // when this is called.
+      return;
+    }
   }
 
   /**


### PR DESCRIPTION
prevents a crash when _repeatGlobalToolHistory replays setting tool mode passive for brush tools

fix #924

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Crashing Bug: using the Brush tool with `globalToolSyncEnabled` can cause the application to crash when a new element is enabled.

- `_repeatGlobalToolHistory` replays all tool changes on a new element before the image is loaded
- BaseBrushTool calls `cornerstone.updateImage` in it's `passiveCallback`
- `cornerstone.updateImage` will crash if the image is not loaded

* **What is the new behavior (if this is a feature change)?**

Wrapped the call to `updateImage` in a `try ... catch`.

This should be seen as a temporary fix. A more permanent fix could be to keep track of the current tool state instead of recording and replaying changes. Alternatively, there appears to be no reason why `cornerstone.updateImage` need to crash when the image is not loaded so changing this behaviour could be more effective.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

