### PR TITLE
Fix/circle tool hitarea

### DIFF
--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -121,8 +121,9 @@ export default class CircleRoiTool extends BaseAnnotationTool {
     const radius = _getDistance(startCanvas, endCanvas);
 
     // Checking if point is near the tool by comparing its distance from the center of the circle
-    return !(
-      distanceFromCenter > radius + distance / 2 || distanceFromCenter < radius
+    return (
+      distanceFromCenter > radius - distance / 2 &&
+      distanceFromCenter < radius + distance / 2
     );
   }
 

--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -23,7 +23,7 @@ import numbersWithCommas from './../../util/numbersWithCommas.js';
 import throttle from './../../util/throttle.js';
 import { getLogger } from '../../util/logger.js';
 
-const logger = getLogger('tools:annotation:EllipticalRoiTool');
+const logger = getLogger('tools:annotation:CircleRoiTool');
 
 /**
  * @public

--- a/src/tools/annotation/CircleRoiTool.test.js
+++ b/src/tools/annotation/CircleRoiTool.test.js
@@ -165,7 +165,7 @@ describe('CircleRoiTool.js', () => {
       expect(isPointNearTool).toBe(false);
     });
 
-    it('returns false when point is inside the cirle roi', () => {
+    it('returns false when point is not in the hit area region', () => {
       const instantiatedTool = new CircleRoiTool();
       const toolMeasurement = instantiatedTool.createNewMeasurement(
         goodMouseEventData
@@ -173,8 +173,8 @@ describe('CircleRoiTool.js', () => {
 
       // Setting the coordinates to be inside the circle annotation
       const coords = {
-        x: 20,
-        y: 20,
+        x: 23.5, // For the 'mouse', we are setting the hit area region to be 7.5 px wide
+        y: 23.5,
       };
 
       // picking a start handler as {x: 25, y: 25} and end handler as {x: 15, y: 15};

--- a/src/tools/base/BaseAnnotationTool.js
+++ b/src/tools/base/BaseAnnotationTool.js
@@ -117,9 +117,9 @@ class BaseAnnotationTool extends BaseTool {
       // Tool data's 'active' does not match coordinates
       // TODO: can't we just do an if/else and save on a pointNearTool check?
       const nearToolAndNotMarkedActive =
-        this.pointNearTool(element, data, coords) && !data.active;
+        this.pointNearTool(element, data, coords, 'mouse') && !data.active;
       const notNearToolAndMarkedActive =
-        !this.pointNearTool(element, data, coords) && data.active;
+        !this.pointNearTool(element, data, coords, 'mouse') && data.active;
 
       if (nearToolAndNotMarkedActive || notNearToolAndMarkedActive) {
         data.active = !data.active;


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When coordinates are inside the circle, it won't highlight the annotation and clicking and dragging wasn't possible from inside the circle. Related to #930 

* **What is the new behavior (if this is a feature change)?**
This new behavior has extended the hit area region towards the center of the circle from the boundary. 
It will now make it possible to click and drag the annotation from within the circle's hit area region. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
