### PR TITLE
Add 10px x-offset to ROI textboxes

### DIFF
--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -159,7 +159,7 @@ export default class CircleRoiTool extends BaseAnnotationTool {
     };
 
     draw(newContext, context => {
-      // If we have tool data for this element - iterate over each set and draw it
+      // If we have tool data for this element, iterate over each set and draw it
       for (let i = 0; i < toolData.data.length; i++) {
         const data = toolData.data[i];
 

--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -250,7 +250,7 @@ export default class CircleRoiTool extends BaseAnnotationTool {
           textBoxAnchorPoints,
           color,
           lineWidth,
-          0,
+          10,
           true
         );
       }

--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -257,7 +257,7 @@ export default class EllipticalRoiTool extends BaseAnnotationTool {
           textBoxAnchorPoints,
           color,
           lineWidth,
-          0,
+          10,
           true
         );
       }

--- a/src/tools/annotation/RectangleRoiTool.js
+++ b/src/tools/annotation/RectangleRoiTool.js
@@ -244,7 +244,7 @@ export default class RectangleRoiTool extends BaseAnnotationTool {
           textBoxAnchorPoints,
           color,
           lineWidth,
-          0,
+          10,
           true
         );
       }


### PR DESCRIPTION
The ROI textboxes are dangerously close to the handles if you draw a shape that is shorter in height than the textbox.  This is very evident if the textboxes have a background color.

![image](https://user-images.githubusercontent.com/3342530/58104586-03863400-7bb3-11e9-8d1b-ea4bc8719b2d.png)

This change adds a 10px x-offset to those textboxes, which matches the x-offset already used by the Length tool (probably for the same reason?).
