### PR TITLE
fix(mouseDownActivate.js): fix throwing issue in mouseDownActivate

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
+++ b/src/eventDispatchers/mouseEventHandlers/mouseDownActivate.js
@@ -11,6 +11,10 @@ export default function(evt) {
   const { element, buttons } = evt.detail;
   const activeTool = getActiveTool(element, buttons, 'mouse');
 
+  if (!activeTool) {
+    return;
+  }
+
   if (typeof activeTool.preMouseDownActivateCallback === 'function') {
     const consumedEvent = activeTool.preMouseDownActivateCallback(evt);
 


### PR DESCRIPTION
mouseDownActivate does not check if getActiveTool returned anything before accessing a property
thereof

fix #942

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

FIX

* **What is the current behavior?** (You can also link to an open issue here)

`mouseDownActivate.js` throws if `getActiveTool` returns `undefined`.

* **What is the new behavior (if this is a feature change)?**

Exit early if `getActiveTool` has not returned a tool.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

N


* **Other information**:
