### PR TITLE
feat(CircleRoiTool.js): Adds cursor for CircleRoiTool

### DIFF
--- a/src/tools/annotation/CircleRoiTool.js
+++ b/src/tools/annotation/CircleRoiTool.js
@@ -24,6 +24,7 @@ import numbersWithCommas from './../../util/numbersWithCommas.js';
 import throttle from './../../util/throttle.js';
 import { getLogger } from '../../util/logger.js';
 import getPixelSpacing from '../../util/getPixelSpacing';
+import { circleRoiCursor } from '../cursors/index.js';
 
 const logger = getLogger('tools:annotation:CircleRoiTool');
 
@@ -40,6 +41,7 @@ export default class CircleRoiTool extends BaseAnnotationTool {
     const defaultProps = {
       name: 'CircleRoi',
       supportedInteractionTypes: ['Mouse', 'Touch'],
+      svgCursor: circleRoiCursor,
     };
 
     super(props, defaultProps);

--- a/src/tools/cursors/index.js
+++ b/src/tools/cursors/index.js
@@ -70,6 +70,16 @@ export const cobbAngleCursor = new MouseCursor(
   }
 );
 
+export const circleRoiCursor = new MouseCursor(
+  `<circle stroke="ACTIVE_COLOR" fill="none" stroke-width="3" cx="16" cy="16" r="14" />`,
+  {
+    viewBox: {
+      x: 32,
+      y: 32,
+    },
+  }
+);
+
 export const ellipticalRoiCursor = new MouseCursor(
   `<path stroke="ACTIVE_COLOR" fill="none" stroke-width="3" d="M30.74 15.76C30.74 20.99 24.14 25.23 16
     25.23C7.86 25.23 1.26 20.99 1.26 15.76C1.26 10.54 7.86 6.3 16 6.3C24.14


### PR DESCRIPTION
fix #944

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix / minor feature

Adds an SVG cursor for the CircleROITool

<img width="451" alt="Screen Shot 2019-05-28 at 12 17 05 pm" src="https://user-images.githubusercontent.com/814227/58446099-be2dad80-8142-11e9-8de9-f78b3407153e.png">

NOTE: Ignore the colour of the cursor in this screenshot. Mac OS has done something weird in the screen capture. The cursor does not specify a custom colour.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No