### PR TITLE
feat(tools/brush/BrushTool.js): configuration option alwaysEraseOnClick

### DIFF
--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -30,7 +30,7 @@ export default class BrushTool extends BaseBrushTool {
         nonOverlapping: _nonOverlappingStrategy,
       },
       defaultStrategy: 'overlapping',
-      configuration: {},
+      configuration: { alwaysEraseOnClick: false },
     };
 
     super(props, defaultProps);
@@ -114,7 +114,7 @@ export default class BrushTool extends BaseBrushTool {
   }
 }
 
-function _overlappingStrategy(evt) {
+function _overlappingStrategy(evt, configuration) {
   const eventData = evt.detail;
   const element = eventData.element;
   const { rows, columns } = eventData.image;
@@ -141,10 +141,10 @@ function _overlappingStrategy(evt) {
   const radius = brushModule.state.radius;
   const pointerArray = getCircle(radius, rows, columns, x, y);
 
-  _drawMainColor(eventData, toolData, pointerArray);
+  _drawMainColor(eventData, toolData, pointerArray, configuration);
 }
 
-function _nonOverlappingStrategy(evt) {
+function _nonOverlappingStrategy(evt, configuration) {
   const eventData = evt.detail;
   const element = eventData.element;
   const { rows, columns } = eventData.image;
@@ -187,11 +187,12 @@ function _nonOverlappingStrategy(evt) {
     }
   }
 
-  _drawMainColor(eventData, toolData, pointerArray);
+  _drawMainColor(eventData, toolData, pointerArray, configuration);
 }
 
-function _drawMainColor(eventData, toolData, pointerArray) {
-  const shouldErase = _isCtrlDown(eventData);
+function _drawMainColor(eventData, toolData, pointerArray, configuration) {
+  const shouldErase =
+    configuration.alwaysEraseOnClick || _isCtrlDown(eventData);
   const columns = eventData.image.columns;
   const segmentationIndex = brushModule.state.drawColorId;
 


### PR DESCRIPTION
When alwaysEraseOnClick is on, the brush tool will erase in both strategies. This is useful for e.g.
touch devices, or if you want to add a "delete only" brush tool to your app.