### PR TITLE
vNext - Segmentation overhaul

### DIFF
--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -35,7 +35,7 @@
 							<td>
 								<table>
 									<tr>
-										<td>Click and drag to use the paint with the selected segmentation.</td>
+										<td>Click and drag to paint with the selected segment.</td>
 									</tr>
 									<tr>
 										<td>Release the mouse to stop painting.</td>
@@ -306,10 +306,10 @@
 	function brushApiCall (opperation) {
 		switch (opperation) {
 			case 'next-segment':
-				brushTool.nextSegmentation();
+				brushTool.nextSegment();
 				break;
 			case 'previous-segment':
-				brushTool.previousSegmentation();
+				brushTool.previousSegment();
 				break;
       case 'switch-labelmap':
         if (activeLabelmap === 0) {

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -81,9 +81,17 @@
 								<input type="range" id="alpha" min="0" max="255">
 							</td>
 							<td>
-								alpha - The transparency of segmentations.
+								alpha - The transparency of the active segmentation.
 							</td>
 						</tr>
+            <tr>
+              <td>
+                <input type="range" id="alpha-inactive" min="0" max="255">
+              </td>
+              <td>
+                alphaOfInactiveLabelmap - The transparency of inactive segmentations.
+              </td>
+            </tr>
 					</table>
 				</div>
 			</div>
@@ -325,13 +333,22 @@
 	// API Sliders
 	const alphaSlider = document.getElementById("alpha");
 
-	alphaSlider.defaultValue = Math.floor(0.4*255);
+  alphaSlider.defaultValue = Math.floor(0.6*255);
+  alphaSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value/255.0;
 
-	alphaSlider.addEventListener('input', event => {
-		const normalisedAlpha = event.target.value/255.0;
+    brushTool.alpha = normalisedAlpha;
+  });
 
-		brushTool.alpha = normalisedAlpha;
-	});
+
+  const alphaOfInactiveLabelmapSlider = document.getElementById("alpha-inactive");
+
+  alphaOfInactiveLabelmapSlider.defaultValue = Math.floor(0.0);
+  alphaOfInactiveLabelmapSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value/255.0;
+
+    brushTool.alphaOfInactiveLabelmap = normalisedAlpha;
+  });
 
 
 </script>

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -47,87 +47,45 @@
 								</table>
 							</td>
 						</tr>
-						<tr>
-							<th>Keyboard Input</th>
-							<td>
-								<table>
-									<tr>
-										<td>Next Segmentation:</td>
-										<td>]</td>
-									</tr>
-									<tr>
-										<td>Previous Segmentation:</td>
-										<td>[</td>
-									</tr>
-									<tr>
-										<td>Increase Brush Size:</td>
-										<td>+</td>
-									</tr>
-									<tr>
-										<td>Decrease Brush Size :</td>
-										<td>-</td>
-									</tr>
-								</table>
-							</td>
-						</tr>
 					</table>
 					<h2>Brush Tool API</h2>
 					<table>
 						<tr>
 							<th>
-								<button type="button" api-call="hide-all">
-									Hide All Segmentations
+								<button type="button" api-call="next-segment">
+									Next Segment
 								</button>
 							</th>
 							<td>
-									Hides all segmentations unless that segmentation is actively being drawn.
+								Switch to the next segment index.
 							</td>
 						</tr>
-						<tr>
-							<th>
-								<button type="button" api-call="show-all">
-									Show All Segmentations
-								</button>
-							</th>
-							<td>
-								Shows all segmentations on the canvas, all the time.
-							</td>
-						</tr>
-						<tr>
-							<th>
-								<button type="button" api-call="hide-third">
-									Hide 3rd Segmentation
-								</button>
-							</th>
-							<td>
-								An example of hiding a single segmentation. Hide's the 3rd (yellow) segmentation. When hidden it can only be seen whilst actively being drawn.
-							</td>
-						</tr>
-						<tr>
-							<th>
-								<button type="button" api-call="show-third">
-									Show 3rd Segmentation
-								</button>
-							</th>
-							<td><p>
-								An example of un-hiding a single segmentation. Unhide's the 3rd (yellow) segmentation.
-							</p></td>
-						</tr>
-
+            <tr>
+              <th>
+                <button type="button" api-call="previous-segment">
+                  Previous Segment
+                </button>
+              </th>
+              <td>
+                Switch to the previous segment index.
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <button type="button" api-call="switch-labelmap">
+                  Switch Labelmap
+                </button>
+              </th>
+              <td id="active-label-map-label">
+                Active labelmap: 0
+              </td>
+            </tr>
 						<tr>
 							<td>
 								<input type="range" id="alpha" min="0" max="255">
 							</td>
 							<td>
 								alpha - The transparency of segmentations.
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<input type="range" id="alphaWhenHiddenButActive" min="0">
-							</td>
-							<td>
-								alphaWhenHiddenButActive - The transparency of segmentations when set to hidden but actively drawing.
 							</td>
 						</tr>
 					</table>
@@ -174,10 +132,9 @@
 	element.focus();
 
 	cornerstone.loadImage(imageIds[0]).then(function (image) {
+    cornerstoneTools.addStackStateManager(element, ['stack']);
+    cornerstoneTools.addToolState(element, 'stack', stack);
 		cornerstone.displayImage(element, image);
-
-		cornerstoneTools.addStackStateManager(element, ['stack']);
-		cornerstoneTools.addToolState(element, 'stack', stack);
 	});
 
 	function setAllToolsPassive() {
@@ -341,45 +298,44 @@
 
 	const brushTool = cornerstoneTools.getToolForElement(element, 'Brush');
 
+  let activeLabelmap = 0;
+
 	function brushApiCall (opperation) {
 		switch (opperation) {
-			case 'hide-all':
-				brushTool.hideAllSegmentationsOnElement();
+			case 'next-segment':
+				brushTool.nextSegmentation();
 				break;
-			case 'show-all':
-				brushTool.showAllSegmentationsOnElement();
+			case 'previous-segment':
+				brushTool.previousSegmentation();
 				break;
-			case 'hide-third':
-				brushTool.hideSegmentationOnElement(2); //Zero-indexed
-				break;
-			case 'show-third':
-				brushTool.showSegmentationOnElement(2); //Zero-indexed
-				break;
+      case 'switch-labelmap':
+        if (activeLabelmap === 0) {
+          activeLabelmap = 1;
+        } else {
+          activeLabelmap = 0;
+        }
+
+        cornerstoneTools.store.modules.brush.setters.activeLabelmap(element, activeLabelmap);
+
+        const label = document.getElementById("active-label-map-label");
+        label.innerHTML = "Active Labelmap: " + activeLabelmap;
+
+        break;
 			default:
 				return;
 		}
 	}
 
-	// BRUSH TOOL Key interface
 
 	// API Sliders
-
 	const alphaSlider = document.getElementById("alpha");
-	const alphaWhenHiddenButActiveSlider = document.getElementById("alphaWhenHiddenButActive");
 
 	alphaSlider.defaultValue = Math.floor(0.4*255);
-	alphaWhenHiddenButActiveSlider.defaultValue = Math.floor(0.2*255);
 
 	alphaSlider.addEventListener('input', event => {
 		const normalisedAlpha = event.target.value/255.0;
 
 		brushTool.alpha = normalisedAlpha;
-	});
-
-	alphaWhenHiddenButActiveSlider.addEventListener('input', event => {
-		const normalisedAlpha = event.target.value/255.0;
-
-		brushTool.hiddenButActiveAlpha = normalisedAlpha;
 	});
 
 

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -15,17 +15,13 @@
 		<div class="wrapper">
 			<!-- Select Tool Category -->
 			<ul class="tool-category-list">
-				<li><a class="tools" data-category="tools" href="#">Brush</a></li>
-				<li><a data-category="mousewheel" href="#">MouseWheel</a></li>
+				<li><a class="tools" data-category="tools" href="#">Drag</a></li>
 			</ul>
 
 			<!-- Select Active Tool -->
 			<ul class="tool-category active" data-tool-category="tools">
 				<li><a href="#" data-tool="Brush">Brush</a></li>
-			</ul>
-			<ul class="tool-category" data-tool-category="mousewheel">
-				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a></li>
-				<li><a href="#" data-tool="ZoomMouseWheel" data-tool-type="wheel">ZoomMouseWheel</a></li>
+        <li><a href="#" data-tool="StackScroll">StackScroll</a></li>
 			</ul>
 
 			<!-- Our beautiful element targets -->
@@ -115,8 +111,7 @@
 	cornerstoneTools.init();
 	const imageIds = [
 		'example://1',
-		'example://2',
-		'example://3'
+		'example://2'
 	];
 	const stack = {
 		currentImageIdIndex: 0,

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -9,6 +9,8 @@ import {
   transformCanvasContext,
 } from '../drawing/index.js';
 
+const brushModule = store.modules.brush;
+
 /* Safari and Edge polyfill for createImageBitmap
  * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
  */
@@ -63,28 +65,16 @@ export default function(evt) {
   const element = eventData.element;
   const maxSegmentations = BaseBrushTool.getNumberOfColors();
 
-  const brushStackState = getToolState(
-    element,
-    BaseBrushTool.getReferencedToolDataName()
+  const { brushStackState, currentImageIdIndex } = brushModule.getters.labelmap(
+    element
   );
 
-  if (!brushStackState.data.length) {
-    return;
-  }
+  const labelMap2D = brushStackState.labelMap2D[currentImageIdIndex];
 
-  const stackState = getToolState(element, 'stack');
-  const currentImageIdIndex = stackState.data[0].currentImageIdIndex;
+  if (labelMap2D) {
+    const imageBitmapCache = brushStackState.imageBitmapCache;
 
-  for (let i = 0; i < brushStackState.data.length; i++) {
-    const brushStackData = brushStackState.data[i];
-
-    const labelMap2D = brushStackData.labelMap2D[currentImageIdIndex];
-
-    if (labelMap2D) {
-      const imageBitmapCache = brushStackData.imageBitmapCache;
-
-      renderSegmentation(evt, brushStackData, labelMap2D, imageBitmapCache);
-    }
+    renderSegmentation(evt, brushStackState, labelMap2D, imageBitmapCache);
   }
 }
 

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -9,10 +9,6 @@ import {
   transformCanvasContext,
 } from '../drawing/index.js';
 
-import { getLogger } from '../util/logger.js';
-
-const logger = getLogger('eventListeners:onImageRenderedBrushEventHandler');
-
 /* Safari and Edge polyfill for createImageBitmap
  * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
  */
@@ -72,10 +68,6 @@ export default function(evt) {
     BaseBrushTool.getReferencedToolDataName()
   );
 
-  logger.warn('LABELMAP RENDER:');
-
-  logger.warn(brushStackState);
-
   if (!brushStackState.data.length) {
     return;
   }
@@ -121,9 +113,6 @@ function createNewBitmapAndQueueRenderOfSegmentation(
   const enabledElement = external.cornerstone.getEnabledElement(element);
 
   const pixelData = labelMap2D.pixelData;
-
-  logger.warn(`createNewBitmapAndQueueRenderOfSegmentation`);
-  logger.warn(state.colorLutTable);
 
   const imageData = new ImageData(
     eventData.image.width,

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -69,37 +69,30 @@ export default function(evt) {
   const element = eventData.element;
 
   const {
-    brushStackState,
+    labelmaps3D,
     currentImageIdIndex,
-  } = brushModule.getters.labelMapsForElement(element);
+  } = brushModule.getters.labelMaps3DForElement(element);
 
-  if (!brushStackState) {
+  if (!labelmaps3D) {
     return;
   }
 
-  for (let i = 0; i < brushStackState.length; i++) {
-    const labelMapSpecificBrushStackState = brushStackState[i];
+  for (let i = 0; i < labelmaps3D.length; i++) {
+    const labelmap3D = labelmaps3D[i];
 
-    const labelMap2D =
-      labelMapSpecificBrushStackState.labelMap2D[currentImageIdIndex];
+    const labelMap2D = labelmap3D.labelmaps2D[currentImageIdIndex];
 
     if (labelMap2D) {
-      const imageBitmapCache = labelMapSpecificBrushStackState.imageBitmapCache;
+      const imageBitmapCache = labelmap3D.imageBitmapCache;
 
-      renderSegmentation(
-        evt,
-        labelMapSpecificBrushStackState,
-        i,
-        labelMap2D,
-        imageBitmapCache
-      );
+      renderSegmentation(evt, labelmap3D, i, labelMap2D, imageBitmapCache);
     }
   }
 }
 
 function renderSegmentation(
   evt,
-  brushStackData,
+  labelmap3D,
   labelMapIndex,
   labelMap2D,
   imageBitmapCache
@@ -112,7 +105,7 @@ function renderSegmentation(
   if (labelMap2D.invalidated) {
     createNewBitmapAndQueueRenderOfSegmentation(
       evt,
-      brushStackData,
+      labelmap3D,
       labelMapIndex,
       labelMap2D
     );
@@ -121,7 +114,7 @@ function renderSegmentation(
 
 function createNewBitmapAndQueueRenderOfSegmentation(
   evt,
-  brushStackData,
+  labelmap3D,
   labelMapIndex,
   labelMap2D
 ) {
@@ -150,7 +143,7 @@ function createNewBitmapAndQueueRenderOfSegmentation(
   );
 
   window.createImageBitmap(imageData).then(newImageBitmap => {
-    brushStackData.imageBitmapCache = newImageBitmap;
+    labelmap3D.imageBitmapCache = newImageBitmap;
     labelMap2D.invalidated = false;
 
     external.cornerstone.updateImage(eventData.element);

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -65,16 +65,24 @@ export default function(evt) {
   const element = eventData.element;
   const maxSegmentations = BaseBrushTool.getNumberOfColors();
 
-  const { brushStackState, currentImageIdIndex } = brushModule.getters.labelmap(
-    element
-  );
+  // TEMP Fetch every label map.
+  const {
+    labelMapSpecificBrushStackState,
+    currentImageIdIndex,
+  } = brushModule.getters.getAndCacheLabelMap2D(element, 0);
 
-  const labelMap2D = brushStackState.labelMap2D[currentImageIdIndex];
+  const labelMap2D =
+    labelMapSpecificBrushStackState.labelMap2D[currentImageIdIndex];
 
   if (labelMap2D) {
-    const imageBitmapCache = brushStackState.imageBitmapCache;
+    const imageBitmapCache = labelMapSpecificBrushStackState.imageBitmapCache;
 
-    renderSegmentation(evt, brushStackState, labelMap2D, imageBitmapCache);
+    renderSegmentation(
+      evt,
+      labelMapSpecificBrushStackState,
+      labelMap2D,
+      imageBitmapCache
+    );
   }
 }
 

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -18,15 +18,24 @@ export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
 
-  const {
-    labelmaps3D,
-    currentImageIdIndex,
-  } = brushModule.getters.labelMaps3DForElement(element);
+  const { labelmaps3D, currentImageIdIndex } = brushModule.getters.labelmaps3D(
+    element
+  );
+
+  if (!labelmaps3D) {
+    return;
+  }
 
   let invalidated = false;
 
   for (let i = 0; i < labelmaps3D.length; i++) {
-    const labelmap2D = labelmaps3D[i].labelmaps2D[currentImageIdIndex];
+    const labelmap3D = labelmaps3D[i];
+
+    if (!labelmap3D) {
+      continue;
+    }
+
+    const labelmap2D = labelmap3D.labelmaps2D[currentImageIdIndex];
 
     if (labelmap2D) {
       labelmap2D.invalidated = true;

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -18,17 +18,20 @@ export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
 
-  const { brushStackState, currentImageIdIndex } = brushModule.getters.labelmap(
-    element
-  );
+  const {
+    labelmaps3D,
+    currentImageIdIndex,
+  } = brushModule.getters.labelMaps3DForElement(element);
 
   let invalidated = false;
 
-  const labelMap2D = brushStackState.labelMap2D[currentImageIdIndex];
+  for (let i = 0; i < labelmaps3D.length; i++) {
+    const labelmap2D = labelmaps3D[i].labelmaps2D[currentImageIdIndex];
 
-  if (labelMap2D) {
-    labelMap2D.invalidated = true;
-    invalidated = true;
+    if (labelmap2D) {
+      labelmap2D.invalidated = true;
+      invalidated = true;
+    }
   }
 
   if (invalidated) {

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -26,8 +26,11 @@ export default function(evt) {
 
   let invalidated = false;
 
+  console.log(brushStackState);
+
   for (let i = 0; i < brushStackState.data.length; i++) {
-    const brushStackData = brushStackState[i];
+    const brushStackData = brushStackState.data[i];
+
     const labelMap2D = brushStackData.labelMap2D[currentImageIdIndex];
 
     if (labelMap2D) {

--- a/src/eventListeners/onNewImageBrushEventHandler.js
+++ b/src/eventListeners/onNewImageBrushEventHandler.js
@@ -1,6 +1,9 @@
 import { getToolState, addToolState } from '../stateManagement/toolState.js';
 import BaseBrushTool from './../tools/base/BaseBrushTool.js';
 import external from '../externalModules.js';
+import store from '../store/index.js';
+
+const brushModule = store.modules.brush;
 
 const referencedToolDataName = BaseBrushTool.getReferencedToolDataName();
 
@@ -15,28 +18,17 @@ export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
 
-  const brushStackState = getToolState(element, referencedToolDataName);
-
-  if (!brushStackState.data.length) {
-    return;
-  }
-
-  const stackState = getToolState(element, 'stack');
-  const currentImageIdIndex = stackState.data[0].currentImageIdIndex;
+  const { brushStackState, currentImageIdIndex } = brushModule.getters.labelmap(
+    element
+  );
 
   let invalidated = false;
 
-  console.log(brushStackState);
+  const labelMap2D = brushStackState.labelMap2D[currentImageIdIndex];
 
-  for (let i = 0; i < brushStackState.data.length; i++) {
-    const brushStackData = brushStackState.data[i];
-
-    const labelMap2D = brushStackData.labelMap2D[currentImageIdIndex];
-
-    if (labelMap2D) {
-      labelMap2D.invalidated = true;
-      invalidated = true;
-    }
+  if (labelMap2D) {
+    labelMap2D.invalidated = true;
+    invalidated = true;
   }
 
   if (invalidated) {

--- a/src/events.js
+++ b/src/events.js
@@ -197,6 +197,11 @@ const EVENTS = {
    *  @type {String}
    */
   STACK_SCROLL: 'cornerstonetoolsstackscroll',
+
+  /**
+   *  @type {String}
+   */
+  LABELMAP_MODIFIED: 'cornersontetoolslabelmapmodified',
 };
 
 export default EVENTS;

--- a/src/stateManagement/stackSpecificStateManager.js
+++ b/src/stateManagement/stackSpecificStateManager.js
@@ -3,6 +3,7 @@ import {
   getElementToolStateManager,
   setElementToolStateManager,
 } from './toolState.js';
+import BaseBrushTool from '../tools/base/BaseBrushTool.js';
 
 /**
  * Implements an Stack specific tool state management strategy. This means
@@ -96,6 +97,7 @@ function addStackStateManager(element, otherTools) {
     'referenceLines',
     'crosshairs',
     'stackRenderer',
+    BaseBrushTool.getReferencedToolDataName(),
   ];
 
   if (otherTools) {

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -207,6 +207,12 @@ function _changeBrushColor(element, increaseOrDecrease = 'increase') {
   }
 }
 
+/*
+function setLabelmaps3DForFirstImageId(firstImageId, buffer, labelmapIndex) {
+  for
+}
+*/
+
 /**
  * getLabelmaps3D - Returns the labelmaps associated with the series displayed
  * in the element, the activeLabelmapIndex and the currentImageIdIndex.
@@ -259,6 +265,7 @@ function getLabelmapBuffers(element) {
     if (labelmaps3D[i]) {
       labelmapBuffers.push({
         labelmapIndex: i,
+        bytesPerVoxel: 2,
         buffer: labelmaps3D[i].buffer,
       });
     }
@@ -355,8 +362,9 @@ function getAndCacheLabelmap2D(element) {
  * @returns {null}
  */
 function addLabelmap3D(brushStackState, labelmapIndex, size) {
+  // Buffer size is multiplied by 2 as we are using 2 bytes/voxel for 65536 segments.
   brushStackState.labelmaps3D[labelmapIndex] = {
-    buffer: new ArrayBuffer(size),
+    buffer: new ArrayBuffer(size * 2),
     labelmaps2D: [],
     metadata: {},
     activeDrawColorId: 1,
@@ -440,13 +448,16 @@ function addLabelmap2DView(
   rows,
   columns
 ) {
+  // sliceLengthInBytes is multiplied by 2 as we are using 2 bytes/voxel for 65536 segments.
+  const sliceLengthInBytes = rows * columns * 2;
+
   brushStackState.labelmaps3D[labelmapIndex].labelmaps2D[
     currentImageIdIndex
   ] = {
-    pixelData: new Uint8Array(
+    pixelData: new Uint16Array(
       brushStackState.labelmaps3D[labelmapIndex].buffer,
-      currentImageIdIndex * rows * columns,
-      rows * columns
+      currentImageIdIndex * sliceLengthInBytes,
+      sliceLengthInBytes
     ),
     segments: {},
     invalidated: true,

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -1,6 +1,7 @@
 import external from './../../externalModules.js';
 import { getToolState } from '../../stateManagement/toolState.js';
 import getNewBrushColorMap from '../../util/brush/getNewBrushColorMap.js';
+import labelmapStats from '../../util/brush/labelmapStats.js';
 
 import { getLogger } from '../../util/logger.js';
 
@@ -63,7 +64,7 @@ function getLabelmapStats(element, segmentIndex) {
 
       logger.warn(imagePixelData);
 
-      const labelmapStats = _labelmapStats(
+      const labelmapStats = labelmapStats(
         labelmap3Dbuffer,
         imagePixelData,
         rows * columns,
@@ -72,55 +73,6 @@ function getLabelmapStats(element, segmentIndex) {
       resolve(labelmapStats);
     });
   });
-}
-
-/**
- * _labelmapStats - description
- *
- * @param  {type} labelmapBuffer The buffer for the labelmap.
- * @param  {Number[][]} imagePixelData The pixeldata of each image slice.
- * @param  {Number} sliceLength    The number of pixels in one slice.
- * @param  {Number} segmentIndex   The index of the segment.
- * @returns {Promise} A promise that resolves to the stats.
- */
-function _labelmapStats(
-  labelmapBuffer,
-  imagePixelData,
-  sliceLength,
-  segmentIndex
-) {
-  let maximum = 0;
-  let count = 0;
-  let total = 0;
-  let meanOfSquares = 0;
-
-  for (let img = 0; img < imagePixelData.length; img++) {
-    const Uint8SliceView = new Uint8Array(
-      labelmapBuffer,
-      img * sliceLength,
-      sliceLength
-    );
-    const image = imagePixelData[img];
-
-    for (let ind = 0; ind < image.length; ind++) {
-      if (Uint8SliceView[ind] == segmentIndex) {
-        if (image[ind] > maximum) {
-          maximum = image[ind];
-        }
-        total += image[ind];
-        count += 1;
-        meanOfSquares += image[ind] ** 2;
-      }
-    }
-  }
-  let mean = total / count;
-  let stdDev = (meanOfSquares / count - mean ** 2) ** 0.5;
-
-  return {
-    maximum,
-    mean,
-    stdDev,
-  };
 }
 
 function setActiveLabelmap(element, labelmapIndex = 0) {

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -444,12 +444,11 @@ function setMetadata(
 }
 
 /**
- * setLabelmap3D - Takes an 16-bit encoded ArrayBuffer and stores
+ * setLabelmap3DForElement - Takes an 16-bit encoded ArrayBuffer and stores
  * it as a segmentation for the series assoicated with the element.
  *
- * @param  {HTMLElement|string} elementOrFirstImageId The cornerstone enabled
- *                                    element currently displaying the series,
- *                                    or The first imageId of the the series.
+ * @param  {HTMLElement|string} elementOrEnabledElementUID The cornerstone
+ *                                                  enabled element or its UUID.
  * @param  {ArrayBuffer} buffer
  * @param  {number} labelmapIndex The index to store the labelmap under.
  * @param  {Object[]} metadata = [] Any metadata about the segments.
@@ -486,6 +485,19 @@ function setLabelmap3DForElement(
   }
 }
 
+/**
+ * setLabelmap3DForElement - Takes an 16-bit encoded ArrayBuffer and stores
+ * it as a segmentation for the series assoicated with the firstImageId.
+ *
+ * @param  {HTMLElement|string} firstImageId  The firstImageId of the series to
+ *                                            store the segmentation on.
+ * @param  {ArrayBuffer} buffer
+ * @param  {number} labelmapIndex The index to store the labelmap under.
+ * @param  {Object[]} metadata = [] Any metadata about the segments.
+ * @param  {number} numberOfFrames The number of frames, required to set up the
+ *                                 relevant labelmap2D views.
+ * @returns {null}
+ */
 function setLabelmap3DByFirstImageId(
   firstImageId,
   buffer,

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -388,6 +388,7 @@ function addLabelmap2DView(
       currentImageIdIndex * rows * columns,
       rows * columns
     ),
+    segments: {},
     invalidated: true,
   };
   // Clear cache for this displaySet to avoid flickering.

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -12,83 +12,10 @@ const state = {
   maxRadius: 50,
   alpha: 0.4,
   renderBrushIfHiddenButActive: true,
-  hiddenButActiveAlpha: 0.2,
   colorMapId: 'BrushColorMap',
-
-  segmentations: [],
-
-  // TODO -> this should be stack tool state.
-
-  /*
-  segmentationData: [
-    {
-      seriesInstanceUid: 'blah',
-      segmentations: [
-        {
-          metadata: [],
-          labelmap: new Uint8ArrayBuffer(wholeVolumeLength)
-        }
-
-      ]
-
-      segments: [
-        {
-          index: 0,
-          metadata,
-          frames: [
-            new Uint8ArrayBuffer(sliceDimensions);
-          ]
-        }
-      ]
-    }
-  ]
-  */
-
-  visibleSegmentations: {},
-  imageBitmapCache: {},
-  segmentationMetadata: {}, // TODO ^ move this into segmentations object.
+  visibleSegmentations: {}, // TODO - We aren't currently using this.
+  segmentationMetadata: {},
 };
-
-// TODO -> REDO THIS
-
-function getSegment(seriesInstanceUid, segmentIndex, frame) {
-  const stack = state.segmentations.find(
-    stack => (stack.seriesInstanceUid = seriesInstanceUid)
-  );
-
-  const segment = stack.segments.find(
-    segment => segment.index === segmentIndex
-  );
-
-  if (!segment) {
-    return;
-  }
-
-  return frame ? segment.frames[frame] : segment.frames;
-}
-
-function setSegment(seriesInstanceUid, segmentIndex, frame) {
-  const segmentations = stack.segmentations;
-
-  let stack = segmentations.find(
-    stack => (stack.seriesInstanceUid = seriesInstanceUid)
-  );
-
-  if (!stack) {
-    segmentations.push({
-      seriesInstanceUid,
-      segments: [],
-    });
-
-    stack = segmentations[segmentations.length - 1];
-  }
-
-  let segment = stack.segments.find(segment => segment.index === segmentIndex);
-
-  if (!segment) {
-    stack.segments.find;
-  }
-}
 
 /**
  * Sets the brush radius, account for global min/max radius
@@ -289,7 +216,7 @@ function _initDefaultColorMap() {
   // Values here are hand picked to jump around the color wheel in such a way
   // that you only get colors that are similar after every 15ish colors.
 
-  let l = 1;
+  let l = 0.5;
   let h = 0;
 
   let minL = 50;
@@ -297,7 +224,9 @@ function _initDefaultColorMap() {
   let decLumCount = 15;
   let inc = 97;
 
-  for (let i = 0; i < defaultSegmentationCount; i++) {
+  colormap.setColor(0, [0, 0, 0, 0]);
+
+  for (let i = 1; i <= defaultSegmentationCount; i++) {
     colormap.setColor(i, [...hslToRgb(h, 1, l), 255]);
 
     h += inc;
@@ -307,13 +236,11 @@ function _initDefaultColorMap() {
 
     if (decLumCount === 0) {
       decLumCount = 15;
-      l = Math.min(l - 0.02, minL);
+      l = Math.min(l + 0.02, minL);
     }
   }
 
-  const colorLutTable = [[0, 0, 0, 0]];
-
-  logger.warn(colormap);
+  const colorLutTable = [];
 
   for (let i = 0; i < defaultSegmentationCount; i++) {
     colorLutTable.push(colormap.getColor(i));

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -2,6 +2,7 @@ import external from './../../externalModules.js';
 import { getToolState } from '../../stateManagement/toolState.js';
 import getNewColorLUT from '../../util/brush/getNewColorLUT.js';
 import labelmapStats from '../../util/brush/labelmapStats.js';
+import EVENTS from '../../events.js';
 
 import { getters as storeGetters } from '../index.js';
 
@@ -162,6 +163,7 @@ function getAndCacheLabelmap2D(element) {
   return {
     labelmap3D: brushStackState.labelmaps3D[activeLabelmapIndex],
     currentImageIdIndex,
+    activeLabelmapIndex,
   };
 }
 
@@ -355,9 +357,10 @@ function setLabelmap3D(
   metadata = []
 ) {
   let firstImageId;
+  let element;
 
   if (elementOrFirstImageId instanceof HTMLElement) {
-    const element = elementOrFirstImageId;
+    element = elementOrFirstImageId;
     const stackState = getToolState(element, 'stack');
 
     firstImageId = stackState.data[0].imageIds[0];
@@ -384,9 +387,11 @@ function setLabelmap3D(
     imageBitmapCache: null,
   };
 
-  external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
-    labelmapIndex,
-  });
+  if (element) {
+    external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
+      labelmapIndex,
+    });
+  }
 }
 
 /**

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -28,13 +28,24 @@ const state = {
  * segmentIndex is specified, otherwise returns an array of all segment metadata
  * for the labelmap.
  *
- * @param  {HTMLElement} element          The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param  {number} labelmapIndex = 0     The labelmap index.
  * @param  {number} segmentIndex          The segment index.
  * @returns {Object|Object[]}             A metadata object or an array of
  *                                        metadata objects.
  */
-function getMetadata(element, labelmapIndex = 0, segmentIndex) {
+function getMetadata(
+  elementOrEnabledElementUID,
+  labelmapIndex = 0,
+  segmentIndex
+) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
   const firstImageId = stackData.imageIds[0];
@@ -60,11 +71,18 @@ function getMetadata(element, labelmapIndex = 0, segmentIndex) {
  * getLabelmaps3D - Returns the labelmaps associated with the series displayed
  * in the element, the activeLabelmapIndex and the currentImageIdIndex.
  *
- * @param  {HTMLElement} element  The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @returns {Object}              An object containing the 3D labelmaps,
  *                                the activeLabelmapIndex amd the currentImageIdIndex.
  */
-function getLabelmaps3D(element) {
+function getLabelmaps3D(elementOrEnabledElementUID) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
 
@@ -91,10 +109,17 @@ function getLabelmaps3D(element) {
  *                         Allocates memory for the labelmap and sets a 2D view
  *                         for the currentImageIdIndex if it does not yet exist.
  *
- * @param  {HTMLElement} element  The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @returns {Object}              The 3D labelmap and the currentImageIdIndex.
  */
-function getAndCacheLabelmap2D(element) {
+function getAndCacheLabelmap2D(elementOrEnabledElementUID) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
@@ -171,12 +196,19 @@ function getAndCacheLabelmap2D(element) {
  * getLabelmapStats - returns the maximum pixel value, mean and standard
  * deviation of the segment given by the segmentIndex of the scan on the element.
  *
- * @param  {HTMLElement} element  The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param  {number} segmentIndex  The segment index to query.
  * @returns {Object}              An object containing the maximum pixel value,
  *                                the mean and the standard deviation.
  */
-function getLabelmapStats(element, segmentIndex) {
+function getLabelmapStats(elementOrEnabledElementUID, segmentIndex) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   return new Promise(resolve => {
     const cornerstone = external.cornerstone;
     const stackState = getToolState(element, 'stack');
@@ -226,11 +258,18 @@ function getLabelmapStats(element, segmentIndex) {
  * getBrushColor - Returns the brush color as a string for the active segment of
  * the active labelmap for the series displayed on the element.
  *
- * @param  {HTMLElement} element        The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param  {boolean} drawing = false    Whether the user is drawing or not.
  * @returns {string}                    An rgba value as a string.
  */
-function getBrushColor(element, drawing = false) {
+function getBrushColor(elementOrEnabledElementUID, drawing = false) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
   const firstImageId = stackData.imageIds[0];
@@ -268,13 +307,20 @@ function getBrushColor(element, drawing = false) {
  *                      with the series displayed on the element, or a specific
  *                      one if labelmapIndex is defined.
  *
- * @param  {type} element The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param {type} [labelmapIndex] Optional filtering to only return one labelmap.
  * @returns {Object|Object[]} An array of objects containing the labelmapIndex and
  *                        corresponding ArrayBuffer. Only one object if
  *                        labelmapIndex was specified.
  */
-function getLabelmapBuffers(element, labelmapIndex) {
+function getLabelmapBuffers(elementOrEnabledElementUID, labelmapIndex) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const { labelmaps3D } = getLabelmaps3D(element);
 
   if (!labelmaps3D) {
@@ -282,7 +328,7 @@ function getLabelmapBuffers(element, labelmapIndex) {
   }
 
   if (labelmapIndex !== undefined) {
-    if (labelmap3D[labelmapIndex]) {
+    if (labelmaps3D[labelmapIndex]) {
       return {
         labelmapIndex,
         bytesPerVoxel: 2,
@@ -313,10 +359,17 @@ function getLabelmapBuffers(element, labelmapIndex) {
  *                           labelmap associated with the series displayed on
  *                           the element.
  *
- * @param  {type} element The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @returns {Object}      An object containing the ArrayBuffer.
  */
-function getActiveLabelmapBuffer(element) {
+function getActiveLabelmapBuffer(elementOrEnabledElementUID) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const imageIds = stackState.data[0].imageIds;
@@ -336,14 +389,26 @@ function getActiveLabelmapBuffer(element) {
 /**
  * setMetadata - Sets the metadata object for a particular segment of a
  * labelmap3D.
-
- * @param  {HTMLElement} element           The cornerstone enabled element.
+ *
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param  {number} labelmapIndex = 0 The labelmap index.
  * @param  {number} segmentIndex      The segment index.
  * @param  {Object} metadata          The metadata object to set.
  * @returns {null}
  */
-function setMetadata(element, labelmapIndex = 0, segmentIndex, metadata) {
+function setMetadata(
+  elementOrEnabledElementUID,
+  labelmapIndex = 0,
+  segmentIndex,
+  metadata
+) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
@@ -379,8 +444,8 @@ function setMetadata(element, labelmapIndex = 0, segmentIndex, metadata) {
 }
 
 /**
- * setLabelmap3DForFirstImageId - Takes an 16-bit encoded ArrayBuffer and stores
- * it as a segmentation for the series assoicated with the firstImageId.
+ * setLabelmap3D - Takes an 16-bit encoded ArrayBuffer and stores
+ * it as a segmentation for the series assoicated with the element.
  *
  * @param  {HTMLElement|string} elementOrFirstImageId The cornerstone enabled
  *                                    element currently displaying the series,
@@ -390,24 +455,44 @@ function setMetadata(element, labelmapIndex = 0, segmentIndex, metadata) {
  * @param  {Object[]} metadata = [] Any metadata about the segments.
  * @returns {null}
  */
-function setLabelmap3D(
-  elementOrFirstImageId,
+function setLabelmap3DForElement(
+  elementOrEnabledElementUID,
   buffer,
   labelmapIndex,
   metadata = []
 ) {
-  let firstImageId;
-  let element;
+  const element = _getEnabledElement(elementOrEnabledElementUID);
 
-  if (elementOrFirstImageId instanceof HTMLElement) {
-    element = elementOrFirstImageId;
-    const stackState = getToolState(element, 'stack');
-
-    firstImageId = stackState.data[0].imageIds[0];
-  } else {
-    firstImageId = elementOrFirstImageId;
+  if (!element) {
+    return;
   }
 
+  const stackState = getToolState(element, 'stack');
+  const numberOfFrames = stackState.data[0].imageIds.length;
+  const firstImageId = stackState.data[0].imageIds[0];
+
+  setLabelmap3DByFirstImageId(
+    firstImageId,
+    buffer,
+    labelmapIndex,
+    metadata,
+    numberOfFrames
+  );
+
+  if (element) {
+    external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
+      labelmapIndex,
+    });
+  }
+}
+
+function setLabelmap3DByFirstImageId(
+  firstImageId,
+  buffer,
+  labelmapIndex,
+  metadata = [],
+  numberOfFrames
+) {
   let brushStackState = state.series[firstImageId];
 
   if (!brushStackState) {
@@ -427,10 +512,25 @@ function setLabelmap3D(
     imageBitmapCache: null,
   };
 
-  if (element) {
-    external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
-      labelmapIndex,
-    });
+  const labelmaps2D = brushStackState.labelmaps3D[labelmapIndex].labelmaps2D;
+
+  const slicelengthInBytes = buffer / numberOfFrames;
+  const sliceLengthInUint16 = slicelengthInBytes / 2; //sliceLength in Uint16.
+
+  for (let i = 0; i < numberOfFrames; i++) {
+    const pixelData = new Uint16Array(
+      buffer,
+      slicelengthInBytes * i,
+      sliceLengthInUint16
+    );
+
+    if (pixelData.some(element => !element)) {
+      labelmaps2D[i] = {
+        pixelData,
+        getSegmentIndexes: () => new Set(pixelData),
+        invalidated: true,
+      };
+    }
   }
 }
 
@@ -439,11 +539,18 @@ function setLabelmap3D(
  * elemenet to the labelmap given by the labelmapIndex. Creates the labelmap if
  * it doesn't exist.
  *
- * @param  {HTMLElement} element           The cornerstone enabled element.
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
  * @param  {number} labelmapIndex = 0 The index of the labelmap.
  * @returns {null}
  */
-function setActiveLabelmap(element, labelmapIndex = 0) {
+function setActiveLabelmap(elementOrEnabledElementUID, labelmapIndex = 0) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
@@ -487,6 +594,80 @@ function setActiveLabelmap(element, labelmapIndex = 0) {
 }
 
 /**
+ * setIncrementBrushColor - Increment the brush color for the active labelmap on
+ *                          the element.
+ *
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
+ * @returns {null}
+ */
+function setIncrementBrushColor(elementOrEnabledElementUID) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
+  _changeBrushColor(element, 'increase');
+}
+
+/**
+ * setDecrementBrushColor - Decrement the brush color for the active labelmap on
+ *                          the element.
+ *
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
+ * @returns {null}
+ */
+function setDecrementBrushColor(elementOrEnabledElementUID) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
+  _changeBrushColor(element, 'decrease');
+}
+
+/**
+ * setBrushColor - Set the brush color for the active labelmap on
+ *                          the element.
+ *
+ * @param  {HTMLElement} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
+ * @param {number}  segmentIndex The index to set the brush to.
+ * @returns {null}
+ */
+function setBrushColor(elementOrEnabledElementUID, segmentIndex) {
+  const element = _getEnabledElement(elementOrEnabledElementUID);
+
+  if (!element) {
+    return;
+  }
+
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+  const firstImageId = stackData.imageIds[0];
+
+  const brushStackState = state.series[firstImageId];
+
+  if (!brushStackState) {
+    return;
+  }
+
+  const activeLabelmapIndex = brushStackState.activeLabelmapIndex;
+  const labelmap3D = brushStackState.labelmaps3D[activeLabelmapIndex];
+
+  if (segmentIndex <= 0) {
+    segmentIndex = 1;
+  } else if (segmentIndex > state.segmentsPerLabelmap) {
+    segmentIndex = state.segmentsPerLabelmap;
+  }
+
+  labelmap3D.activeDrawColorId = segmentIndex;
+}
+
+/**
  * Invalidate all the brush data for a labelmap. Useful if multiple libraries
  * are writting to the same labelmap.
  *
@@ -499,12 +680,10 @@ function invalidateBrushOnEnabledElement(
   elementOrEnabledElementUID,
   labelmapIndex = 0
 ) {
-  let element;
+  const element = _getEnabledElement(elementOrEnabledElementUID);
 
-  if (elementOrEnabledElementUID instanceof HTMLElement) {
-    element = elementOrEnabledElementUID;
-  } else {
-    element = storeGetters.enabledElementByUID(elementOrEnabledElementUID);
+  if (!element) {
+    return;
   }
 
   const { labelmaps3D } = getLabelmaps3D(element);
@@ -516,6 +695,14 @@ function invalidateBrushOnEnabledElement(
   }
 
   external.cornerstone.updateImage(element, true);
+}
+
+function _getEnabledElement(elementOrEnabledElementUID) {
+  if (elementOrEnabledElementUID instanceof HTMLElement) {
+    return elementOrEnabledElementUID;
+  }
+
+  return storeGetters.enabledElementByUID(elementOrEnabledElementUID);
 }
 
 /**
@@ -608,9 +795,11 @@ export default {
   },
   setters: {
     metadata: setMetadata,
-    labelmap3D: setLabelmap3D,
-    incrementBrushColor: element => _changeBrushColor(element, 'increase'),
-    decrementBrushColor: element => _changeBrushColor(element, 'decrease'),
+    labelmap3DForElement: setLabelmap3DForElement,
+    labelmap3DByFirstImageId: setLabelmap3DByFirstImageId,
+    incrementBrushColor: setIncrementBrushColor,
+    decrementBrushColor: setDecrementBrushColor,
+    brushColor: setBrushColor,
     colorLUT: setColorLUT,
     activeLabelmap: setActiveLabelmap,
     radius: setRadius,

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -2,15 +2,12 @@ import external from './../../externalModules.js';
 import { getToolState } from '../../stateManagement/toolState.js';
 import getNewBrushColorMap from '../../util/brush/getNewBrushColorMap.js';
 
-//import BaseBrushTool from '../../tools/base/BaseBrushTool.js';
-
 import { getLogger } from '../../util/logger.js';
 
 const logger = getLogger('store:modules:brushModule');
 
 const state = {
   colorLutTables: {},
-  drawColorId: 1,
   radius: 10,
   minRadius: 1,
   maxRadius: 50,
@@ -20,11 +17,171 @@ const state = {
   visibleSegmentations: {}, // TODO - We aren't currently using this.
   segmentationMetadata: {},
   series: {},
-
-  // TODO -> active labelmap per series?
 };
 
-function getLabelMapsForElement(element) {
+/**
+ * getLabelMapStats - returns the maximum pixel value, mean and standard
+ * deviation of the segment given by the segmentIndex of the scan on the element.
+ *
+ * @param  {HTMLElement} element  The cornerstone enabled element.
+ * @param  {Number} segmentIndex  The segment index to query.
+ * @returns {object}              An object containing the maximum pixel value,
+ *                                the mean and the standard deviation.
+ */
+function getLabelMapStats(element, segmentIndex) {
+  return new Promise(resolve => {
+    const cornerstone = external.cornerstone;
+    const stackState = getToolState(element, 'stack');
+    const stackData = stackState.data[0];
+    const imageIds = stackState.data[0].imageIds;
+    const firstImageId = imageIds[0];
+
+    const brushStackState = state.series[firstImageId];
+
+    if (!brushStackState) {
+      resolve();
+    }
+
+    const activeLabelMapIndex = brushStackState.activeLabelMapIndex;
+    const labelmap3D = brushStackState.labelmaps3D[activeLabelMapIndex];
+    const labelmap3Dbuffer = labelmap3D.buffer;
+
+    const imagePromises = [];
+
+    for (let i = 0; i < imageIds.length; i++) {
+      imagePromises.push(cornerstone.loadAndCacheImage(imageIds[i]));
+    }
+
+    Promise.all(imagePromises).then(images => {
+      const imagePixelData = [];
+
+      const { rows, columns } = images[0];
+
+      for (let i = 0; i < images.length; i++) {
+        imagePixelData.push(images[i].getPixelData());
+      }
+
+      logger.warn(imagePixelData);
+
+      const labelmapStats = _labelMapStats(
+        labelmap3Dbuffer,
+        imagePixelData,
+        rows * columns,
+        segmentIndex
+      );
+      resolve(labelmapStats);
+    });
+  });
+}
+
+/**
+ * _labelMapStats - description
+ *
+ * @param  {type} labelMapBuffer The buffer for the labelmap.
+ * @param  {Number[][]} imagePixelData The pixeldata of each image slice.
+ * @param  {Number} sliceLength    The number of pixels in one slice.
+ * @param  {Number} segmentIndex   The index of the segment.
+ * @returns {Promise} A promise that resolves to the stats.
+ */
+function _labelMapStats(
+  labelMapBuffer,
+  imagePixelData,
+  sliceLength,
+  segmentIndex
+) {
+  let maximum = 0;
+  let count = 0;
+  let total = 0;
+  let meanOfSquares = 0;
+
+  for (let img = 0; img < imagePixelData.length; img++) {
+    const Uint8SliceView = new Uint8Array(
+      labelMapBuffer,
+      img * sliceLength,
+      sliceLength
+    );
+    const image = imagePixelData[img];
+
+    for (let ind = 0; ind < image.length; ind++) {
+      if (Uint8SliceView[ind] == segmentIndex) {
+        if (image[ind] > maximum) {
+          maximum = image[ind];
+        }
+        total += image[ind];
+        count += 1;
+        meanOfSquares += image[ind] ** 2;
+      }
+    }
+  }
+  let mean = total / count;
+  let stdDev = (meanOfSquares / count - mean ** 2) ** 0.5;
+
+  return {
+    maximum,
+    mean,
+    stdDev,
+  };
+}
+
+function getBrushColor(element, drawing = false) {
+  const cornerstone = external.cornerstone;
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+  const firstImageId = stackData.imageIds[0];
+
+  const brushStackState = state.series[firstImageId];
+
+  let color;
+
+  if (brushStackState) {
+    const activeLabelMapIndex = brushStackState.activeLabelMapIndex;
+    const labelmap3D = brushStackState.labelmaps3D[activeLabelMapIndex];
+
+    color = labelmap3D.activeDrawColorId;
+  } else {
+    // No data yet, make brush the default color of colormap 0.
+    color = state.colorLutTables[`${state.colorMapId}_0`][1];
+  }
+
+  return drawing
+    ? `rgba(${color[[0]]}, ${color[[1]]}, ${color[[2]]}, 1.0 )`
+    : `rgba(${color[[0]]}, ${color[[1]]}, ${color[[2]]}, 0.8 )`;
+}
+
+function _changeBrushColor(element, increaseOrDecrease = 'increase') {
+  const cornerstone = external.cornerstone;
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+  const firstImageId = stackData.imageIds[0];
+
+  const brushStackState = state.series[firstImageId];
+
+  if (!brushStackState) {
+    return;
+  }
+
+  const activeLabelMapIndex = brushStackState.activeLabelMapIndex;
+  const labelmap3D = brushStackState.labelmaps3D[activeLabelMapIndex];
+
+  switch (increaseOrDecrease) {
+    case 'increase':
+      labelmap3D.activeDrawColorId++;
+
+      if (labelmap3D.activeDrawColorId > segmentsPerLabelMap) {
+        labelmap3D.activeDrawColorId = 1;
+      }
+      break;
+    case 'decrease':
+      labelmap3D.activeDrawColorId--;
+
+      if (labelmap3D.activeDrawColorId <= 0) {
+        labelmap3D.activeDrawColorId = segmentsPerLabelMap;
+      }
+      break;
+  }
+}
+
+function getLabelMaps3DForElement(element) {
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
@@ -38,8 +195,14 @@ function getLabelMapsForElement(element) {
 
   let brushStackState = state.series[firstImageId];
 
+  let labelmaps3D;
+
+  if (brushStackState) {
+    labelmaps3D = brushStackState.labelmaps3D;
+  }
+
   return {
-    brushStackState,
+    labelmaps3D,
     currentImageIdIndex,
   };
 }
@@ -58,8 +221,8 @@ function getAndCacheLabelMap2D(element, labelMapIndex = 0) {
 
   let brushStackState = state.series[firstImageId];
 
-  if (Array.isArray(brushStackState)) {
-    if (!brushStackState[labelMapIndex]) {
+  if (brushStackState) {
+    if (!brushStackState.labelmaps3D[labelMapIndex]) {
       addLabelMap3D(
         brushStackState,
         labelMapIndex,
@@ -67,7 +230,11 @@ function getAndCacheLabelMap2D(element, labelMapIndex = 0) {
       );
     }
 
-    if (!brushStackState[labelMapIndex].labelMap2D[currentImageIdIndex]) {
+    if (
+      !brushStackState.labelmaps3D[labelMapIndex].labelmaps2D[
+        currentImageIdIndex
+      ]
+    ) {
       addLabelMap2DView(
         brushStackState,
         labelMapIndex,
@@ -77,7 +244,10 @@ function getAndCacheLabelMap2D(element, labelMapIndex = 0) {
       );
     }
   } else {
-    state.series[firstImageId] = [];
+    state.series[firstImageId] = {
+      activeLabelMapIndex: labelMapIndex,
+      labelmaps3D: [],
+    };
 
     brushStackState = state.series[firstImageId];
 
@@ -97,15 +267,16 @@ function getAndCacheLabelMap2D(element, labelMapIndex = 0) {
   }
 
   return {
-    labelMapSpecificBrushStackState: brushStackState[labelMapIndex],
+    labelmap3D: brushStackState.labelmaps3D[labelMapIndex],
     currentImageIdIndex,
   };
 }
 
 function addLabelMap3D(brushStackState, labelMapIndex, size) {
-  brushStackState[labelMapIndex] = {
+  brushStackState.labelmaps3D[labelMapIndex] = {
     buffer: new ArrayBuffer(size),
-    labelMap2D: [],
+    labelmaps2D: [],
+    activeDrawColorId: 1,
     imageBitmapCache: null,
   };
 }
@@ -117,16 +288,18 @@ function addLabelMap2DView(
   rows,
   columns
 ) {
-  brushStackState[labelMapIndex].labelMap2D[currentImageIdIndex] = {
+  brushStackState.labelmaps3D[labelMapIndex].labelmaps2D[
+    currentImageIdIndex
+  ] = {
     pixelData: new Uint8Array(
-      brushStackState[labelMapIndex].buffer,
+      brushStackState.labelmaps3D[labelMapIndex].buffer,
       currentImageIdIndex * rows * columns,
       rows * columns
     ),
     invalidated: true,
   };
   // Clear cache for this displaySet to avoid flickering.
-  brushStackState[labelMapIndex].imageBitmapCache = null;
+  brushStackState.labelmaps3D[labelMapIndex].imageBitmapCache = null;
 }
 
 /**
@@ -254,7 +427,8 @@ const getters = {
   visibleSegmentationsForElement: getVisibleSegmentationsForElement,
   metadata: getMetadata,
   getAndCacheLabelMap2D: getAndCacheLabelMap2D,
-  labelMapsForElement: getLabelMapsForElement,
+  labelMaps3DForElement: getLabelMaps3DForElement,
+  brushColor: getBrushColor,
 };
 
 const setters = {
@@ -264,6 +438,12 @@ const setters = {
   imageBitmapCacheForElement: setImageBitmapCacheForElement,
   clearImageBitmapCacheForElement: clearImageBitmapCacheForElement,
   metadata: setMetadata,
+  incrementBrushColor: element => {
+    _changeBrushColor(element, 'increase');
+  },
+  decrementBrushColor: element => {
+    _changeBrushColor(element, 'decrease');
+  },
 };
 
 /**
@@ -306,7 +486,7 @@ function removeEnabledElementCallback(enabledElement) {
  * @returns {void}
  */
 function onRegisterCallback() {
-  _initDefaultColorMap();
+  initColorMap(0);
 }
 
 export default {
@@ -317,21 +497,25 @@ export default {
   setters,
 };
 
-let colorPairIndex = 0;
+const segmentsPerLabelMap = 255;
 
-function _initDefaultColorMap() {
-  const defaultSegmentationCount = 255;
-  const colorMapId = `${state.colorMapId}_0`;
-
+/**
+ * initColorMap - description
+ *
+ * @param  {type} labelMapIndex description
+ * @returns {type}               description
+ */
+function initColorMap(labelMapIndex) {
+  const colorMapId = `${state.colorMapId}_${labelMapIndex}`;
   const colormap = external.cornerstone.colors.getColormap(colorMapId);
 
-  colormap.setNumberOfColors(defaultSegmentationCount);
+  colormap.setNumberOfColors(segmentsPerLabelMap);
 
-  const colorMap = getNewBrushColorMap(defaultSegmentationCount);
+  const newColormap = getNewBrushColorMap(segmentsPerLabelMap);
 
-  for (let i = 0; i < defaultSegmentationCount; i++) {
-    colormap.setColor(i, colorMap[i]);
+  for (let i = 0; i < segmentsPerLabelMap; i++) {
+    colormap.setColor(i, newColormap[i]);
   }
 
-  state.colorLutTables[colorMapId] = colorMap;
+  state.colorLutTables[colorMapId] = newColormap;
 }

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -9,7 +9,7 @@ import { getLogger } from '../../util/logger.js';
 const logger = getLogger('store:modules:brushModule');
 
 const state = {
-  colorLutTable: [],
+  colorLutTables: {},
   drawColorId: 1,
   radius: 10,
   minRadius: 1,
@@ -20,6 +20,8 @@ const state = {
   visibleSegmentations: {}, // TODO - We aren't currently using this.
   segmentationMetadata: {},
   series: {},
+
+  // TODO -> active labelmap per series?
 };
 
 function getLabelMapsForElement(element) {
@@ -252,6 +254,7 @@ const getters = {
   visibleSegmentationsForElement: getVisibleSegmentationsForElement,
   metadata: getMetadata,
   getAndCacheLabelMap2D: getAndCacheLabelMap2D,
+  labelMapsForElement: getLabelMapsForElement,
 };
 
 const setters = {
@@ -291,8 +294,6 @@ function removeEnabledElementCallback(enabledElement) {
   );
 
   const enabledElementUID = cornerstoneEnabledElement.uuid;
-  const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
-  const numberOfColors = colormap.getNumberOfColors();
 
   // Remove enabledElement specific data.
   delete state.visibleSegmentations[enabledElementUID];
@@ -320,7 +321,9 @@ let colorPairIndex = 0;
 
 function _initDefaultColorMap() {
   const defaultSegmentationCount = 255;
-  const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+  const colorMapId = `${state.colorMapId}_0`;
+
+  const colormap = external.cornerstone.colors.getColormap(colorMapId);
 
   colormap.setNumberOfColors(defaultSegmentationCount);
 
@@ -330,5 +333,5 @@ function _initDefaultColorMap() {
     colormap.setColor(i, colorMap[i]);
   }
 
-  state.colorLutTable = colorMap;
+  state.colorLutTables[colorMapId] = colorMap;
 }

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -383,6 +383,10 @@ function setLabelmap3D(
     activeDrawColorId: 1,
     imageBitmapCache: null,
   };
+
+  external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
+    labelmapIndex,
+  });
 }
 
 /**

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -1,5 +1,7 @@
 import external from './../../externalModules.js';
 import { getToolState } from '../../stateManagement/toolState.js';
+import getNewBrushColorMap from '../../util/brush/getNewBrushColorMap.js';
+
 //import BaseBrushTool from '../../tools/base/BaseBrushTool.js';
 
 import { getLogger } from '../../util/logger.js';
@@ -13,14 +15,14 @@ const state = {
   minRadius: 1,
   maxRadius: 50,
   alpha: 0.4,
-  renderBrushIfHiddenButActive: true,
+  renderBrushIfHiddenButActive: true, // TODO - We aren't currently using this.
   colorMapId: 'BrushColorMap',
   visibleSegmentations: {}, // TODO - We aren't currently using this.
   segmentationMetadata: {},
   series: {},
 };
 
-function getLabelMap(element) {
+function getLabelMapsForElement(element) {
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
@@ -34,44 +36,95 @@ function getLabelMap(element) {
 
   let brushStackState = state.series[firstImageId];
 
-  if (brushStackState) {
-    if (!brushStackState.labelMap2D[currentImageIdIndex]) {
-      brushStackState.labelMap2D[currentImageIdIndex] = {
-        pixelData: new Uint8Array(
-          brushStackState.buffer,
-          currentImageIdIndex * rows * columns,
-          rows * columns
-        ),
-        invalidated: true,
-      };
-      // Clear cache for this displaySet to avoid flickering.
-      brushStackState.imageBitmapCache = null;
-    }
-  } else {
-    state.series[firstImageId] = {
-      buffer: new ArrayBuffer(rows * columns * numberOfFrames),
-      labelMap2D: [],
-      imageBitmapCache: null,
-    };
-
-    brushStackState = state.series[firstImageId];
-
-    brushStackState.labelMap2D[currentImageIdIndex] = {
-      pixelData: new Uint8Array(
-        brushStackState.buffer,
-        currentImageIdIndex * rows * columns,
-        rows * columns
-      ),
-      invalidated: true,
-    };
-    // Clear cache for this displaySet to avoid flickering.
-    brushStackState.imageBitmapCache = null;
-  }
-
   return {
     brushStackState,
     currentImageIdIndex,
   };
+}
+
+function getAndCacheLabelMap2D(element, labelMapIndex = 0) {
+  const cornerstone = external.cornerstone;
+  const stackState = getToolState(element, 'stack');
+  const stackData = stackState.data[0];
+
+  const enabledElement = cornerstone.getEnabledElement(element);
+
+  const currentImageIdIndex = stackData.currentImageIdIndex;
+  const { rows, columns } = enabledElement.image;
+  const numberOfFrames = stackData.imageIds.length;
+  const firstImageId = stackData.imageIds[0];
+
+  let brushStackState = state.series[firstImageId];
+
+  if (Array.isArray(brushStackState)) {
+    if (!brushStackState[labelMapIndex]) {
+      addLabelMap3D(
+        brushStackState,
+        labelMapIndex,
+        rows * columns * numberOfFrames
+      );
+    }
+
+    if (!brushStackState[labelMapIndex].labelMap2D[currentImageIdIndex]) {
+      addLabelMap2DView(
+        brushStackState,
+        labelMapIndex,
+        currentImageIdIndex,
+        rows,
+        columns
+      );
+    }
+  } else {
+    state.series[firstImageId] = [];
+
+    brushStackState = state.series[firstImageId];
+
+    addLabelMap3D(
+      brushStackState,
+      labelMapIndex,
+      rows * columns * numberOfFrames
+    );
+
+    addLabelMap2DView(
+      brushStackState,
+      labelMapIndex,
+      currentImageIdIndex,
+      rows,
+      columns
+    );
+  }
+
+  return {
+    labelMapSpecificBrushStackState: brushStackState[labelMapIndex],
+    currentImageIdIndex,
+  };
+}
+
+function addLabelMap3D(brushStackState, labelMapIndex, size) {
+  brushStackState[labelMapIndex] = {
+    buffer: new ArrayBuffer(size),
+    labelMap2D: [],
+    imageBitmapCache: null,
+  };
+}
+
+function addLabelMap2DView(
+  brushStackState,
+  labelMapIndex,
+  currentImageIdIndex,
+  rows,
+  columns
+) {
+  brushStackState[labelMapIndex].labelMap2D[currentImageIdIndex] = {
+    pixelData: new Uint8Array(
+      brushStackState[labelMapIndex].buffer,
+      currentImageIdIndex * rows * columns,
+      rows * columns
+    ),
+    invalidated: true,
+  };
+  // Clear cache for this displaySet to avoid flickering.
+  brushStackState[labelMapIndex].imageBitmapCache = null;
 }
 
 /**
@@ -198,7 +251,7 @@ const getters = {
   imageBitmapCacheForElement: getImageBitmapCacheForElement,
   visibleSegmentationsForElement: getVisibleSegmentationsForElement,
   metadata: getMetadata,
-  labelmap: getLabelMap,
+  getAndCacheLabelMap2D: getAndCacheLabelMap2D,
 };
 
 const setters = {
@@ -271,64 +324,11 @@ function _initDefaultColorMap() {
 
   colormap.setNumberOfColors(defaultSegmentationCount);
 
-  // Values here are hand picked to jump around the color wheel in such a way
-  // that you only get colors that are similar after every 15ish colors.
-
-  let l = 0.5;
-  let h = 0;
-
-  let minL = 50;
-
-  let decLumCount = 15;
-  let inc = 97;
-
-  colormap.setColor(0, [0, 0, 0, 0]);
-
-  for (let i = 1; i <= defaultSegmentationCount; i++) {
-    colormap.setColor(i, [...hslToRgb(h, 1, l), 255]);
-
-    h += inc;
-    if (h > 360) h -= 360;
-
-    decLumCount--;
-
-    if (decLumCount === 0) {
-      decLumCount = 15;
-      l = Math.min(l + 0.02, minL);
-    }
-  }
-
-  const colorLutTable = [];
+  const colorMap = getNewBrushColorMap(defaultSegmentationCount);
 
   for (let i = 0; i < defaultSegmentationCount; i++) {
-    colorLutTable.push(colormap.getColor(i));
+    colormap.setColor(i, colorMap[i]);
   }
 
-  state.colorLutTable = colorLutTable;
-}
-
-function hslToRgb(h, s = 1.0, l = 0.58) {
-  //logger.warn(`hslToRgb: hsl: ${h}, ${s}, ${l}`);
-
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-
-  let rp, gp, bp;
-
-  if (h < 60) {
-    [rp, gp, bp] = [c, x, 0];
-  } else if (h < 120) {
-    [rp, gp, bp] = [x, c, 0];
-  } else if (h < 180) {
-    [rp, gp, bp] = [0, c, x];
-  } else if (h < 240) {
-    [rp, gp, bp] = [0, x, c];
-  } else if (h < 300) {
-    [rp, gp, bp] = [x, 0, c];
-  } else {
-    [rp, gp, bp] = [c, 0, x];
-  }
-
-  return [(rp + m) * 255, (gp + m) * 255, (bp + m) * 255];
+  state.colorLutTable = colorMap;
 }

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -22,10 +22,6 @@ class BaseBrushTool extends BaseTool {
     }
     defaultProps.configuration.referencedToolData = 'brush';
 
-    if (defaultProps.configuration.activeLabelMapIndex === undefined) {
-      defaultProps.configuration.activeLabelMapIndex = 0;
-    }
-
     super(props, defaultProps);
 
     this.updateOnMouseMove = true;
@@ -161,33 +157,6 @@ class BaseBrushTool extends BaseTool {
   // ===================================================================
   // Implementation interface
   // ===================================================================
-
-  /**
-   * Get the draw color (segmentation) of the tool.
-   *
-   * @protected
-   * @param  {Number} drawId The id of the color (segmentation) to switch to.
-   * @returns {string} The brush color in rgba format
-   */
-  _getBrushColor(drawId) {
-    const configuration = this.configuration;
-    const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelMapIndex
-    }`;
-
-    const colormap = external.cornerstone.colors.getColormap(colorMapId);
-    const colorArray = colormap.getColor(drawId);
-
-    if (this._drawing) {
-      return `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${
-        colorArray[[2]]
-      }, 1.0 )`;
-    }
-
-    return `rgba(${colorArray[[0]]}, ${colorArray[[1]]}, ${
-      colorArray[[2]]
-    }, 0.8 )`;
-  }
 
   /**
    * Event handler for MOUSE_UP during the drawing event loop.

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -253,7 +253,7 @@ class BaseBrushTool extends BaseTool {
     let drawId = state.drawColorId + 1;
 
     if (drawId === numberOfColors) {
-      drawId = 0;
+      drawId = 1;
     }
 
     state.drawColorId = drawId;
@@ -271,7 +271,7 @@ class BaseBrushTool extends BaseTool {
 
     let drawId = state.drawColorId - 1;
 
-    if (drawId < 0) {
+    if (drawId === 0) {
       drawId = numberOfColors - 1;
     }
 

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -227,15 +227,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   nextSegmentation() {
-    const numberOfColors = this._getNumberOfColors();
-
-    let drawId = state.drawColorId + 1;
-
-    if (drawId === numberOfColors) {
-      drawId = 1;
-    }
-
-    state.drawColorId = drawId;
+    setters.incrementBrushColor(this.element);
   }
 
   /**
@@ -246,15 +238,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   previousSegmentation() {
-    const numberOfColors = this._getNumberOfColors();
-
-    let drawId = state.drawColorId - 1;
-
-    if (drawId === 0) {
-      drawId = numberOfColors - 1;
-    }
-
-    state.drawColorId = drawId;
+    setters.decrementBrushColor(this.element);
   }
 
   /**
@@ -337,7 +321,7 @@ class BaseBrushTool extends BaseTool {
 
     const configuration = this.configuration;
     const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelMapIndex
+      configuration.activeLabelmapIndex
     }`;
 
     const colormap = external.cornerstone.colors.getColormap(colorMapId);
@@ -363,7 +347,7 @@ class BaseBrushTool extends BaseTool {
 
     const configuration = this.configuration;
     const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelMapIndex
+      configuration.activeLabelmapIndex
     }`;
 
     const colormap = external.cornerstone.colors.getColormap(colorMapId);
@@ -374,25 +358,6 @@ class BaseBrushTool extends BaseTool {
     }
 
     external.cornerstone.updateImage(enabledElement.element);
-  }
-
-  /**
-   * Returns the number of colors in the colormap.
-   *
-   * @static
-   * @public
-   * @api
-   * @returns {Number} The number of colors in the color map.
-   */
-  _getNumberOfColors() {
-    const configuration = this.configuration;
-    const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelMapIndex
-    }`;
-
-    const colormap = external.cornerstone.colors.getColormap(colorMapId);
-
-    return colormap.getNumberOfColors();
   }
 
   get alpha() {

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -21,6 +21,11 @@ class BaseBrushTool extends BaseTool {
       defaultProps.configuration = {};
     }
     defaultProps.configuration.referencedToolData = 'brush';
+
+    if (defaultProps.configuration.activeLabelMapIndex === undefined) {
+      defaultProps.configuration.activeLabelMapIndex = 0;
+    }
+
     super(props, defaultProps);
 
     this.updateOnMouseMove = true;
@@ -165,7 +170,12 @@ class BaseBrushTool extends BaseTool {
    * @returns {string} The brush color in rgba format
    */
   _getBrushColor(drawId) {
-    const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+    const configuration = this.configuration;
+    const colorMapId = `${state.colorMapId}_${
+      configuration.activeLabelMapIndex
+    }`;
+
+    const colormap = external.cornerstone.colors.getColormap(colorMapId);
     const colorArray = colormap.getColor(drawId);
 
     if (this._drawing) {
@@ -248,7 +258,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   nextSegmentation() {
-    const numberOfColors = this.constructor.getNumberOfColors();
+    const numberOfColors = this._getNumberOfColors();
 
     let drawId = state.drawColorId + 1;
 
@@ -267,7 +277,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   previousSegmentation() {
-    const numberOfColors = this.constructor.getNumberOfColors();
+    const numberOfColors = this._getNumberOfColors();
 
     let drawId = state.drawColorId - 1;
 
@@ -355,7 +365,13 @@ class BaseBrushTool extends BaseTool {
   showAllSegmentationsOnElement() {
     const enabledElement = this._getEnabledElement();
     const enabledElementUID = enabledElement.uuid;
-    const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+
+    const configuration = this.configuration;
+    const colorMapId = `${state.colorMapId}_${
+      configuration.activeLabelMapIndex
+    }`;
+
+    const colormap = external.cornerstone.colors.getColormap(colorMapId);
     const numberOfColors = colormap.getNumberOfColors();
 
     for (let segIndex = 0; segIndex < numberOfColors; segIndex++) {
@@ -375,7 +391,13 @@ class BaseBrushTool extends BaseTool {
   hideAllSegmentationsOnElement() {
     const enabledElement = this._getEnabledElement();
     const enabledElementUID = enabledElement.uuid;
-    const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+
+    const configuration = this.configuration;
+    const colorMapId = `${state.colorMapId}_${
+      configuration.activeLabelMapIndex
+    }`;
+
+    const colormap = external.cornerstone.colors.getColormap(colorMapId);
     const numberOfColors = colormap.getNumberOfColors();
 
     for (let segIndex = 0; segIndex < numberOfColors; segIndex++) {
@@ -393,8 +415,13 @@ class BaseBrushTool extends BaseTool {
    * @api
    * @returns {Number} The number of colors in the color map.
    */
-  static getNumberOfColors() {
-    const colormap = external.cornerstone.colors.getColormap(state.colorMapId);
+  _getNumberOfColors() {
+    const configuration = this.configuration;
+    const colorMapId = `${state.colorMapId}_${
+      configuration.activeLabelMapIndex
+    }`;
+
+    const colormap = external.cornerstone.colors.getColormap(colorMapId);
 
     return colormap.getNumberOfColors();
   }

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -218,13 +218,13 @@ class BaseBrushTool extends BaseTool {
   // ===================================================================
 
   /**
-   * Switches to the next segmentation color.
+   * Switches to the next segment color.
    *
    * @public
    * @api
    * @returns {void}
    */
-  nextSegmentation() {
+  nextSegment() {
     setters.incrementBrushColor(this.element);
   }
 
@@ -235,7 +235,7 @@ class BaseBrushTool extends BaseTool {
    * @api
    * @returns {void}
    */
-  previousSegmentation() {
+  previousSegment() {
     setters.decrementBrushColor(this.element);
   }
 

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -275,91 +275,6 @@ class BaseBrushTool extends BaseTool {
     setters.radius(newRadius);
   }
 
-  /**
-   * Displays a segmentation on the element.
-   *
-   * @public
-   * @api
-   * @param  {Number} segIndex        The index of the segmentation.
-   * @returns {void}
-   */
-  showSegmentationOnElement(segIndex) {
-    const enabledElement = this._getEnabledElement();
-    const enabledElementUID = enabledElement.uuid;
-
-    setters.brushVisibilityForElement(enabledElementUID, segIndex, true);
-
-    external.cornerstone.updateImage(enabledElement.element);
-  }
-
-  /**
-   * Hides a segmentation on an element.
-   *
-   * @public
-   * @api
-   * @param  {Number} segIndex        The index of the segmentation.
-   * @returns {void}
-   */
-  hideSegmentationOnElement(segIndex) {
-    const enabledElement = this._getEnabledElement();
-    const enabledElementUID = enabledElement.uuid;
-
-    setters.brushVisibilityForElement(enabledElementUID, segIndex, false);
-    external.cornerstone.updateImage(enabledElement.element);
-  }
-
-  /**
-   * Displays all segmentations on an element.
-   *
-   * @public
-   * @api
-   * @returns {void}
-   */
-  showAllSegmentationsOnElement() {
-    const enabledElement = this._getEnabledElement();
-    const enabledElementUID = enabledElement.uuid;
-
-    const configuration = this.configuration;
-    const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelmapIndex
-    }`;
-
-    const colormap = external.cornerstone.colors.getColormap(colorMapId);
-    const numberOfColors = colormap.getNumberOfColors();
-
-    for (let segIndex = 0; segIndex < numberOfColors; segIndex++) {
-      setters.brushVisibilityForElement(enabledElementUID, segIndex, true);
-    }
-
-    external.cornerstone.updateImage(enabledElement.element);
-  }
-
-  /**
-   * Hides all segmentations on an element.
-   *
-   * @public
-   * @api
-   * @returns {void}
-   */
-  hideAllSegmentationsOnElement() {
-    const enabledElement = this._getEnabledElement();
-    const enabledElementUID = enabledElement.uuid;
-
-    const configuration = this.configuration;
-    const colorMapId = `${state.colorMapId}_${
-      configuration.activeLabelmapIndex
-    }`;
-
-    const colormap = external.cornerstone.colors.getColormap(colorMapId);
-    const numberOfColors = colormap.getNumberOfColors();
-
-    for (let segIndex = 0; segIndex < numberOfColors; segIndex++) {
-      setters.brushVisibilityForElement(enabledElementUID, segIndex, false);
-    }
-
-    external.cornerstone.updateImage(enabledElement.element);
-  }
-
   get alpha() {
     return state.alpha;
   }
@@ -371,14 +286,14 @@ class BaseBrushTool extends BaseTool {
     external.cornerstone.updateImage(enabledElement.element);
   }
 
-  get hiddenButActiveAlpha() {
-    return state.hiddenButActiveAlpha;
+  get alphaOfInactiveLabelmap() {
+    return state.alphaOfInactiveLabelmap;
   }
 
-  set hiddenButActiveAlpha(value) {
+  set alphaOfInactiveLabelmap(value) {
     const enabledElement = this._getEnabledElement();
 
-    state.hiddenButActiveAlpha = value;
+    state.alphaOfInactiveLabelmap = value;
     external.cornerstone.updateImage(enabledElement.element);
   }
 
@@ -396,96 +311,6 @@ class BaseBrushTool extends BaseTool {
   static getReferencedToolDataName() {
     return 'brush';
   }
-
-  /**
-   * WIP - Invalidate all the brush data.
-   *
-   * @static
-   * @public
-   * @param {string} enabledElementUID - This identifier for the enabled element.
-   * @returns {void}
-   */
-  /*
-  static invalidateBrushOnEnabledElement(enabledElementUID) {
-    const element = store.getters.enabledElementByUID(enabledElementUID);
-
-    const stackToolState = getToolState(element, 'stack');
-
-    if (!stackToolState) {
-      return;
-    }
-
-    const imageIds = stackToolState.data[0].imageIds;
-
-    const toolState = globalImageIdSpecificToolStateManager.saveToolState();
-
-    for (let i = 0; i < imageIds.length; i++) {
-      const imageId = imageIds[i];
-
-      if (toolState[imageId] && toolState[imageId].brush) {
-        const brushData = toolState[imageId].brush.data;
-
-        for (let j = 0; j < brushData.length; j++) {
-          if (brushData[j].pixelData) {
-            brushData[j].invalidated = true;
-          }
-        }
-      }
-    }
-
-    external.cornerstone.updateImage(element, true);
-  }
-  */
-
-  /**
-   * WIP - Returns a datacube for the segmentation.
-   *
-   * @static
-   * @param {string} enabledElementUID - This identifier for the enabled element.
-   * @returns {type}  description
-   */
-  /*
-  static getDataAsVolume(enabledElementUID) {
-    const element = store.getters.enabledElementByUID(enabledElementUID);
-
-    const stackToolState = getToolState(element, 'stack');
-
-    if (!stackToolState) {
-      return;
-    }
-
-    const imageIds = stackToolState.data[0].imageIds;
-
-    const enabledElement = external.cornerstone.getEnabledElement(element);
-
-    const image = enabledElement.image;
-
-    const dim = {
-      xy: image.columns * image.rows,
-      z: image.rows,
-      xyz: image.columns * image.rows * imageIds.length,
-    };
-
-    const toolState = globalImageIdSpecificToolStateManager.saveToolState();
-
-    const buffer = new ArrayBuffer(dim.xyz);
-
-    const uint8View = new Uint8Array(buffer);
-
-    for (let i = 0; i < imageIds.length; i++) {
-      const imageId = imageIds[i];
-
-      // TODO -> Workout HTF we will do this for multiple colors etc.
-      if (
-        toolState[imageId] &&
-        toolState[imageId].brush &&
-        toolState[imageId].brush.data[0].pixelData
-      ) {
-        // ADD brush data to the location of that slice.
-      }
-    }
-  }
-  */
 }
 
 export default BaseBrushTool;

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -437,15 +437,15 @@ class BaseBrushTool extends BaseTool {
   }
 
   /**
-   * Invalidate all the brush data.
+   * WIP - Invalidate all the brush data.
    *
    * @static
    * @public
    * @param {string} enabledElementUID - This identifier for the enabled element.
    * @returns {void}
    */
+  /*
   static invalidateBrushOnEnabledElement(enabledElementUID) {
-    /** WIP **/
     const element = store.getters.enabledElementByUID(enabledElementUID);
 
     const stackToolState = getToolState(element, 'stack');
@@ -474,16 +474,17 @@ class BaseBrushTool extends BaseTool {
 
     external.cornerstone.updateImage(element, true);
   }
+  */
 
   /**
-   * Returns a datacube for the segmentation.
+   * WIP - Returns a datacube for the segmentation.
    *
    * @static
    * @param {string} enabledElementUID - This identifier for the enabled element.
    * @returns {type}  description
    */
+  /*
   static getDataAsVolume(enabledElementUID) {
-    /** WIP **/
     const element = store.getters.enabledElementByUID(enabledElementUID);
 
     const stackToolState = getToolState(element, 'stack');
@@ -523,6 +524,7 @@ class BaseBrushTool extends BaseTool {
       }
     }
   }
+  */
 }
 
 export default BaseBrushTool;

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -7,6 +7,9 @@ import {
 import store from './../../store/index.js';
 import brushUtils from './../../util/brush/index.js';
 import EVENTS from '../../events.js';
+import { getLogger } from '../../util/logger.js';
+
+const logger = getLogger('tools:BrushTool');
 
 const { drawBrushPixels, getCircle } = brushUtils;
 
@@ -110,18 +113,20 @@ export default class BrushTool extends BaseBrushTool {
       return;
     }
 
-    const { brushStackState, currentImageIdIndex } = this._getLabelMap(evt);
+    const {
+      brushStackState,
+      currentImageIdIndex,
+    } = brushModule.getters.labelmap(element);
 
     const radius = brushModule.state.radius;
     const pointerArray = getCircle(radius, rows, columns, x, y);
-
     const shouldErase = _isCtrlDown(eventData);
     const segmentIndex = brushModule.state.drawColorId;
 
     // Draw / Erase the active color.
     drawBrushPixels(
       pointerArray,
-      brushStackState.data[0],
+      brushStackState,
       currentImageIdIndex,
       segmentIndex,
       columns,
@@ -135,53 +140,6 @@ export default class BrushTool extends BaseBrushTool {
     );
 
     external.cornerstone.updateImage(evt.detail.element);
-  }
-
-  _getLabelMap(evt) {
-    const eventData = evt.detail;
-    const element = eventData.element;
-    const { rows, columns } = eventData.image;
-    const stackState = getToolState(element, 'stack');
-    let brushStackState = getToolState(
-      element,
-      BaseBrushTool.getReferencedToolDataName()
-    );
-
-    if (!brushStackState.data.length) {
-      const numberOfFrames = stackState.data[0].imageIds.length;
-
-      addToolState(element, referencedToolDataName, {
-        buffer: new ArrayBuffer(rows * columns * numberOfFrames),
-        labelMap2D: [],
-        imageBitmapCache: null,
-      });
-
-      brushStackState = getToolState(
-        element,
-        BaseBrushTool.getReferencedToolDataName()
-      );
-    }
-
-    const currentImageIdIndex = stackState.data[0].currentImageIdIndex;
-    const brushStackData = brushStackState.data[0];
-
-    if (!brushStackData.labelMap2D[currentImageIdIndex]) {
-      brushStackData.labelMap2D[currentImageIdIndex] = {
-        pixelData: new Uint8Array(
-          brushStackData.buffer,
-          currentImageIdIndex * rows * columns,
-          rows * columns
-        ),
-        invalidated: true,
-      };
-      // Clear cache for this displaySet to avoid flickering.
-      brushStackData.imageBitmapCache = null;
-    }
-
-    return {
-      brushStackState,
-      currentImageIdIndex,
-    };
   }
 }
 

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -112,6 +112,7 @@ export default class BrushTool extends BaseBrushTool {
     const {
       labelmap3D,
       currentImageIdIndex,
+      activeLabelmapIndex,
     } = brushModule.getters.getAndCacheLabelmap2D(element);
 
     const radius = brushModule.state.radius;
@@ -122,7 +123,6 @@ export default class BrushTool extends BaseBrushTool {
 
     // Draw / Erase the active color.
     drawBrushPixels(
-      element,
       pointerArray,
       labelmap3D,
       currentImageIdIndex,
@@ -130,6 +130,10 @@ export default class BrushTool extends BaseBrushTool {
       columns,
       shouldErase
     );
+
+    external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
+      activeLabelmapIndex,
+    });
 
     external.cornerstone.updateImage(evt.detail.element);
   }

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -28,7 +28,7 @@ export default class BrushTool extends BaseBrushTool {
     const defaultProps = {
       name: 'Brush',
       supportedInteractionTypes: ['Mouse', 'Touch'],
-      configuration: { activeLabelMapIndex: 0 },
+      configuration: {},
     };
 
     super(props, defaultProps);
@@ -74,8 +74,7 @@ export default class BrushTool extends BaseBrushTool {
     const radius = brushModule.state.radius;
     const context = eventData.canvasContext;
     const element = eventData.element;
-    const drawId = brushModule.state.drawColorId;
-    const color = this._getBrushColor(drawId);
+    const color = brushModule.getters.brushColor(element, this._drawing);
 
     context.setTransform(1, 0, 0, 1, 0, 0);
 
@@ -116,7 +115,7 @@ export default class BrushTool extends BaseBrushTool {
     }
 
     const {
-      labelMapSpecificBrushStackState,
+      labelmap3D,
       currentImageIdIndex,
     } = brushModule.getters.getAndCacheLabelMap2D(
       element,
@@ -126,12 +125,12 @@ export default class BrushTool extends BaseBrushTool {
     const radius = brushModule.state.radius;
     const pointerArray = getCircle(radius, rows, columns, x, y);
     const shouldErase = _isCtrlDown(eventData);
-    const segmentIndex = brushModule.state.drawColorId;
+    const segmentIndex = labelmap3D.activeDrawColorId;
 
     // Draw / Erase the active color.
     drawBrushPixels(
       pointerArray,
-      labelMapSpecificBrushStackState,
+      labelmap3D,
       currentImageIdIndex,
       segmentIndex,
       columns,

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -122,18 +122,13 @@ export default class BrushTool extends BaseBrushTool {
 
     // Draw / Erase the active color.
     drawBrushPixels(
+      element,
       pointerArray,
       labelmap3D,
       currentImageIdIndex,
       segmentIndex,
       columns,
       shouldErase
-    );
-
-    external.cornerstone.triggerEvent(
-      evt.detail.element,
-      EVENTS.MEASUREMENT_MODIFIED,
-      evt.detail
     );
 
     external.cornerstone.updateImage(evt.detail.element);

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -28,10 +28,12 @@ export default class BrushTool extends BaseBrushTool {
     const defaultProps = {
       name: 'Brush',
       supportedInteractionTypes: ['Mouse', 'Touch'],
-      configuration: {},
+      configuration: { activeLabelMapIndex: 0 },
     };
 
     super(props, defaultProps);
+
+    logger.warn(this);
 
     this.touchDragCallback = this._paint.bind(this);
   }
@@ -114,9 +116,12 @@ export default class BrushTool extends BaseBrushTool {
     }
 
     const {
-      brushStackState,
+      labelMapSpecificBrushStackState,
       currentImageIdIndex,
-    } = brushModule.getters.labelmap(element);
+    } = brushModule.getters.getAndCacheLabelMap2D(
+      element,
+      this.configuration.activeLabelMapIndex
+    );
 
     const radius = brushModule.state.radius;
     const pointerArray = getCircle(radius, rows, columns, x, y);
@@ -126,7 +131,7 @@ export default class BrushTool extends BaseBrushTool {
     // Draw / Erase the active color.
     drawBrushPixels(
       pointerArray,
-      brushStackState,
+      labelMapSpecificBrushStackState,
       currentImageIdIndex,
       segmentIndex,
       columns,

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -1,9 +1,5 @@
 import external from './../../externalModules.js';
 import BaseBrushTool from './../base/BaseBrushTool.js';
-import {
-  getToolState,
-  addToolState,
-} from './../../stateManagement/toolState.js';
 import store from './../../store/index.js';
 import brushUtils from './../../util/brush/index.js';
 import EVENTS from '../../events.js';
@@ -14,7 +10,6 @@ const logger = getLogger('tools:BrushTool');
 const { drawBrushPixels, getCircle } = brushUtils;
 
 const brushModule = store.modules.brush;
-const referencedToolDataName = BaseBrushTool.getReferencedToolDataName();
 
 /**
  * @public

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -7,9 +7,6 @@ import {
 import store from './../../store/index.js';
 import brushUtils from './../../util/brush/index.js';
 import EVENTS from '../../events.js';
-import { getLogger } from '../../util/logger.js';
-
-const logger = getLogger('tools:BrushTool');
 
 const { drawBrushPixels, getCircle } = brushUtils;
 
@@ -137,8 +134,6 @@ export default class BrushTool extends BaseBrushTool {
       evt.detail
     );
 
-    logger.warn('update Image');
-
     external.cornerstone.updateImage(evt.detail.element);
   }
 
@@ -152,12 +147,8 @@ export default class BrushTool extends BaseBrushTool {
       BaseBrushTool.getReferencedToolDataName()
     );
 
-    logger.warn(brushStackState);
-
     if (!brushStackState.data.length) {
       const numberOfFrames = stackState.data[0].imageIds.length;
-
-      logger.warn(stackState);
 
       addToolState(element, referencedToolDataName, {
         buffer: new ArrayBuffer(rows * columns * numberOfFrames),
@@ -171,10 +162,7 @@ export default class BrushTool extends BaseBrushTool {
       );
     }
 
-    logger.warn(brushStackState);
-
     const currentImageIdIndex = stackState.data[0].currentImageIdIndex;
-
     const brushStackData = brushStackState.data[0];
 
     if (!brushStackData.labelMap2D[currentImageIdIndex]) {
@@ -189,8 +177,6 @@ export default class BrushTool extends BaseBrushTool {
       // Clear cache for this displaySet to avoid flickering.
       brushStackData.imageBitmapCache = null;
     }
-
-    logger.warn(brushStackState);
 
     return {
       brushStackState,

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -117,10 +117,7 @@ export default class BrushTool extends BaseBrushTool {
     const {
       labelmap3D,
       currentImageIdIndex,
-    } = brushModule.getters.getAndCacheLabelMap2D(
-      element,
-      this.configuration.activeLabelMapIndex
-    );
+    } = brushModule.getters.getAndCacheLabelmap2D(element);
 
     const radius = brushModule.state.radius;
     const pointerArray = getCircle(radius, rows, columns, x, y);

--- a/src/util/brush/drawBrush.js
+++ b/src/util/brush/drawBrush.js
@@ -14,7 +14,6 @@ import { draw, fillBox } from '../../drawing/index.js';
  * @returns {null}
  */
 function drawBrushPixels(
-  element,
   pointerArray,
   labelmap3D,
   imageIdIndex,
@@ -42,10 +41,6 @@ function drawBrushPixels(
   if (shouldErase && pixelData.some(element => !element)) {
     delete labelmap3D.labelmaps2D[imageIdIndex];
   }
-
-  external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
-    labelmapIndex,
-  });
 }
 
 export { drawBrushPixels };

--- a/src/util/brush/drawBrush.js
+++ b/src/util/brush/drawBrush.js
@@ -1,10 +1,6 @@
 import external from '../../externalModules.js';
 import { draw, fillBox } from '../../drawing/index.js';
 
-import { getLogger } from '../logger.js';
-
-const logger = getLogger('util:brush:drawBrush');
-
 /**
  * Fills in the brush mask data with new data.
  * @export @public @method
@@ -31,20 +27,20 @@ function drawBrushPixels(
   pointerArray.forEach(point => {
     const spIndex = getPixelIndex(point[0], point[1]);
 
-    if (shouldErase && pixelData[spIndex] === segmentIndex) {
-      pixelData[spIndex] = 0;
+    if (shouldErase) {
+      if (pixelData[spIndex] === segmentIndex) {
+        pixelData[spIndex] = 0;
+      }
     } else {
       pixelData[spIndex] = segmentIndex;
     }
   });
 
-  logger.warn(pixelData);
-
   brushStackData.labelMap2D[imageIdIndex].invalidated = true;
 
   // If Erased the last pixel, delete the pixelData array.
   if (shouldErase && !pixelData.some(element => element !== 0)) {
-    logger.warn('deleting');
+    console.log('deleting');
     delete brushStackData.labelMap2D[imageIdIndex];
   }
 }

--- a/src/util/brush/drawBrush.js
+++ b/src/util/brush/drawBrush.js
@@ -14,7 +14,7 @@ import { draw, fillBox } from '../../drawing/index.js';
  */
 function drawBrushPixels(
   pointerArray,
-  brushStackData,
+  labelmap3D,
   imageIdIndex,
   segmentIndex,
   columns,
@@ -22,7 +22,7 @@ function drawBrushPixels(
 ) {
   const getPixelIndex = (x, y) => y * columns + x;
 
-  const pixelData = brushStackData.labelMap2D[imageIdIndex].pixelData;
+  const pixelData = labelmap3D.labelmaps2D[imageIdIndex].pixelData;
 
   pointerArray.forEach(point => {
     const spIndex = getPixelIndex(point[0], point[1]);
@@ -36,11 +36,11 @@ function drawBrushPixels(
     }
   });
 
-  brushStackData.labelMap2D[imageIdIndex].invalidated = true;
+  labelmap3D.labelmaps2D[imageIdIndex].invalidated = true;
 
   // If Erased the last pixel, delete the pixelData array.
   if (shouldErase && !pixelData.some(element => element !== 0)) {
-    delete brushStackData.labelMap2D[imageIdIndex];
+    delete labelmap3D.labelmaps2D[imageIdIndex];
   }
 }
 

--- a/src/util/brush/drawBrush.js
+++ b/src/util/brush/drawBrush.js
@@ -40,7 +40,6 @@ function drawBrushPixels(
 
   // If Erased the last pixel, delete the pixelData array.
   if (shouldErase && !pixelData.some(element => element !== 0)) {
-    console.log('deleting');
     delete brushStackData.labelMap2D[imageIdIndex];
   }
 }

--- a/src/util/brush/drawBrush.js
+++ b/src/util/brush/drawBrush.js
@@ -1,4 +1,5 @@
 import external from '../../externalModules.js';
+import EVENTS from '../../events.js';
 import { draw, fillBox } from '../../drawing/index.js';
 
 /**
@@ -13,6 +14,7 @@ import { draw, fillBox } from '../../drawing/index.js';
  * @returns {null}
  */
 function drawBrushPixels(
+  element,
   pointerArray,
   labelmap3D,
   imageIdIndex,
@@ -40,46 +42,10 @@ function drawBrushPixels(
   if (shouldErase && pixelData.some(element => !element)) {
     delete labelmap3D.labelmaps2D[imageIdIndex];
   }
-}
 
-/**
- * Draws the brush data to the canvas.
- * @export @public @method
- *
- * @param  {Object[]} pointerArray Array of points to draw.
- * @param  {Object} context      The canvas context.
- * @param  {string} color        The color to draw the pixels.
- * @param  {HTMLElement} element      The element on which the canvas resides.
- * @returns {void}
- */
-function drawBrushOnCanvas(pointerArray, context, color, element) {
-  const canvasPtTL = external.cornerstone.pixelToCanvas(element, {
-    x: 0,
-    y: 0,
-  });
-  const canvasPtBR = external.cornerstone.pixelToCanvas(element, {
-    x: 1,
-    y: 1,
-  });
-  const sizeX = canvasPtBR.x - canvasPtTL.x;
-  const sizeY = canvasPtBR.y - canvasPtTL.y;
-
-  draw(context, context => {
-    pointerArray.forEach(point => {
-      const canvasPt = external.cornerstone.pixelToCanvas(element, {
-        x: point[0],
-        y: point[1],
-      });
-      const boundingBox = {
-        left: canvasPt.x,
-        top: canvasPt.y,
-        width: sizeX,
-        height: sizeY,
-      };
-
-      fillBox(context, boundingBox, color);
-    });
+  external.cornerstone.triggerEvent(element, EVENTS.LABELMAP_MODIFIED, {
+    labelmapIndex,
   });
 }
 
-export { drawBrushPixels, drawBrushOnCanvas };
+export { drawBrushPixels };

--- a/src/util/brush/getNewBrushColorMap.js
+++ b/src/util/brush/getNewBrushColorMap.js
@@ -10,7 +10,7 @@ export default function getNewBrushColorMap(numberOfColors = 255) {
   rgbArr.push([0, 0, 0, 0]);
 
   for (var i = 0; i < numberOfColors; i++) {
-    rgbArr.push(getRGBAfromHSLA(getNextHue()));
+    rgbArr.push(getRGBAfromHSLA(getNextHue(), getNextL()));
   }
 
   return rgbArr;
@@ -27,6 +27,23 @@ function getNextHue() {
   }
 
   return hueValue;
+}
+
+let l = 0.6;
+let maxL = 0.8;
+let minL = 0.6;
+let incL = 0.07;
+
+function getNextL() {
+  l += incL;
+
+  if (l > maxL) {
+    const diff = l - maxL;
+
+    l = minL + diff;
+  }
+
+  return l;
 }
 
 /**

--- a/src/util/brush/getNewBrushColorMap.js
+++ b/src/util/brush/getNewBrushColorMap.js
@@ -1,0 +1,63 @@
+/**
+ * getNewBrushColorMap - Returns an array of RGB colors of length numberOfColors.
+ *
+ * @param  {Number} numberOfColors = 255 The number of colors to generate
+ * @returns {Number[][]}           The array of RGB values.
+ */
+export default function getNewBrushColorMap(numberOfColors = 255) {
+  const rgbArr = [];
+
+  rgbArr.push([0, 0, 0, 0]);
+
+  for (var i = 0; i < numberOfColors; i++) {
+    rgbArr.push(getRGBAfromHSLA(getNextHue()));
+  }
+
+  return rgbArr;
+}
+
+const goldenAngle = 137.5;
+let hueValue = 0;
+
+function getNextHue() {
+  hueValue += goldenAngle;
+
+  if (hueValue > 360) {
+    hueValue -= 360;
+  }
+
+  return hueValue;
+}
+
+/**
+ * getRGBAfromHSL - Returns an RGBA color given H, S, L and A.
+ *
+ * @param  {Number} hue         The hue.
+ * @param  {Number} s = 1       The saturation.
+ * @param  {Number} l = 0.6     The lightness.
+ * @param  {Number} alpha = 255 The alpha.
+ * @returns {Number[]}            The RGBA formatted color.
+ */
+function getRGBAfromHSLA(hue, s = 1, l = 0.6, alpha = 255) {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r, g, b;
+
+  if (hue < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (hue < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (hue < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (hue < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (hue < 300) {
+    [r, g, b] = [x, 0, c];
+  } else if (hue < 360) {
+    [r, g, b] = [c, 0, x];
+  }
+
+  return [(r + m) * 255, (g + m) * 255, (b + m) * 255, alpha];
+}

--- a/src/util/brush/getNewColorLUT.js
+++ b/src/util/brush/getNewColorLUT.js
@@ -7,7 +7,7 @@
 export default function getNewColorLUT(numberOfColors = 255) {
   const rgbArr = [];
 
-  for (var i = 0; i < numberOfColors; i++) {
+  for (let i = 0; i < numberOfColors; i++) {
     rgbArr.push(getRGBAfromHSLA(getNextHue(), getNextL()));
   }
 
@@ -28,9 +28,9 @@ function getNextHue() {
 }
 
 let l = 0.6;
-let maxL = 0.82;
-let minL = 0.3;
-let incL = 0.07;
+const maxL = 0.82;
+const minL = 0.3;
+const incL = 0.07;
 
 function getNextL() {
   l += incL;

--- a/src/util/brush/getNewColorLUT.js
+++ b/src/util/brush/getNewColorLUT.js
@@ -1,13 +1,11 @@
 /**
- * getNewBrushColorMap - Returns an array of RGB colors of length numberOfColors.
+ * getNewColorLUT - Generates an array of RGB colors of length numberOfColors.
  *
  * @param  {Number} numberOfColors = 255 The number of colors to generate
  * @returns {Number[][]}           The array of RGB values.
  */
-export default function getNewBrushColorMap(numberOfColors = 255) {
+export default function getNewColorLUT(numberOfColors = 255) {
   const rgbArr = [];
-
-  rgbArr.push([0, 0, 0, 0]);
 
   for (var i = 0; i < numberOfColors; i++) {
     rgbArr.push(getRGBAfromHSLA(getNextHue(), getNextL()));
@@ -17,12 +15,12 @@ export default function getNewBrushColorMap(numberOfColors = 255) {
 }
 
 const goldenAngle = 137.5;
-let hueValue = 0;
+let hueValue = 222.5;
 
 function getNextHue() {
   hueValue += goldenAngle;
 
-  if (hueValue > 360) {
+  if (hueValue >= 360) {
     hueValue -= 360;
   }
 
@@ -30,8 +28,8 @@ function getNextHue() {
 }
 
 let l = 0.6;
-let maxL = 0.8;
-let minL = 0.6;
+let maxL = 0.82;
+let minL = 0.3;
 let incL = 0.07;
 
 function getNextL() {

--- a/src/util/brush/index.js
+++ b/src/util/brush/index.js
@@ -1,8 +1,7 @@
-import { drawBrushPixels, drawBrushOnCanvas } from './drawBrush.js';
+import { drawBrushPixels } from './drawBrush.js';
 import getCircle from './getCircle.js';
 
 export default {
   drawBrushPixels,
-  drawBrushOnCanvas,
   getCircle,
 };

--- a/src/util/brush/labelmapStats.js
+++ b/src/util/brush/labelmapStats.js
@@ -1,0 +1,54 @@
+/**
+ * _labelmapStats - description
+ *
+ * @param  {type} labelmapBuffer The buffer for the labelmap.
+ * @param  {Number[][]} imagePixelData The pixeldata of each image slice.
+ * @param  {Number} sliceLength    The number of pixels in one slice.
+ * @param  {Number} segmentIndex   The index of the segment.
+ * @returns {Promise} A promise that resolves to the stats.
+ */
+export default function labelmapStats(
+  labelmapBuffer,
+  imagePixelData,
+  sliceLength,
+  segmentIndex
+) {
+  let segmentPixelValues = [];
+
+  for (let img = 0; img < imagePixelData.length; img++) {
+    const Uint8SliceView = new Uint8Array(
+      labelmapBuffer,
+      img * sliceLength,
+      sliceLength
+    );
+    const image = imagePixelData[img];
+
+    for (let ind = 0; ind < image.length; ind++) {
+      if (Uint8SliceView[ind] == segmentIndex) {
+        segmentPixelValues.push(image[ind]);
+      }
+    }
+  }
+  const maximum = Math.max(...segmentPixelValues);
+  let mean = 0;
+
+  for (let i = 0; i < segmentPixelValues.length; i++) {
+    mean += segmentPixelValues[i];
+  }
+
+  mean / segmentPixelValues.length;
+
+  let stDev = 0;
+
+  for (let i = 0; i < segmentPixelValues.length; i++) {
+    stDev += Math.pow(segmentPixelValues[i] - mean, 2);
+  }
+
+  let stdDev = Math.pow(stDev, 0.5);
+
+  return {
+    maximum,
+    mean,
+    stdDev,
+  };
+}

--- a/src/util/brush/labelmapStats.js
+++ b/src/util/brush/labelmapStats.js
@@ -1,5 +1,5 @@
 /**
- * _labelmapStats - description
+ * labelmapStats - Returns the statistics of the requested labelmap.
  *
  * @param  {type} labelmapBuffer The buffer for the labelmap.
  * @param  {Number[][]} imagePixelData The pixeldata of each image slice.
@@ -13,7 +13,7 @@ export default function labelmapStats(
   sliceLength,
   segmentIndex
 ) {
-  let segmentPixelValues = [];
+  const segmentPixelValues = [];
 
   for (let img = 0; img < imagePixelData.length; img++) {
     const Uint8SliceView = new Uint8Array(
@@ -24,7 +24,7 @@ export default function labelmapStats(
     const image = imagePixelData[img];
 
     for (let ind = 0; ind < image.length; ind++) {
-      if (Uint8SliceView[ind] == segmentIndex) {
+      if (Uint8SliceView[ind] === segmentIndex) {
         segmentPixelValues.push(image[ind]);
       }
     }
@@ -36,15 +36,15 @@ export default function labelmapStats(
     mean += segmentPixelValues[i];
   }
 
-  mean / segmentPixelValues.length;
+  mean /= segmentPixelValues.length;
 
-  let stDev = 0;
+  let stdDev = 0;
 
   for (let i = 0; i < segmentPixelValues.length; i++) {
-    stDev += Math.pow(segmentPixelValues[i] - mean, 2);
+    stdDev += Math.pow(segmentPixelValues[i] - mean, 2);
   }
 
-  let stdDev = Math.pow(stDev, 0.5);
+  stdDev = Math.pow(stdDev, 0.5);
 
   return {
     maximum,


### PR DESCRIPTION
# Segmentation Overhaul - This is a breaking change!

Hey all, this is a breaking change. I've forked the current master branch to a `vNext` that we can PR against for anything which is a breaking change, namely these PRs currently: #915, #921.

In this PR I rebuild the segmentation mask system from the ground up to solve two main issues:

- Interoperability with other libraries (e.g. [`vtkjs`](https://github.com/Kitware/vtk-js))

- Scalability for large segment counts.

## Interoperability with other libraries
During the [NAMIC Project Week 30](https://projectweek.na-mic.org/PW30_2019_GranCanaria/), a bunch of us [cornerstone devs](https://projectweek.na-mic.org/PW30_2019_GranCanaria/Projects/DICOMSEG-Cornerstone-VTKJS/) attempted to link vtkjs and cornerstone. We made some good headway with a [simple POC](https://deploy-preview-5--react-vtkjs-viewport.netlify.com/cornerstone-sync-painting) where we allocated an `ArrayBuffer` globally for the segmentation, and (albeit rather hackily) made both `cornerstoneTools` and `vtkjs` read and write to it.

We only did this for one segment in our POC. `vtkjs` renders a labelmap, and `cornerstoneTools` had binary maps, so we were a bit limited.

With this PR `cornerstoneTools` now uses labelmaps, whilst supporting overlapping segment functionality. All memory management is done by `cornerstoneTools`, and vtkjs and other libraries that want to operate on the labelmap data will be able to through a simple yet powerful api.

## Scalability
Previously each segment was stored as a binary label map which was stored per segment. This wasn't scalable in the browser due to memory constraints if you had multiple segments on every slice. We even had a hard-coded limit of 19 segments in `cornerstoneTools` 3.0.

### Non-overlapping labelmaps

With this PR a 3D labelmap can be assigned to a scan, which can have up to 65535 _non-overlapping_ segments. This means we will be able to support things such as [freesurfer](https://surfer.nmr.mgh.harvard.edu/) segmentations, which often have 200-400 labels per map. And detailed fullbody segmentations which may come out of future AI pipelines, etc.

Previously I used to only allocate per-slice binary maps for each segment when it was drawn on. This is nice whilst living in 2D cornerstone land, but its just way to slow to dynamically interoperate with vtkjs in such a fashion. Internal discussions made it quite clear that allocating enough space for the whole labelmap is worth it for cleaner and faster interoperability as we make more advanced PWAs.

### Dealing with overlapping segments

For the _vast majority_ of use cases, segmentation files (DICOMSEG, NIFTI, etc) contain non-overlapping segments. Overlapping segments do exist however, and they are still possible in this library. To have multiple segments overlap, we simply add _multiple labelmaps_. These can then be encoded as a single overlapping DICOMSEG provided the correct bridges are built in [`dcmjs`](https://github.com/dcmjs-org/dcmjs).

The only segments I've previously seen that are overlapping are radiotherapy targets, and even then, these are much much more likely to be encoded as RTSTRUCTs, which can be easily visualized by the `FreehandMouseTool`.

As we are now using 2 Bytes/voxel for a labelmap rather than 1 byte/voxel on the binary map. In the _worst case_ scenario where all the segments overlap, you will use twice the memory allocation. In my opinion this is a worthy trade-off to have the more commonly seen segmentations packed up to 3,276,750% more densely than previously. **If you are currently using overlapping segments for a more difficult use, please comment and we can discuss solutions.**

## Extensibility
New labelmap types which might be predicted as output of AI/ML pipelines, such as probability maps or occupation maps should be easy to add as a new segment type, without causing another breaking change. One such fractional segment can be stored in the same amount of memory.

## API
### "Standard Usage"

For general `cornerstoneTools` usage, nothing much has changed. If you start painting on a scan, all will work as expected. As before the `BaseBrushTool` has methods to change:
- The actively drawn segment color:
```js
instanceOfBaseBrushTool.nextSegment();
instanceOfBaseBrushTool.previousSegment();
```
- The brush size:
```js
instanceOfBaseBrushTool.increaseBrushSize();
instanceOfBaseBrushTool.decreaseBrushSize();
```

Assume this from here to the end of this section:

```js
const brushModule = cornerstoneTools.store.modules.brush;
```

Labelmap `0` will be drawn on by default, this can be changed in the brush store currently by:
```js
brushModule.setters.activeLabelmap(element, labelmapIndex);
```

The alpha rendering settings of active labelmaps is configured by `brushModule.state.alpha`, and the alpha of inactive labelmaps is set by `brushModule.state.alphaOfInactiveLabelmap`.

If multiple labelmaps are present on a scan, the active one is rendered on top. If `brushModule.state.alphaOfInactiveLabelmap === 0`, inactive labelmaps aren't rendered at all, saving on rendering computation.

Cached bitmaps are used  if the labelmap doesn't change between rendering frames, and are only regenerated when the labelmap is invalidated, or a new slice is scrolled to.

### Read/Write labelmap from external lib

To get a reference to all the labelmaps on a slice:

```js
const labelmapBuffers = brushModule.getters.labelmapBuffers(element);
// Optional pass a labelmapIndex as a second parameter and you only get that buffer back.
```
Which will return an object like this:

```js
[
  {
    labelmapIndex: 0,
    bytesPerVoxel: 2,
    buffer
  },
  {
    labelmapIndex: 1,
    bytesPerVoxel: 2,
    buffer
  }
  ...
]
```

Even more laziliy, you may fetch only the active labelmap via:
```js
brushModule.getters.activeLabelmapBuffer(element);
```

You can then read from this `ArrayBuffer` to render your data using another lib, and write straight to this buffer directly to update the labelmap. When you do so make sure to call:
```js
brushModule.setters.invalidateBrushOnEnabledElement(elementOrEnabledElementUID, labelmapIndex);
```
to let cornerstoneTools know the data has been modified, so that it will regenerate cached images.

### Load a segmentation in from an external source.
A labelmap can be set from an external labelmap buffer of size rows * columns * frames by:

```js
// By providing the cornerstone enabled element or an enabled element's UUID:
brushModule.setters.labelmap3DForElement(
  elementOrEnabledElementUID,
  buffer,
  labelmapIndex,
  metadata = []
);

// Or by providing the imageId of the first image of the stack. This is useful if you want to load a
// segmentation into cornerstone when its not yet being displayed. As we don't have access to an element, the numberOfFrames must be explicitly specified.
brushModule.setters.labelmap3DByFirstImageId(
  firstImageId,
  buffer,
  labelmapIndex,
  metadata = [],
  numberOfFrames
);
```
The metadata is optional and is currently available for arbitrary data. I typically store the segment metadata info from DICOMSEG here.

Adapaters for stuff like DICOMSEG should be written in [`dcmjs`](https://github.com/dcmjs-org/dcmjs). The current `dcmjs` implementations for segmentations are out of date with regards to this PR.

### Custom colorLUTs.
Color LUTs are generated automatically by default for each subsequent labelmap, however if you wish to set your own LUT, you can by:

```js
brushModule.setters.colorLUT(labelmapIndex, colorLUT);
```

Where colorLUT is an array-of-arrays of 4 integers: `[R, G, B, A].` The zero value (i.e. no segment) does not need to be supplied and is prepended to the input.

I want to add an API endpoint to set the visibility of individual segment colors by directly manipulating the alpha, which will then be multiplied by the global alpha (similar to ITK snap if you've used it), but I haven't done this yet.
