### PR TITLE
convertVectro3 -> convertVector3

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -134,7 +134,7 @@ export const lib = {
   'util/numbersWithCommas': numbersWithCommas,
   'util/lineSegDistance': lineSegDistance,
   'util/triggerEvent': triggerEvent,
-  'util/convertToVectro3': convertToVector3,
+  'util/convertToVector3': convertToVector3,
 
   // Whole tool specific util packages
   'util/ellipseUtils': ellipseUtils,


### PR DESCRIPTION
Change `convertVectro3` -> `convertVector3` in the lib.js exports.

Thanks @mbauskar.