### PR TITLE
vNext - Rename cornerstoneTools.import to importInternalModule

### DIFF
--- a/docs/latest/custom-tools/adding-mixins.md
+++ b/docs/latest/custom-tools/adding-mixins.md
@@ -4,7 +4,7 @@ Next you can add any [mixins](../anatomy-of-a-tool/index.md#mixins) you wish to 
 
 ```js
 import csTools from 'cornerstone-tools';
-const BaseTool = csTools.import('base/BaseTool');
+const BaseTool = csTools.importInternalModule('base/BaseTool');
 
 export default class HelloWorldMouseTool extends BaseTool {
   constructor(name = 'HelloWorldMouse') {

--- a/docs/latest/custom-tools/creating-your-tool.md
+++ b/docs/latest/custom-tools/creating-your-tool.md
@@ -4,22 +4,17 @@ Once you have an appropriate base class chosen (we will use the `BaseTool` in th
 
 ### Class Definition
 
-By convention the class name should be in PascalCase, and suffixed with:
-
-- `Tool` - If it supports both `mouse` and `touch` input.
-- `MouseTool` - If it only supports `mouse` input.
-- `TouchTool` - If it only supports `touch` input.
-
-For example, our example is going to support mouse, so we shall call it the `HelloWorldMouseTool`:
+By convention the class name should be in PascalCase, and suffixed with `Tool`.
+For example we shall call our wonderful tool `HelloWorldTool`:
 
 ```js
 import csTools from 'cornerstone-tools';
-const BaseTool = csTools.import('base/BaseTool');
+const BaseTool = csTools.importInternalModule('base/BaseTool');
 // NOTE: if you're creating a tool inside the CornerstoneTools repository
 // you can import BaseTool directly from `src/tools/base`.
 
-export default class HelloWorldMouseTool extends BaseTool {
-  constructor(name = 'HelloWorldMouse') {
+export default class HelloWorldTool extends BaseTool {
+  constructor(name = 'HelloWorld') {
     super({
       name,
       supportedInteractionTypes: ['Mouse'],

--- a/docs/latest/custom-tools/event-dispatcher-callbacks.md
+++ b/docs/latest/custom-tools/event-dispatcher-callbacks.md
@@ -9,10 +9,10 @@ For our Tool we want to log to the console on mouse click. `BaseTool` has two ap
 
 ```js
 import csTools from 'cornerstone-tools';
-const BaseTool = csTools.import('base/BaseTool');
+const BaseTool = csTools.importInternalModule('base/BaseTool');
 
-export default class HelloWorldMouseTool extends BaseTool {
-  constructor(name = 'HelloWorldMouse') {
+export default class HelloWorldTool extends BaseTool {
+  constructor(name = 'HelloWorld') {
     super({
       name,
       supportedInteractionTypes: ['Mouse'],

--- a/docs/latest/custom-tools/mode-change-callbacks.md
+++ b/docs/latest/custom-tools/mode-change-callbacks.md
@@ -13,10 +13,10 @@ For our example Tool, this gives us more chances to log hello to the console:
 
 ```js
 import csTools from 'cornerstone-tools';
-const BaseTool = csTools.import('base/BaseTool');
+const BaseTool = csTools.importInternalModule('base/BaseTool');
 
-export default class HelloWorldMouseTool extends BaseTool {
-  constructor(name = 'HelloWorldMouse') {
+export default class HelloWorldTool extends BaseTool {
+  constructor(name = 'HelloWorld') {
     super({
       name,
       supportedInteractionTypes: ['Mouse'],

--- a/docs/latest/third-party-functionality/imports.md
+++ b/docs/latest/third-party-functionality/imports.md
@@ -1,9 +1,9 @@
 ## Imports {#imports}
 
-Both core and registered functionality can be retrieved by the top-level `import` function, e.g.:
+Both core and registered functionality can be retrieved by the top-level `importInternalModule` function, e.g.:
 
 ```js
-const evenMoreHelloWorldMixin = cornerstoneTools.import('mixins/evenMoreHelloWorld');
+const evenMoreHelloWorldMixin = cornerstoneTools.importInternalModule('mixins/evenMoreHelloWorld');
 ```
 
 And store modules may be retrieved from the modules object of cornerstoneTools:

--- a/docs/latest/third-party-functionality/item-types.md
+++ b/docs/latest/third-party-functionality/item-types.md
@@ -19,7 +19,7 @@ Additionally, custom `module`s can be added to the `store`.
 A user can define a new `abstract` base Tool type, from which third-party Tools can inherit from. The new Tool type must inherit from either `BaseTool`, `BaseAnnotationTool` or `BaseBrushTool`. To create a new base Tool type simply [`import`](index.md#imports) the base type you wish to extend and extend it as:
 
 ```js
-const BaseTool = cornerstoneTools.import('core/base/BaseTool');
+const BaseTool = cornerstoneTools.importInternalModule('core/base/BaseTool');
 
 export default class BaseNewTypeTool extends BaseTool {
   // implementation ...

--- a/docs/latest/third-party-functionality/tools.md
+++ b/docs/latest/third-party-functionality/tools.md
@@ -2,13 +2,13 @@
 
 Third-party tools may be easily created by `import`ing the required base tool Type and extending it.
 
-For instance, if we wanted to package the `HelloWorldMouseTool` we made in the [Custom Tools](custom-tools/index.md) section into a third-party tool:
+For instance, if we wanted to package the `HelloWorldTool` we made in the [Custom Tools](custom-tools/index.md) section into a third-party tool:
 
 ```js
-const BaseTool = cornerstoneTools.import('base/BaseTool');
+const BaseTool = cornerstoneTools.importInternalModule('base/BaseTool');
 
-export default class HelloWorldMouseTool extends BaseTool {
-  constructor (name = 'HelloWorldMouse') {
+export default class HelloWorldTool extends BaseTool {
+  constructor (name = 'HelloWorld') {
     super({
       name,
       supportedInteractionTypes: ['mouse'],

--- a/netlify-example/thirdParty/index.html
+++ b/netlify-example/thirdParty/index.html
@@ -98,7 +98,7 @@
   };
 
   // 3) A Tool
-  const BaseTool = cornerstoneTools.import('base/BaseTool');
+  const BaseTool = cornerstoneTools.importInternalModule('base/BaseTool');
 
   class HelloWorldMouseTool extends BaseTool {
     constructor (name = 'HelloWorldMouse') {

--- a/src/importInternalModule.js
+++ b/src/importInternalModule.js
@@ -5,7 +5,7 @@ import { lib } from './lib.js';
  * @export
  * @public
  * @method
- * @name import
+ * @name importInternalModule
  *
  * @param  {string} uri the import path for the entity to import.
  * @returns {Class|Object|Function} The entity requested.

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ import {
   ZoomTouchPinchTool,
 } from './tools/index.js';
 
-import { default as imp } from './import.js';
+import { default as importInternalModule } from './importInternalModule.js';
 
 import { default as init } from './init.js';
 
@@ -280,7 +280,7 @@ const cornerstoneTools = {
   SaveAs,
   enableLogger,
   disableLogger,
-  import: imp,
+  importInternalModule,
   register,
   registerSome,
   wwwcSynchronizer,
@@ -390,12 +390,10 @@ export {
   stackImageIndexSynchronizer,
   panZoomSynchronizer,
   requestPoolManager,
+  importInternalModule,
   external,
   EVENTS,
   version,
 };
-
-// This has a weird name, so we can't just import it as 'import';
-export { default as import } from './import.js';
 
 export default cornerstoneTools;

--- a/src/tools/CrosshairsTool.test.js
+++ b/src/tools/CrosshairsTool.test.js
@@ -1,6 +1,6 @@
 import CrosshairsTool from './CrosshairsTool.js';
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/DoubleTapFitToWindowTool.test.js
+++ b/src/tools/DoubleTapFitToWindowTool.test.js
@@ -7,7 +7,7 @@ jest.mock('../externalModules.js', () => ({
   },
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/DragProbeTool.test.js
+++ b/src/tools/DragProbeTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../externalModules.js', () => ({
   },
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/PanMultiTouchTool.test.js
+++ b/src/tools/PanMultiTouchTool.test.js
@@ -6,7 +6,7 @@ jest.mock('./../externalModules.js', () => ({
   cornerstone: {},
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/PanTool.test.js
+++ b/src/tools/PanTool.test.js
@@ -5,7 +5,7 @@ jest.mock('./../externalModules.js', () => ({
   cornerstone: {},
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/RotateTool.test.js
+++ b/src/tools/RotateTool.test.js
@@ -5,7 +5,7 @@ jest.mock('./../externalModules.js', () => ({
   cornerstone: {},
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/RotateTouchTool.test.js
+++ b/src/tools/RotateTouchTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../externalModules.js', () => ({
   },
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/ScaleOverlayTool.test.js
+++ b/src/tools/ScaleOverlayTool.test.js
@@ -18,7 +18,7 @@ jest.mock('../drawing/index.js', () => ({
   getNewContext: jest.fn(),
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/StackScrollMouseWheelTool.test.js
+++ b/src/tools/StackScrollMouseWheelTool.test.js
@@ -3,7 +3,7 @@ import scroll from '../util/scroll.js';
 
 jest.mock('../util/scroll.js');
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/StackScrollMultiTouchTool.test.js
+++ b/src/tools/StackScrollMultiTouchTool.test.js
@@ -4,7 +4,7 @@ import scroll from '../util/scroll.js';
 
 jest.mock('../util/scroll.js');
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/StackScrollTool.test.js
+++ b/src/tools/StackScrollTool.test.js
@@ -4,7 +4,7 @@ import scroll from '../util/scroll.js';
 
 jest.mock('../util/scroll.js');
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/WwwcRegionTool.test.js
+++ b/src/tools/WwwcRegionTool.test.js
@@ -1,6 +1,6 @@
 import WwwcRegionTool from './WwwcRegionTool.js';
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/WwwcTool.test.js
+++ b/src/tools/WwwcTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../externalModules.js', () => ({
   },
 }));
 
-jest.mock('../import.js', () => ({
+jest.mock('../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/annotation/CircleRoiTool.test.js
+++ b/src/tools/annotation/CircleRoiTool.test.js
@@ -13,7 +13,7 @@ jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 
@@ -34,7 +34,7 @@ const goodMouseEventData = {
 
 const image = {
   rowPixelSpacing: 0.8984375,
-  columnPixelSpacing: 0.8984375
+  columnPixelSpacing: 0.8984375,
 };
 
 describe('CircleRoiTool.js', () => {
@@ -247,18 +247,43 @@ describe('CircleRoiTool.js', () => {
     };
 
     external.cornerstone.getPixels = () => {
-      return [100, 100, 100,
-        100, 4, 5,
-        100, 3, 6,
-        100, 100, 100,
-        100, 4, 5,
-        100, 3, 6,
-        100, 100, 100,
-        100, 4, 5,
-        100, 3, 6,
-        100, 100, 100,
-        100, 4, 5,
-        100, 3, 6
+      return [
+        100,
+        100,
+        100,
+        100,
+        4,
+        5,
+        100,
+        3,
+        6,
+        100,
+        100,
+        100,
+        100,
+        4,
+        5,
+        100,
+        3,
+        6,
+        100,
+        100,
+        100,
+        100,
+        4,
+        5,
+        100,
+        3,
+        6,
+        100,
+        100,
+        100,
+        100,
+        4,
+        5,
+        100,
+        3,
+        6,
       ];
     };
 
@@ -269,12 +294,12 @@ describe('CircleRoiTool.js', () => {
         handles: {
           start: {
             x: 3,
-            y: 3
+            y: 3,
           },
           end: {
             x: 4,
-            y: 4
-          }
+            y: 4,
+          },
         },
       };
 

--- a/src/tools/annotation/EllipticalRoiTool.test.js
+++ b/src/tools/annotation/EllipticalRoiTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 
@@ -17,10 +17,8 @@ jest.mock('./../../externalModules.js', () => ({
       get: jest.fn(),
     },
     getPixels: () => {
-      return [100, 100, 100,
-        100, 4, 5,
-        100, 3, 6];
-    }
+      return [100, 100, 100, 100, 4, 5, 100, 3, 6];
+    },
   },
 }));
 
@@ -39,7 +37,7 @@ const goodMouseEventData = {
 
 const image = {
   rowPixelSpacing: 0.8984375,
-  columnPixelSpacing: 0.8984375
+  columnPixelSpacing: 0.8984375,
 };
 
 describe('EllipticalRoiTool.js', () => {
@@ -192,12 +190,12 @@ describe('EllipticalRoiTool.js', () => {
         handles: {
           start: {
             x: 0,
-            y: 0
+            y: 0,
           },
           end: {
             x: 3,
-            y: 3
-          }
+            y: 3,
+          },
         },
       };
       instantiatedTool.updateCachedStats(image, element, data);

--- a/src/tools/annotation/FreehandRoiTool.test.js
+++ b/src/tools/annotation/FreehandRoiTool.test.js
@@ -15,7 +15,7 @@ jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 

--- a/src/tools/annotation/LengthTool.test.js
+++ b/src/tools/annotation/LengthTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 
@@ -31,7 +31,7 @@ const goodMouseEventData = {
 
 const image = {
   rowPixelSpacing: 0.8984375,
-  columnPixelSpacing: 0.8984375
+  columnPixelSpacing: 0.8984375,
 };
 
 describe('LengthTool.js', () => {
@@ -172,12 +172,12 @@ describe('LengthTool.js', () => {
         handles: {
           start: {
             x: 166.10687022900754,
-            y: 90.8702290076336
+            y: 90.8702290076336,
           },
           end: {
             x: 145.58778625954199,
-            y: 143.63358778625957
-          }
+            y: 143.63358778625957,
+          },
         },
       };
       instantiatedTool.updateCachedStats(image, element, data);

--- a/src/tools/annotation/ProbeTool.test.js
+++ b/src/tools/annotation/ProbeTool.test.js
@@ -7,7 +7,7 @@ jest.mock('../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('../../import.js', () => ({
+jest.mock('../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 
@@ -17,11 +17,9 @@ jest.mock('./../../externalModules.js', () => ({
       get: jest.fn(),
     },
     getStoredPixels: (element, x, y) => {
-      const storedPixels = [10, 20, 30,
-        40, 50, 60,
-        70, 80, 90];
+      const storedPixels = [10, 20, 30, 40, 50, 60, 70, 80, 90];
       return [storedPixels[x * 2 + y]];
-    }
+    },
   },
 }));
 
@@ -40,7 +38,7 @@ const image = {
   columns: 3,
   slope: 1,
   intercept: 1,
-  color: false
+  color: false,
 };
 
 describe('ProbeTool.js', () => {
@@ -168,8 +166,8 @@ describe('ProbeTool.js', () => {
         handles: {
           end: {
             x: 0,
-            y: 0
-          }
+            y: 0,
+          },
         },
       };
 

--- a/src/tools/annotation/RectangleRoiTool.test.js
+++ b/src/tools/annotation/RectangleRoiTool.test.js
@@ -7,7 +7,7 @@ jest.mock('./../../stateManagement/toolState.js', () => ({
   getToolState: jest.fn(),
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 
@@ -17,10 +17,8 @@ jest.mock('./../../externalModules.js', () => ({
       get: jest.fn(),
     },
     getPixels: () => {
-      return [100, 100, 100,
-        100, 4, 5,
-        100, 3, 6];
-    }
+      return [100, 100, 100, 100, 4, 5, 100, 3, 6];
+    },
   },
 }));
 
@@ -39,7 +37,7 @@ const goodMouseEventData = {
 
 const image = {
   rowPixelSpacing: 0.8984375,
-  columnPixelSpacing: 0.8984375
+  columnPixelSpacing: 0.8984375,
 };
 
 describe('RectangleRoiTool.js', () => {
@@ -192,12 +190,12 @@ describe('RectangleRoiTool.js', () => {
         handles: {
           start: {
             x: 0,
-            y: 0
+            y: 0,
           },
           end: {
             x: 3,
-            y: 3
-          }
+            y: 3,
+          },
         },
       };
       instantiatedTool.updateCachedStats(image, element, data);

--- a/src/tools/base/BaseTool.test.js
+++ b/src/tools/base/BaseTool.test.js
@@ -11,7 +11,7 @@ jest.mock('./../../externalModules.js', () => ({
   },
 }));
 
-jest.mock('./../../import.js', () => ({
+jest.mock('./../../importInternalModule.js', () => ({
   default: jest.fn(),
 }));
 


### PR DESCRIPTION
As it is a reserved word and cause issues on different platforms.