### PR TITLE
vNext Brush Scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cornerstone-tools",
-  "version": "4.0.0",
+  "version": "4.0.0-rc2",
   "description": "Medical imaging tools for the Cornerstone library",
   "main": "./dist/cornerstoneTools.js",
   "module": "./dist/cornerstoneTools.js",

--- a/src/store/modules/brushModule.js
+++ b/src/store/modules/brushModule.js
@@ -59,8 +59,6 @@ function getMetadata(elementOrEnabledElementUID, labelmapIndex, segmentIndex) {
     labelmapIndex = brushStackState.activeLabelmapIndex;
   }
 
-  logger.warn(`getMetadata, labelmapIndex: ${labelmapIndex}`);
-
   if (!brushStackState.labelmaps3D[labelmapIndex]) {
     logger.warn(`No labelmap3D of labelmap index ${labelmapIndex} on stack.`);
 
@@ -248,8 +246,6 @@ function getLabelmapStats(elementOrEnabledElementUID, segmentIndex) {
       for (let i = 0; i < images.length; i++) {
         imagePixelData.push(images[i].getPixelData());
       }
-
-      logger.warn(imagePixelData);
 
       const stats = labelmapStats(
         labelmap3Dbuffer,

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -5,7 +5,7 @@ import isToolActive from './../../store/isToolActive.js';
 import store from './../../store/index.js';
 import { getLogger } from '../../util/logger.js';
 
-const logger = getLogger('tools:BrushTool');
+const logger = getLogger('tools:BaseBrushTool');
 
 const { state, getters, setters } = store.modules.brush;
 
@@ -73,7 +73,14 @@ class BaseBrushTool extends BaseTool {
    * @param {Object} evt - The event.
    */
   mouseDragCallback(evt) {
-    this._startPainting(evt);
+    const { currentPoints } = evt.detail;
+    this._lastImageCoords = currentPoints.image;
+
+    // Safety measure incase _startPainting is overridden and doesn't always
+    // start a paint.
+    if (this._drawing) {
+      this._paint(evt);
+    }
   }
 
   /**
@@ -84,7 +91,15 @@ class BaseBrushTool extends BaseTool {
    * @param {Object} evt - The event.
    */
   preMouseDownCallback(evt) {
+    const eventData = evt.detail;
+    const { element, currentPoints } = eventData;
+
     this._startPainting(evt);
+
+    this._lastImageCoords = currentPoints.image;
+    this._drawing = true;
+    this._startListeningForMouseUp(element);
+    this._paint(evt);
 
     return true;
   }
@@ -116,11 +131,45 @@ class BaseBrushTool extends BaseTool {
       activeLabelmapIndex,
       shouldErase,
     };
+  }
 
-    this._paint(evt);
-    this._drawing = true;
-    this._startListeningForMouseUp(element);
-    this._lastImageCoords = eventData.currentPoints.image;
+  _endPainting(evt) {
+    const {
+      labelmap3D,
+      currentImageIdIndex,
+      activeLabelmapIndex,
+      shouldErase,
+    } = this.paintEventData;
+
+    const labelmap2D = labelmap3D.labelmaps2D[currentImageIdIndex];
+
+    // Grab the labels on the slice.
+    const segmentSet = new Set(labelmap2D.pixelData);
+    const iterator = segmentSet.values();
+
+    const segmentsOnLabelmap = [];
+    let done = false;
+
+    while (!done) {
+      const next = iterator.next();
+
+      done = next.done;
+
+      if (!done) {
+        segmentsOnLabelmap.push(next.value);
+      }
+    }
+
+    labelmap2D.segmentsOnLabelmap = segmentsOnLabelmap;
+
+    // If labelmap2D now empty, delete it.
+    if (
+      shouldErase &&
+      labelmap2D.segmentsOnLabelmap.length === 1 &&
+      labelmap2D.segmentsOnLabelmap[0] === 0
+    ) {
+      delete labelmap3D.labelmaps2D[currentImageIdIndex];
+    }
   }
 
   /**
@@ -187,47 +236,19 @@ class BaseBrushTool extends BaseTool {
     const eventData = evt.detail;
     const element = eventData.element;
 
+    this._endPainting(evt);
+
     this._drawing = false;
     this._mouseUpRender = true;
-
-    const {
-      labelmap3D,
-      currentImageIdIndex,
-      activeLabelmapIndex,
-      shouldErase,
-    } = this.paintEventData;
-
-    const labelmap2D = labelmap3D.labelmaps2D[currentImageIdIndex];
-
-    // Grab the labels on the slice.
-    const segmentSet = new Set(labelmap2D.pixelData);
-    const iterator = segmentSet.values();
-
-    const segmentsOnLabelmap = [];
-    let done = false;
-
-    while (!done) {
-      const next = iterator.next();
-
-      done = next.done;
-
-      if (!done) {
-        segmentsOnLabelmap.push(next.value);
-      }
-    }
-
-    labelmap2D.segmentsOnLabelmap = segmentsOnLabelmap;
-
-    // If labelmap2D now empty, delete it.
-    if (
-      shouldErase &&
-      labelmap2D.segmentsOnLabelmap.length === 1 &&
-      labelmap2D.segmentsOnLabelmap[0] === 0
-    ) {
-      delete labelmap3D.labelmaps2D[currentImageIdIndex];
-    }
-
     this._stopListeningForMouseUp(element);
+  }
+
+  newImageCallback(evt) {
+    if (this._drawing) {
+      // End painting on one slice and start on another.
+      this._endPainting(evt);
+      this._startPainting(evt);
+    }
   }
 
   /**

--- a/src/tools/brush/BrushTool.js
+++ b/src/tools/brush/BrushTool.js
@@ -28,8 +28,6 @@ export default class BrushTool extends BaseBrushTool {
 
     super(props, defaultProps);
 
-    logger.warn(this);
-
     this.touchDragCallback = this._paint.bind(this);
   }
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '4.0.0';
+export default '4.0.0-rc2';


### PR DESCRIPTION
In this PR I've added support for scrolling whilst drag-painting and still making sure the segments present on each slice are indexed properly.

Whilst doing this I've seperated out the the painting logic into _startPainting` and `_endPainting` in `BaseBrushTool`, with `_paint` being the abstract method that need be implemented in the tool implementation itself (.e.g `BrushTool` in the `cornerstoneTools` core library).

This slice-by-slice indexing makes it very easy to build things such as segment deletion.

On my system, deleting a randomly sampled segmentation across 100 slices of a 512x512 CT from a labelmap, and any of its associated metadata took <40 ms.