### PR TITLE
docs(stack-scroll-mouse-wheel): Corrected toolname in setup snippet

### DIFF
--- a/examples/tools/stack-scroll-mouse-wheel.md
+++ b/examples/tools/stack-scroll-mouse-wheel.md
@@ -38,7 +38,7 @@ cornerstone.loadImage(imageIds[0]).then((image) => {
 })
 
 cornerstoneTools.addTool(StackScrollMouseWheelTool)
-cornerstoneTools.setToolActive('StackScrollMouseWheelTool', { })
+cornerstoneTools.setToolActive('StackScrollMouseWheel', { })
 
 {% endhighlight %}
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Documentation update


* **What is the current behavior?** (You can also link to an open issue here)
In the stack-scroll-mouse-wheel example, using "StackScrollMouseWheelTool" as the toolName will cause an error `Unhandled Rejection (TypeError): Cannot read property 'activeBindings' of undefined`.


* **What is the new behavior (if this is a feature change)?**
By using "'StackScrollMouseWheel" instead, when copying the setup snippet, the example code will compile and run as expected without throwing any errors.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
