### PR TITLE
Fix: off by one brush get circle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6631,14 +6631,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6653,20 +6651,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6783,8 +6778,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6796,7 +6790,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6811,7 +6804,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6819,14 +6811,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6845,7 +6835,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6926,8 +6915,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6939,7 +6927,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7061,7 +7048,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/util/brush/getCircle.js
+++ b/src/util/brush/getCircle.js
@@ -37,7 +37,7 @@ export default function getCircle(
     for (let x = -radius; x <= radius; x++) {
       const xCoord = x0 + x;
 
-      if (xCoord > columns || xCoord < 0) {
+      if (xCoord >= columns || xCoord < 0) {
         continue;
       }
 

--- a/src/util/brush/getCircle.js
+++ b/src/util/brush/getCircle.js
@@ -17,8 +17,8 @@ export default function getCircle(
   xCoord = 0,
   yCoord = 0
 ) {
-  const x0 = Math.round(xCoord);
-  const y0 = Math.round(yCoord);
+  const x0 = Math.floor(xCoord);
+  const y0 = Math.floor(yCoord);
 
   if (radius === 1) {
     return [[x0, y0]];

--- a/src/util/brush/getCircle.test.js
+++ b/src/util/brush/getCircle.test.js
@@ -1,0 +1,30 @@
+import getCircle from './getCircle.js';
+
+describe('getCircle.js', function() {
+  beforeEach(() => {});
+
+  it('returns an empty array when there are no rows or columns', () => {
+    const brushRadius = 10;
+    const rows = 0;
+    const columns = 0;
+
+    // SUT
+    const actualCircle = getCircle(brushRadius, rows, columns);
+
+    const emptyArray = [];
+
+    expect(actualCircle).toEqual(emptyArray);
+  });
+
+  it('returns an array of all points when brush covers entire area', () => {
+    const brushRadius = 10;
+    const xAndY = 5;
+    const rows = 10;
+    const columns = 10;
+
+    // SUT
+    const actualCircle = getCircle(brushRadius, rows, columns, xAndY, xAndY);
+
+    expect(actualCircle.length).toEqual(110);
+  });
+});


### PR DESCRIPTION
- Brush would "get pixels" on the next row when trying to paint the right edge
- Brush would paint the next pixel when slightly over the center-line of a pixel
  - Mostly an issue when using the 1px brush and low res images