### PR TITLE
export the scroll tool so that we can use it for the `nextImage` and `previousImage` actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,7 @@ import {
   enable as enableLogger,
   disable as disableLogger,
 } from './util/logger.js';
+import { default as scroll } from './util/scroll';
 
 // ~~~~~~ THIRD PARTY SUPPORT  ~~~~~ //
 import { default as register } from './thirdParty/register.js';
@@ -295,6 +296,7 @@ const cornerstoneTools = {
   external,
   EVENTS,
   version,
+  scroll,
 };
 
 // Named Exports
@@ -393,6 +395,7 @@ export {
   external,
   EVENTS,
   version,
+  scroll,
 };
 
 // This has a weird name, so we can't just import it as 'import';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Scroll is not exported with cornerstoneTools


* **What is the new behavior (if this is a feature change)?**
Scroll is exported with cornerstoneTools


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
This is part of a series of PRs that will add arrow up and arrow down for scrolling through the images of a series in ohif/Viewers

https://github.com/trustsitka/sitka/issues/3426