### PR TITLE
refactor(FreehandMouseTool): Consistently access event `element`

### DIFF
--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -394,13 +394,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
               // The mouse location
               lines.push(config.mouseLocation.handles.start);
             }
-            drawJoinedLines(
-              context,
-              eventData.element,
-              data.handles.points[j],
-              lines,
-              { color }
-            );
+            drawJoinedLines(context, element, data.handles.points[j], lines, {
+              color,
+            });
           }
         }
 
@@ -573,9 +569,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
   }
 
   handleSelectedCallback(evt, toolData, handle, interactionType = 'mouse') {
-    const eventData = evt.detail;
-    const element = eventData.element;
-    const toolState = getToolState(eventData.element, this.name);
+    const { element } = evt.detail;
+    const toolState = getToolState(element, this.name);
 
     if (handle.hasBoundingBox) {
       // Use default move handler.
@@ -620,14 +615,14 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingMouseMoveCallback(evt) {
     const eventData = evt.detail;
-    const element = eventData.element;
-    const toolState = getToolState(eventData.element, this.name);
+    const { currentPoints, element } = eventData;
+    const toolState = getToolState(element, this.name);
 
     const config = this.configuration;
     const currentTool = config.currentTool;
 
     const data = toolState.data[currentTool];
-    const coords = eventData.currentPoints.canvas;
+    const coords = currentPoints.canvas;
 
     // Set the mouseLocation handle
     this._getMouseLocation(eventData);
@@ -649,7 +644,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     }
 
     // Force onImageRendered
-    external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(element);
   }
 
   /**
@@ -680,8 +675,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
 
   _drawingDrag(evt) {
     const eventData = evt.detail;
+    const { element } = eventData;
 
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
 
     const config = this.configuration;
     const currentTool = config.currentTool;
@@ -695,7 +691,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     this._dragging = true;
 
     // Force onImageRendered
-    external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(element);
   }
 
   /**
@@ -706,7 +702,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _drawingMouseUpCallback(evt) {
-    const eventData = evt.detail;
+    const { element } = evt.detail;
 
     if (!this._dragging) {
       return;
@@ -714,11 +710,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
 
     this._dragging = false;
 
-    const element = eventData.element;
-
     const config = this.configuration;
     const currentTool = config.currentTool;
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
     const data = toolState.data[currentTool];
 
     if (!freehandIntersect.end(data.handles.points) && data.canComplete) {
@@ -741,17 +735,17 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingMouseDownCallback(evt) {
     const eventData = evt.detail;
+    const { buttons, currentPoints, element } = eventData;
 
-    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+    if (!this.options.mouseButtonMask.includes(buttons)) {
       return;
     }
 
-    const element = eventData.element;
-    const coords = eventData.currentPoints.canvas;
+    const coords = currentPoints.canvas;
 
     const config = this.configuration;
     const currentTool = config.currentTool;
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
     const data = toolState.data[currentTool];
 
     const handleNearby = this._pointNearHandle(element, data, coords);
@@ -778,13 +772,13 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _drawingTouchStartCallback(evt) {
     const eventData = evt.detail;
+    const { currentPoints, element } = eventData;
 
-    const element = eventData.element;
-    const coords = eventData.currentPoints.canvas;
+    const coords = currentPoints.canvas;
 
     const config = this.configuration;
     const currentTool = config.currentTool;
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
     const data = toolState.data[currentTool];
 
     const handleNearby = this._pointNearHandle(element, data, coords);
@@ -835,9 +829,10 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _drawingMouseDoubleClickCallback(evt) {
-    const eventData = evt.detail;
+    const { element } = evt.detail;
 
-    this.completeDrawing(eventData.element);
+    this.completeDrawing(element);
+
     preventPropagation(evt);
   }
 
@@ -849,9 +844,10 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _drawingDoubleTapClickCallback(evt) {
-    const eventData = evt.detail;
+    const { element } = evt.detail;
 
-    this.completeDrawing(eventData.element);
+    this.completeDrawing(element);
+
     preventPropagation(evt);
   }
 
@@ -864,12 +860,13 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _editMouseDragCallback(evt) {
     const eventData = evt.detail;
+    const { element, buttons } = eventData;
 
-    if (!this.options.mouseButtonMask.includes(eventData.buttons)) {
+    if (!this.options.mouseButtonMask.includes(buttons)) {
       return;
     }
 
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
 
     const config = this.configuration;
     const data = toolState.data[config.currentTool];
@@ -900,7 +897,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     }
 
     // Update the image
-    external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(element);
   }
 
   /**
@@ -912,8 +909,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _editTouchDragCallback(evt) {
     const eventData = evt.detail;
+    const { element } = eventData;
 
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
 
     const config = this.configuration;
     const data = toolState.data[config.currentTool];
@@ -944,7 +942,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     }
 
     // Update the image
-    external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(element);
   }
 
   /**
@@ -970,16 +968,15 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _editMouseUpCallback(evt) {
     const eventData = evt.detail;
-
-    const element = eventData.element;
-    const toolState = getToolState(eventData.element, this.name);
+    const { element } = eventData;
+    const toolState = getToolState(element, this.name);
 
     this._deactivateModify(element);
 
     this._dropHandle(eventData, toolState);
     this._endDrawing(element);
 
-    external.cornerstone.updateImage(eventData.element);
+    external.cornerstone.updateImage(element);
   }
 
   /**
@@ -1032,11 +1029,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
   _startDrawing(evt) {
     const eventData = evt.detail;
     const measurementData = this.createNewMeasurement(eventData);
-    const element = eventData.element;
+    const { element } = eventData;
     const config = this.configuration;
-
-    this._referencedElement = element;
-
     let interactionType;
 
     if (evt.type === EVENTS.MOUSE_DOWN_ACTIVATE) {
@@ -1047,9 +1041,9 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     this._activateDraw(element, interactionType);
     this._getMouseLocation(eventData);
 
-    addToolState(eventData.element, this.name, measurementData);
+    addToolState(element, this.name, measurementData);
 
-    const toolState = getToolState(eventData.element, this.name);
+    const toolState = getToolState(element, this.name);
 
     config.currentTool = toolState.data.length - 1;
 
@@ -1064,7 +1058,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _addPoint(eventData) {
-    const toolState = getToolState(eventData.element, this.name);
+    const { currentPoints, element } = eventData;
+    const toolState = getToolState(element, this.name);
 
     // Get the toolState from the last-drawn polygon
     const config = this.configuration;
@@ -1074,13 +1069,13 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
       return;
     }
 
-    const newHandleData = new FreehandHandleData(eventData.currentPoints.image);
+    const newHandleData = new FreehandHandleData(currentPoints.image);
 
     // If this is not the first handle
     if (data.handles.points.length) {
       // Add the line from the current handle to the new handle
       data.handles.points[config.currentHandle - 1].lines.push(
-        eventData.currentPoints.image
+        currentPoints.image
       );
     }
 
@@ -1091,8 +1086,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     config.currentHandle += 1;
 
     // Force onImageRendered to fire
-    external.cornerstone.updateImage(eventData.element);
-    this.fireModifiedEvent(eventData.element, data);
+    external.cornerstone.updateImage(element);
+    this.fireModifiedEvent(element, data);
   }
 
   /**
@@ -1106,7 +1101,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _addPointPencilMode(eventData, points) {
     const config = this.configuration;
-    const element = eventData.element;
+    const { element } = eventData;
     const mousePoint = config.mouseLocation.handles.start;
 
     const handleFurtherThanMinimumSpacing = handle =>
@@ -1206,8 +1201,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {Object}
    */
   _pointNearHandleAllTools(eventData) {
-    const element = eventData.element;
-    const coords = eventData.currentPoints.canvas;
+    const { currentPoints, element } = eventData;
+    const coords = currentPoints.canvas;
     const toolState = getToolState(element, this.name);
 
     if (!toolState) {
@@ -1239,12 +1234,13 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {undefined}
    */
   _getMouseLocation(eventData) {
+    const { currentPoints, image } = eventData;
     // Set the mouseLocation handle
     const config = this.configuration;
 
-    config.mouseLocation.handles.start.x = eventData.currentPoints.image.x;
-    config.mouseLocation.handles.start.y = eventData.currentPoints.image.y;
-    clipToBox(config.mouseLocation.handles.start, eventData.image);
+    config.mouseLocation.handles.start.x = currentPoints.image.x;
+    config.mouseLocation.handles.start.y = currentPoints.image.y;
+    clipToBox(config.mouseLocation.handles.start, image);
   }
 
   /**
@@ -1256,6 +1252,8 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    * @returns {Boolean}
    */
   _checkInvalidHandleLocation(data, eventData) {
+    const { element } = eventData;
+
     if (data.handles.points.length < 2) {
       return true;
     }
@@ -1265,7 +1263,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     if (this._dragging) {
       invalidHandlePlacement = this._checkHandlesPencilMode(data, eventData);
     } else {
-      invalidHandlePlacement = this._checkHandlesPolygonMode(data, eventData);
+      invalidHandlePlacement = this._checkHandlesPolygonMode(data, element);
     }
 
     data.handles.invalidHandlePlacement = invalidHandlePlacement;
@@ -1282,7 +1280,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _checkHandlesPolygonMode(data, eventData) {
     const config = this.configuration;
-    const element = eventData.element;
+    const { element } = eventData;
     const mousePoint = config.mouseLocation.handles.start;
     const points = data.handles.points;
     let invalidHandlePlacement = false;
@@ -1343,7 +1341,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
    */
   _invalidHandlePencilMode(data, eventData) {
     const config = this.configuration;
-    const element = eventData.element;
+    const { element } = eventData;
     const mousePoint = config.mouseLocation.handles.start;
     const points = data.handles.points;
 

--- a/src/tools/annotation/FreehandMouseTool.js
+++ b/src/tools/annotation/FreehandMouseTool.js
@@ -1263,7 +1263,7 @@ export default class FreehandMouseTool extends BaseAnnotationTool {
     if (this._dragging) {
       invalidHandlePlacement = this._checkHandlesPencilMode(data, eventData);
     } else {
-      invalidHandlePlacement = this._checkHandlesPolygonMode(data, element);
+      invalidHandlePlacement = this._checkHandlesPolygonMode(data, eventData);
     }
 
     data.handles.invalidHandlePlacement = invalidHandlePlacement;


### PR DESCRIPTION
Committing this in smaller parts just to make it easier to follow the refactor as it happens. This
part just makes sure we are accessing the element and using the element in a consistent manner
throughout. Also made some small changes to other attributes that are accessed off the event data.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a refactor of the FreehandMouseTool to make sure we're consistently accessing the `element` associated with the event data.


* **What is the current behavior?** (You can also link to an open issue here)
No change.


* **What is the new behavior (if this is a feature change)?**
No change.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
