### PR TITLE
removing filters from doubleClickCallback to allow users to update text on arrowAnnotateTool

### DIFF
--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -288,13 +288,6 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
   }
 
   doubleClickCallback(evt) {
-    if (
-      !Array.isArray(this.options.mouseButtonMask) ||
-      !this.options.mouseButtonMask.includes(evt.detail.buttons)
-    ) {
-      return;
-    }
-
     return this._updateTextForNearbyAnnotation(evt);
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
removing filters from doubleClickCallback to allow users to update text on arrowAnnotateTool


* **What is the current behavior?** (You can also link to an open issue here)
It is not possible to update the text


* **What is the new behavior (if this is a feature change)?**
now it is possible to update the text


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
