### PR TITLE
refactor(FreehandMouseTool): Break out some calculations into helper functions

### DIFF
--- a/src/util/freehand/calculateMeanStdDev.js
+++ b/src/util/freehand/calculateMeanStdDev.js
@@ -1,0 +1,58 @@
+import external from './../../externalModules.js';
+import calculateSUV from '../../util/calculateSUV.js';
+import calculateFreehandStatistics from './calculateFreehandStatistics';
+import getImageModality from './getImageModality';
+
+/**
+ * Calculates the mean standard deviation and mean standard deviation SUV - if
+ * the image is a PET scan - of all the pixels within the freehand object.
+ * @export @public @method
+ * @name calculateMeanStdDev
+ *
+ * @param {Object} element The element containing the image
+ * @param {Object} image The image
+ * @param {Object} polyBoundingBox Rectangular box enclosing the pixels we care about
+ * @param {Object[]} points The data handles use to calculate the mean standard deviation
+ * @returns {Object} Object containing the mean standard deviation and mean standard deviation SUV.
+ */
+function calculateMeanStdDev({ element, image, polyBoundingBox, points }) {
+  const { intercept, slope } = image;
+  const modality = getImageModality(image);
+  // Retrieve the array of pixels that the ROI bounds cover
+  const pixels = external.cornerstone.getPixels(
+    element,
+    polyBoundingBox.left,
+    polyBoundingBox.top,
+    polyBoundingBox.width,
+    polyBoundingBox.height
+  );
+  // Calculate the mean & standard deviation from the pixels and the object shape
+  const meanStdDev = calculateFreehandStatistics.call(
+    this,
+    pixels,
+    polyBoundingBox,
+    points
+  );
+  let meanStdDevSUV;
+
+  if (modality === 'PT') {
+    // If the image is from a PET scan, use the DICOM tags to
+    // Calculate the SUV from the mean and standard deviation.
+
+    // Note that because we are using modality pixel values from getPixels, and
+    // The calculateSUV routine also rescales to modality pixel values, we are first
+    // Returning the values to storedPixel values before calcuating SUV with them.
+    // TODO: Clean this up? Should we add an option to not scale in calculateSUV?
+    meanStdDevSUV = {
+      mean: calculateSUV(image, (meanStdDev.mean - intercept) / slope),
+      stdDev: calculateSUV(image, (meanStdDev.stdDev - intercept) / slope),
+    };
+  }
+
+  return {
+    meanStdDev,
+    meanStdDevSUV,
+  };
+}
+
+export default calculateMeanStdDev;

--- a/src/util/freehand/calculateMinDistanceFromPointsToCoords.js
+++ b/src/util/freehand/calculateMinDistanceFromPointsToCoords.js
@@ -1,0 +1,27 @@
+import external from './../../externalModules.js';
+
+/**
+ * Calculates the minimum distance from the provided points to the coordinates.
+ * @export @public @method
+ * @name calculateMinDistanceFromPointsToCoords
+ *
+ * @param {Object[]} points The points to iterate over to find the minimum distance
+ * @param {Object} coords The coordinates we're measuring from
+ * @returns {Number} The minimum distance or -1 if no minimum distance could be calculated
+ */
+function calculateMinDistanceFromPointsToCoords(points, coords) {
+  const minimumDistance = points.reduce((minDistance, point) => {
+    const distance = external.cornerstoneMath.point.distance(point, coords);
+
+    return Math.min(minDistance, distance);
+  }, Infinity);
+
+  // If an error caused distance not to be calculated, return -1.
+  if (minimumDistance === Infinity) {
+    return -1;
+  }
+
+  return minimumDistance;
+}
+
+export default calculateMinDistanceFromPointsToCoords;

--- a/src/util/freehand/calculatePolyBoundingBox.js
+++ b/src/util/freehand/calculatePolyBoundingBox.js
@@ -1,0 +1,42 @@
+function _getPointBounds(point) {
+  return {
+    left: point.x,
+    right: point.x,
+    bottom: point.y,
+    top: point.y,
+  };
+}
+
+/**
+ * Calculates the bounding rectangle around a list of points
+ * @export @public @method
+ * @name calculatePolyBoundingBox
+ *
+ * @param {Object[]} points The list of points to contain
+ * @returns {Object} The attributes of the bounding box, undefined if no points provided
+ */
+function calculatePolyBoundingBox(points) {
+  if (points.length === 0) {
+    return;
+  }
+
+  const bounds = points.reduce((roiBounds, point) => {
+    const pointBounds = _getPointBounds(point);
+
+    return {
+      left: Math.min(roiBounds.left, pointBounds.left),
+      right: Math.max(roiBounds.right, pointBounds.right),
+      bottom: Math.min(roiBounds.bottom, pointBounds.bottom),
+      top: Math.max(roiBounds.top, pointBounds.top),
+    };
+  }, _getPointBounds(points[0]));
+
+  return {
+    left: bounds.left,
+    top: bounds.bottom,
+    width: Math.abs(bounds.right - bounds.left),
+    height: Math.abs(bounds.top - bounds.bottom),
+  };
+}
+
+export default calculatePolyBoundingBox;

--- a/src/util/freehand/getImageModality.js
+++ b/src/util/freehand/getImageModality.js
@@ -1,0 +1,28 @@
+import external from './../../externalModules.js';
+
+// TODO: Move this to a more central location and use it everywhere
+
+/**
+ * Gets the modality of the provided image
+ * @export @public @method
+ * @name getImageModality
+ *
+ * @param {Object} image The image
+ * @returns {String} The modality of the image, or null if none could be determined
+ */
+function getImageModality(image) {
+  const { imageId } = image;
+
+  const seriesModule = external.cornerstone.metaData.get(
+    'generalSeriesModule',
+    imageId
+  );
+
+  if (seriesModule) {
+    return seriesModule.modality;
+  }
+
+  return null;
+}
+
+export default getImageModality;

--- a/src/util/freehand/getTextBoxText.js
+++ b/src/util/freehand/getTextBoxText.js
@@ -1,0 +1,72 @@
+import numbersWithCommas from '../../util/numbersWithCommas.js';
+import getImageModality from './getImageModality';
+
+/**
+ * Gets the text box for an image and its data
+ * @export @public @method
+ * @name getTextBoxText
+ *
+ * @param {Object} image The image
+ * @param {Object} data The data
+ * @returns {String[]} The text content for the text box
+ */
+function getTextBoxText(image, data) {
+  const modality = getImageModality(image);
+  const { meanStdDev, meanStdDevSUV, area } = data;
+  // Define an array to store the rows of text for the textbox
+  const textLines = [];
+
+  // If the mean and standard deviation values are present, display them
+  if (meanStdDev && meanStdDev.mean !== undefined) {
+    // If the modality is CT, add HU to denote Hounsfield Units
+    let moSuffix = '';
+
+    if (modality === 'CT') {
+      moSuffix = ' HU';
+    }
+
+    // Create a line of text to display the mean and any units that were specified (i.e. HU)
+    let meanText = `Mean: ${numbersWithCommas(
+      meanStdDev.mean.toFixed(2)
+    )}${moSuffix}`;
+    // Create a line of text to display the standard deviation and any units that were specified (i.e. HU)
+    let stdDevText = `StdDev: ${numbersWithCommas(
+      meanStdDev.stdDev.toFixed(2)
+    )}${moSuffix}`;
+
+    // If this image has SUV values to display, concatenate them to the text line
+    if (meanStdDevSUV && meanStdDevSUV.mean !== undefined) {
+      const SUVtext = ' SUV: ';
+
+      meanText += SUVtext + numbersWithCommas(meanStdDevSUV.mean.toFixed(2));
+      stdDevText +=
+        SUVtext + numbersWithCommas(meanStdDevSUV.stdDev.toFixed(2));
+    }
+
+    // Add these text lines to the array to be displayed in the textbox
+    textLines.push(meanText);
+    textLines.push(stdDevText);
+  }
+
+  // If the area is a sane value, display it
+  if (area) {
+    // Determine the area suffix based on the pixel spacing in the image.
+    // If pixel spacing is present, use millimeters. Otherwise, use pixels.
+    // This uses Char code 178 for a superscript 2
+    let suffix = ` mm${String.fromCharCode(178)}`;
+
+    if (!image.rowPixelSpacing || !image.columnPixelSpacing) {
+      suffix = ` pixels${String.fromCharCode(178)}`;
+    }
+
+    // Create a line of text to display the area and its units
+    const areaText = `Area: ${numbersWithCommas(area.toFixed(2))}${suffix}`;
+
+    // Add this text line to the array to be displayed in the textbox
+    textLines.push(areaText);
+  }
+
+  return textLines;
+}
+
+export default getTextBoxText;

--- a/src/util/freehand/index.js
+++ b/src/util/freehand/index.js
@@ -1,21 +1,31 @@
+import addLine from './addLine.js';
 import calculateFreehandStatistics from './calculateFreehandStatistics.js';
+import calculateMeanStdDev from './calculateMeanStdDev.js';
+import calculateMinDistanceFromPointsToCoords from './calculateMinDistanceFromPointsToCoords.js';
+import calculatePolyBoundingBox from './calculatePolyBoundingBox.js';
 import ClickedLineData from './ClickedLineData.js';
 import freehandArea from './freehandArea.js';
 import FreehandHandleData from './FreehandHandleData.js';
 import freehandIntersect from './freehandIntersect.js';
 import FreehandLineFinder from './FreehandLineFinder.js';
+import getImageModality from './getImageModality.js';
+import getTextBoxText from './getTextBoxText.js';
 import insertOrDelete from './insertOrDelete.js';
 import pointInFreehand from './pointInFreehand.js';
-import addLine from './addLine.js';
 
 export default {
+  addLine,
   calculateFreehandStatistics,
+  calculateMeanStdDev,
+  calculateMinDistanceFromPointsToCoords,
+  calculatePolyBoundingBox,
   ClickedLineData,
   freehandArea,
   FreehandHandleData,
   freehandIntersect,
   FreehandLineFinder,
+  getImageModality,
+  getTextBoxText,
   insertOrDelete,
   pointInFreehand,
-  addLine,
 };


### PR DESCRIPTION
Starting at the top of the file, I walked through and broke out some calculations into helper
functions, some of which were able to be reused. This was mostly to improve readability as it's
often hard to parse code with heavy lifting embedded in them.

Figured this was another good cut-off point for the refactor.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactoring FreehandMouseTool to get some calculations out of the handlers and in to helper functions.


* **What is the current behavior?** (You can also link to an open issue here)
No change in behavior.


* **What is the new behavior (if this is a feature change)?**
No change in behavior.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Adds a few lines, but I think most of that is comments explaining what the helper functions do and what their arguments are.