### PR TITLE
Cornerstone Tools 4.0: Undo/Redo for labelmaps.

### DIFF
--- a/docs/latest/modules/segmentation.md
+++ b/docs/latest/modules/segmentation.md
@@ -91,7 +91,7 @@ const shouldErase = false;
 // Imported from src/util/segmentation
 drawBrushPixels(
   pointerArray,
-  labelmap2D,
+  labelmap2D.pixelData,
   labelmap3D.activeSegmentIndex,
   columns,
   shouldErase

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -1,631 +1,615 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <!-- support for mobile touch devices -->
-    <meta
-      name="viewport"
-      content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1"
-    />
-    <link rel="stylesheet" href="../reset.css" />
-    <link rel="stylesheet" href="../app.css" />
-    <link rel="stylesheet" href="../icon-classes.css" />
-    <link rel="stylesheet" href="../tool-help.css" />
-  </head>
 
-  <body>
-    <div id="app">
-      <div class="wrapper">
-        <!-- Select Tool Category -->
-        <ul class="tool-category-list">
-          <li><a class="tools" data-category="brush" href="#">Brush</a></li>
-          <li>
-            <a class="tools" data-category="scissors" href="#">Scissors</a>
-          </li>
-          <li>
-            <a class="tools" data-category="stack" href="#">Stack</a>
-          </li>
-        </ul>
+<head>
+  <!-- support for mobile touch devices -->
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1" />
+  <link rel="stylesheet" href="../reset.css" />
+  <link rel="stylesheet" href="../app.css" />
+  <link rel="stylesheet" href="../icon-classes.css" />
+  <link rel="stylesheet" href="../tool-help.css" />
+</head>
 
-        <!-- Select Active Tool -->
-        <ul class="tool-category active" data-tool-category="brush">
-          <li><a href="#" data-tool="Brush">Brush</a></li>
-          <li><a href="#" data-tool="SphericalBrush">SphericalBrush</a></li>
-        </ul>
+<body>
+  <div id="app">
+    <div class="wrapper">
+      <!-- Select Tool Category -->
+      <ul class="tool-category-list">
+        <li><a class="tools" data-category="brush" href="#">Brush</a></li>
+        <li>
+          <a class="tools" data-category="scissors" href="#">Scissors</a>
+        </li>
+        <li>
+          <a class="tools" data-category="stack" href="#">Stack</a>
+        </li>
+      </ul>
 
-        <ul class="tool-category" data-tool-category="scissors">
-          <li>
-            <a href="#" data-tool="FreehandScissors">FreehandScissors</a>
-          </li>
-          <li>
-            <a href="#" data-tool="RectangleScissors">RectangleScissors</a>
-          </li>
-          <li>
-            <a href="#" data-tool="CircleScissors">CircleScissors</a>
-          </li>
-          <li>
-            <a href="#" data-tool="CorrectionScissors">CorrectionScissors</a>
-          </li>
-          <li>
-            <select
-              id="change-scissor-strategy"
-              onchange="changeScissorStrategy(this.value)"
-            >
-              <option value="fillInside">Fill Inside</option>
-              <option value="fillOutside">Fill Outside</option>
-              <option value="eraseInside">Erase Inside</option>
-              <option value="eraseOutside">Erase Outside</option>
-            </select>
-          </li>
-        </ul>
+      <!-- Select Active Tool -->
+      <ul class="tool-category active" data-tool-category="brush">
+        <li><a href="#" data-tool="Brush">Brush</a></li>
+        <li><a href="#" data-tool="SphericalBrush">SphericalBrush</a></li>
+      </ul>
 
-        <ul class="tool-category" data-tool-category="stack">
-          <li><a href="#" data-tool="StackScroll">StackScroll</a></li>
-          <li><a href="#" data-tool="Pan">Pan</a></li>
-          <li><a href="#" data-tool="Zoom">Zoom</a></li>
-          <li><a href="#" data-tool="Rotate">Rotate</a></li>
-        </ul>
+      <ul class="tool-category" data-tool-category="scissors">
+        <li>
+          <a href="#" data-tool="FreehandScissors">FreehandScissors</a>
+        </li>
+        <li>
+          <a href="#" data-tool="RectangleScissors">RectangleScissors</a>
+        </li>
+        <li>
+          <a href="#" data-tool="CircleScissors">CircleScissors</a>
+        </li>
+        <li>
+          <a href="#" data-tool="CorrectionScissors">CorrectionScissors</a>
+        </li>
+        <li>
+          <select id="change-scissor-strategy" onchange="changeScissorStrategy(this.value)">
+            <option value="fillInside">Fill Inside</option>
+            <option value="fillOutside">Fill Outside</option>
+            <option value="eraseInside">Erase Inside</option>
+            <option value="eraseOutside">Erase Outside</option>
+          </select>
+        </li>
+      </ul>
 
-        <!-- Our beautiful element targets -->
-        <div class="cornerstone-element-wrapper-help">
-          <div
-            class="cornerstone-element-help"
-            data-index="0"
-            oncontextmenu="return false"
-          ></div>
-          <div class="tool-help">
-            <h2>Renderers</h2>
-            <table>
-              <tr>
-                <td>Segmentation Outline</td>
-                <td>
-                  <input
-                    id="display-outline"
-                    type="checkbox"
-                    name="display-outline"
-                    checked
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>Segmentation Fill</td>
-                <td>
-                  <input
-                    id="display-fill"
-                    type="checkbox"
-                    name="display-fill"
-                    checked
-                  />
-                </td>
-              </tr>
-              <tr>
-                <td>Inactive Labelmaps</td>
-                <td>
-                  <input
-                    id="display-inactive"
-                    type="checkbox"
-                    name="display-inactive"
-                    checked
-                  />
-                </td>
-              </tr>
-            </table>
+      <ul class="tool-category" data-tool-category="stack">
+        <li><a href="#" data-tool="StackScroll">StackScroll</a></li>
+        <li><a href="#" data-tool="Pan">Pan</a></li>
+        <li><a href="#" data-tool="Zoom">Zoom</a></li>
+        <li><a href="#" data-tool="Rotate">Rotate</a></li>
+      </ul>
 
-            <h2>Active Segmentation</h2>
-            <table>
-              <tr>
-                <th>
-                  <button type="button" api-call="next-segment">
-                    Next Segment
-                  </button>
-                </th>
-                <td>
-                  Switch to the next segment index.
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <button type="button" api-call="previous-segment">
-                    Previous Segment
-                  </button>
-                </th>
-                <td>
-                  Switch to the previous segment index.
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <button type="button" api-call="switch-labelmap">
-                    Switch Labelmap
-                  </button>
-                </th>
-                <td id="active-label-map-label">
-                  Active labelmap: 0
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <button type="button" api-call="toggle-segment-1">
-                    Toggle Segment 1 visibility
-                  </button>
-                </th>
-                <td id="toggle-segment-1-label">
-                  visible
-                </td>
-              </tr>
-            </table>
+      <!-- Our beautiful element targets -->
+      <div class="cornerstone-element-wrapper-help">
+        <div class="cornerstone-element-help" data-index="0" oncontextmenu="return false"></div>
+        <div class="tool-help">
+          <h2>Renderers</h2>
+          <table>
+            <tr>
+              <td>Segmentation Outline</td>
+              <td>
+                <input id="display-outline" type="checkbox" name="display-outline" checked />
+              </td>
+            </tr>
+            <tr>
+              <td>Segmentation Fill</td>
+              <td>
+                <input id="display-fill" type="checkbox" name="display-fill" checked />
+              </td>
+            </tr>
+            <tr>
+              <td>Inactive Labelmaps</td>
+              <td>
+                <input id="display-inactive" type="checkbox" name="display-inactive" checked />
+              </td>
+            </tr>
+          </table>
 
-            <h2>Active Labelmap</h2>
-            <table>
-              <tr>
-                <td>
-                  <input type="range" id="fill-alpha" min="0" max="255" />
-                </td>
-                <td>
-                  fillAlpha - Opacity of the active segmentation.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <input type="range" id="outline-alpha" min="0" max="255" />
-                </td>
-                <td>
-                  outlineAlpha - Opacity of the active segmentation outline.
-                </td>
-              </tr>
-            </table>
+          <h2>Active Segmentation</h2>
+          <table>
+            <tr>
+              <th>
+                <button type="button" api-call="next-segment">
+                  Next Segment
+                </button>
+              </th>
+              <td>
+                Switch to the next segment index.
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <button type="button" api-call="previous-segment">
+                  Previous Segment
+                </button>
+              </th>
+              <td>
+                Switch to the previous segment index.
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <button type="button" api-call="switch-labelmap">
+                  Switch Labelmap
+                </button>
+              </th>
+              <td id="active-label-map-label">
+                Active labelmap: 0
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <button type="button" api-call="toggle-segment-1">
+                  Toggle Segment 1 visibility
+                </button>
+              </th>
+              <td id="toggle-segment-1-label">
+                visible
+              </td>
+            </tr>
+          </table>
 
-            <h2>
-              Inactive Labelmap
-            </h2>
+          <h2>Active Labelmap</h2>
+          <table>
+            <tr>
+              <td>
+                <input type="range" id="fill-alpha" min="0" max="255" />
+              </td>
+              <td>
+                fillAlpha - Opacity of the active segmentation.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <input type="range" id="outline-alpha" min="0" max="255" />
+              </td>
+              <td>
+                outlineAlpha - Opacity of the active segmentation outline.
+              </td>
+            </tr>
+          </table>
 
-            <table>
-              <tr>
-                <td>
-                  <input
-                    type="range"
-                    id="fill-alpha-inactive"
-                    min="0"
-                    max="255"
-                  />
-                </td>
-                <td>
-                  fillAlphaInactive - Opacity of inactive segmentations.
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <input
-                    type="range"
-                    id="outline-alpha-inactive"
-                    min="0"
-                    max="255"
-                  />
-                </td>
-                <td>
-                  outlineAlphaInactive - Opacity of inactive segmentation
-                  outlines.
-                </td>
-              </tr>
-            </table>
-          </div>
+          <h2>
+            Inactive Labelmap
+          </h2>
+
+          <table>
+            <tr>
+              <td>
+                <input type="range" id="fill-alpha-inactive" min="0" max="255" />
+              </td>
+              <td>
+                fillAlphaInactive - Opacity of inactive segmentations.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <input type="range" id="outline-alpha-inactive" min="0" max="255" />
+              </td>
+              <td>
+                outlineAlphaInactive - Opacity of inactive segmentation
+                outlines.
+              </td>
+            </tr>
+          </table>
         </div>
       </div>
     </div>
-  </body>
+  </div>
+</body>
 
-  <!-- include the hammer.js library for touch gestures-->
-  <script src="https://unpkg.com/hammerjs@2.0.8/hammer.js"></script>
-  <!-- include Mousetrap to demo keyboard functionality -->
-  <script src="https://unpkg.com/mousetrap@1.6.2/mousetrap.js"></script>
+<!-- include the hammer.js library for touch gestures-->
+<script src="https://unpkg.com/hammerjs@2.0.8/hammer.js"></script>
+<!-- include Mousetrap to demo keyboard functionality -->
+<script src="https://unpkg.com/mousetrap@1.6.2/mousetrap.js"></script>
 
-  <!-- include the cornerstone library -->
-  <script src="https://unpkg.com/cornerstone-core@2.2.6/dist/cornerstone.js"></script>
-  <script src="https://unpkg.com/cornerstone-math@0.1.6/dist/cornerstoneMath.js"></script>
-  <script src="https://unpkg.com/cornerstone-wado-image-loader@3.0.0/dist/cornerstoneWADOImageLoader.js"></script>
-  <script src="https://unpkg.com/dicom-parser@1.8.3/dist/dicomParser.js"></script>
-  <script src="../../dist/cornerstoneTools.js"></script>
-  <script>
-    window.cornerstoneTools ||
-      document.write(
-        '<script src="https://unpkg.com/cornerstone-tools">\x3C/script>'
-      );
-  </script>
+<!-- include the cornerstone library -->
+<script src="https://unpkg.com/cornerstone-core@2.2.6/dist/cornerstone.js"></script>
+<script src="https://unpkg.com/cornerstone-math@0.1.6/dist/cornerstoneMath.js"></script>
+<script src="https://unpkg.com/cornerstone-wado-image-loader@3.0.0/dist/cornerstoneWADOImageLoader.js"></script>
+<script src="https://unpkg.com/dicom-parser@1.8.3/dist/dicomParser.js"></script>
+<script src="../../dist/cornerstoneTools.js"></script>
+<script>
+  window.cornerstoneTools ||
+    document.write(
+      '<script src="https://unpkg.com/cornerstone-tools">\x3C/script>'
+    );
+</script>
 
-  <!-- include special code for these examples which provides images -->
-  <script src="../imageLoader.js"></script>
-  <script src="../metaDataProvider.js"></script>
+<!-- include special code for these examples which provides images -->
+<script src="../imageLoader.js"></script>
+<script src="../metaDataProvider.js"></script>
 
-  <script>
-    cornerstoneTools.init({ showSVGCursors: true });
+<script>
+  cornerstoneTools.init({ showSVGCursors: true });
 
-    cornerstoneWADOImageLoader.external.cornerstone = cornerstone;
+  cornerstoneWADOImageLoader.external.cornerstone = cornerstone;
 
-    // THE DUCK - Still suffers on Outline, would require optimisation of the renderOutline function.
-    /*
-    const baseUrl = window.location.origin;
-    const imageId = `dicomweb:${baseUrl}/examples/assets/dicom/exotic/1.dcm`;
-    const imageIds = [imageId];
-    */
+  // THE DUCK - Still suffers on Outline, would require optimisation of the renderOutline function.
+  /*
+  const baseUrl = window.location.origin;
+  const imageId = `dicomweb:${baseUrl}/examples/assets/dicom/exotic/1.dcm`;
+  const imageIds = [imageId];
+  */
 
-    const imageIds = [
-      'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.11.dcm',
-      'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.12.dcm',
-    ];
 
-    const stack = {
-      currentImageIdIndex: 0,
-      imageIds: imageIds,
-    };
+  const imageIds = [
+    'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.11.dcm',
+    'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.12.dcm',
+  ];
 
-    // Enable & Setup all of our elements
-    const element = document.querySelector('.cornerstone-element-help');
+  /*
+  const imageIds = [
+    'example://1',
+    'example://2'
+  ];
+  */
 
-    cornerstone.enable(element);
+  const stack = {
+    currentImageIdIndex: 0,
+    imageIds: imageIds,
+  };
 
-    const enabledElement = cornerstone.getEnabledElement(element);
+  // Enable & Setup all of our elements
+  const element = document.querySelector('.cornerstone-element-help');
 
-    element.tabIndex = 0;
-    element.focus();
+  cornerstone.enable(element);
 
-    cornerstone.loadImage(imageIds[0]).then(function(image) {
-      cornerstoneTools.addStackStateManager(element, ['stack']);
-      cornerstoneTools.addToolState(element, 'stack', stack);
-      cornerstone.displayImage(element, image);
+  const enabledElement = cornerstone.getEnabledElement(element);
 
-      enabledElement.viewport.pixelReplication = true;
+  element.tabIndex = 0;
+  element.focus();
+
+  cornerstone.loadImage(imageIds[0]).then(function (image) {
+    cornerstoneTools.addStackStateManager(element, ['stack']);
+    cornerstoneTools.addToolState(element, 'stack', stack);
+    cornerstone.displayImage(element, image);
+
+    enabledElement.viewport.pixelReplication = true;
+  });
+
+  function setAllToolsPassive() {
+    cornerstoneTools.store.state.tools.forEach(tool => {
+      cornerstoneTools.setToolPassive(tool.name);
     });
+  }
 
-    function setAllToolsPassive() {
-      cornerstoneTools.store.state.tools.forEach(tool => {
-        cornerstoneTools.setToolPassive(tool.name);
-      });
+  // Iterate over all tool-category links
+  const toolCategoryLinks = document.querySelectorAll(
+    'ul.tool-category-list a'
+  );
+  const toolCategorySections = document.querySelectorAll('ul.tool-category');
+  Array.from(toolCategoryLinks).forEach(link => {
+    //
+    const categoryName = link.getAttribute('data-category');
+    const categoryElement = document.querySelector(
+      `section[data-tool-category="${categoryName}"]`
+    );
+
+    // Setup listener
+    link.addEventListener('click', evt => {
+      evt.preventDefault();
+      setToolCategoryActive(categoryName);
+    });
+  });
+
+  // API calls
+  const apiButtons = document.querySelectorAll('button[api-call]');
+  Array.from(apiButtons).forEach(apiBtn => {
+    const apiCall = apiBtn.getAttribute('api-call');
+
+    apiBtn.addEventListener('mousedown', evt => {
+      brushApiCall(apiCall);
+    });
+  });
+
+  // Iterate over all tool buttons
+  const toolButtons = document.querySelectorAll('a[data-tool]');
+  Array.from(toolButtons).forEach(toolBtn => {
+    // Add the tool
+    const toolName = toolBtn.getAttribute('data-tool');
+    const apiTool = cornerstoneTools[`${toolName}Tool`];
+
+    console.log(apiTool);
+
+    if (apiTool) {
+      cornerstoneTools.addTool(apiTool);
+    } else {
+      console.warn(`unable to add tool with name ${toolName}Tool`);
+      console.log(cornerstoneTools);
     }
 
-    // Iterate over all tool-category links
-    const toolCategoryLinks = document.querySelectorAll(
-      'ul.tool-category-list a'
+    // Setup button listener
+    // Prevent right click context menu for our menu buttons
+    toolBtn.addEventListener(
+      'contextmenu',
+      event => event.preventDefault(),
+      true
     );
-    const toolCategorySections = document.querySelectorAll('ul.tool-category');
-    Array.from(toolCategoryLinks).forEach(link => {
-      //
-      const categoryName = link.getAttribute('data-category');
-      const categoryElement = document.querySelector(
-        `section[data-tool-category="${categoryName}"]`
-      );
+    // Prevent middle click opening a new tab on Chrome & FF
+    toolBtn.addEventListener(
+      'auxclick',
+      event => {
+        if (event.button && event.button === 1) {
+          event.preventDefault();
+        }
+      },
+      false
+    );
+    toolBtn.addEventListener('mousedown', evt => {
+      const mouseButtonMask = evt.buttons
+        ? evt.buttons
+        : convertMouseEventWhichToButtons(evt.which);
+      // TODO: Let's make this happen automagically for mask/touch conflicts?
+      setAllToolsPassive();
+      const toolType = evt.target.getAttribute('data-tool-type');
+      setButtonActive(toolName, mouseButtonMask, toolType);
+      cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
 
-      // Setup listener
-      link.addEventListener('click', evt => {
-        evt.preventDefault();
-        setToolCategoryActive(categoryName);
-      });
+      evt.preventDefault();
+      evt.stopPropagation();
+      evt.stopImmediatePropagation();
+      return false;
     });
+  });
 
-    // API calls
-    const apiButtons = document.querySelectorAll('button[api-call]');
-    Array.from(apiButtons).forEach(apiBtn => {
-      const apiCall = apiBtn.getAttribute('api-call');
+  // Activate first tool
+  cornerstoneTools.setToolActive(cornerstoneTools.store.state.tools[0].name, {
+    mouseButtonMask: 1,
+  });
 
-      apiBtn.addEventListener('mousedown', evt => {
-        brushApiCall(apiCall);
-      });
-    });
-
-    // Iterate over all tool buttons
-    const toolButtons = document.querySelectorAll('a[data-tool]');
-    Array.from(toolButtons).forEach(toolBtn => {
-      // Add the tool
-      const toolName = toolBtn.getAttribute('data-tool');
-      const apiTool = cornerstoneTools[`${toolName}Tool`];
-
-      console.log(apiTool);
-
-      if (apiTool) {
-        cornerstoneTools.addTool(apiTool);
+  const setToolCategoryActive = categoryName => {
+    Array.from(toolCategoryLinks).forEach(toolLink => {
+      if (categoryName === toolLink.getAttribute('data-category')) {
+        toolLink.classList.remove('active');
+        toolLink.classList.add('active');
       } else {
-        console.warn(`unable to add tool with name ${toolName}Tool`);
-        console.log(cornerstoneTools);
+        toolLink.classList.remove('active');
+      }
+    });
+
+    Array.from(toolCategorySections).forEach(toolCategorySection => {
+      if (
+        categoryName ===
+        toolCategorySection.getAttribute('data-tool-category')
+      ) {
+        toolCategorySection.classList.remove('active');
+        toolCategorySection.classList.add('active');
+      } else {
+        toolCategorySection.classList.remove('active');
+      }
+    });
+  };
+
+  const setButtonActive = (toolName, mouseButtonMask, toolType) => {
+    Array.from(toolButtons).forEach(toolBtn => {
+      // Classes we need to set & remove
+      let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
+      let touchIcon = `touch-1`;
+
+      // Update classes depending on the toolType we clicked
+      if (toolType === 'none') {
+        return;
+      } else if (toolType === 'multitouch') {
+        mouseButtonIcon = null;
+        touchIcon = 'touch-2';
+      } else if (toolType === 'pinch') {
+        mouseButtonIcon = null;
+        touchIcon = 'touch-pinch';
+      } else if (toolType === 'wheel') {
+        mouseButtonIcon = 'mousebutton-wheel';
+        touchIcon = null;
       }
 
-      // Setup button listener
-      // Prevent right click context menu for our menu buttons
-      toolBtn.addEventListener(
-        'contextmenu',
-        event => event.preventDefault(),
-        true
-      );
-      // Prevent middle click opening a new tab on Chrome & FF
-      toolBtn.addEventListener(
-        'auxclick',
-        event => {
-          if (event.button && event.button === 1) {
-            event.preventDefault();
-          }
-        },
-        false
-      );
-      toolBtn.addEventListener('mousedown', evt => {
-        const mouseButtonMask = evt.buttons
-          ? evt.buttons
-          : convertMouseEventWhichToButtons(evt.which);
-        // TODO: Let's make this happen automagically for mask/touch conflicts?
-        setAllToolsPassive();
-        const toolType = evt.target.getAttribute('data-tool-type');
-        setButtonActive(toolName, mouseButtonMask, toolType);
-        cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
-
-        evt.preventDefault();
-        evt.stopPropagation();
-        evt.stopImmediatePropagation();
-        return false;
-      });
-    });
-
-    // Activate first tool
-    cornerstoneTools.setToolActive(cornerstoneTools.store.state.tools[0].name, {
-      mouseButtonMask: 1,
-    });
-
-    const setToolCategoryActive = categoryName => {
-      Array.from(toolCategoryLinks).forEach(toolLink => {
-        if (categoryName === toolLink.getAttribute('data-category')) {
-          toolLink.classList.remove('active');
-          toolLink.classList.add('active');
-        } else {
-          toolLink.classList.remove('active');
+      // Update our target button
+      if (toolName === toolBtn.getAttribute('data-tool')) {
+        toolBtn.className = '';
+        toolBtn.classList.add('active');
+        if (mouseButtonIcon) {
+          toolBtn.classList.add(mouseButtonIcon);
         }
-      });
-
-      Array.from(toolCategorySections).forEach(toolCategorySection => {
+        if (touchIcon) {
+          toolBtn.classList.add(touchIcon);
+        }
+        // Remove relevant classes from other buttons
+      } else {
+        if (mouseButtonIcon && toolBtn.classList.contains(mouseButtonIcon)) {
+          toolBtn.classList.remove(mouseButtonIcon);
+        }
+        if (touchIcon && toolBtn.classList.contains(touchIcon)) {
+          toolBtn.classList.remove(touchIcon);
+        }
         if (
-          categoryName ===
-          toolCategorySection.getAttribute('data-tool-category')
+          toolBtn.classList.length === 1 &&
+          toolBtn.classList[0] === 'active'
         ) {
-          toolCategorySection.classList.remove('active');
-          toolCategorySection.classList.add('active');
-        } else {
-          toolCategorySection.classList.remove('active');
+          toolBtn.classList.remove('active');
         }
-      });
-    };
-
-    const setButtonActive = (toolName, mouseButtonMask, toolType) => {
-      Array.from(toolButtons).forEach(toolBtn => {
-        // Classes we need to set & remove
-        let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
-        let touchIcon = `touch-1`;
-
-        // Update classes depending on the toolType we clicked
-        if (toolType === 'none') {
-          return;
-        } else if (toolType === 'multitouch') {
-          mouseButtonIcon = null;
-          touchIcon = 'touch-2';
-        } else if (toolType === 'pinch') {
-          mouseButtonIcon = null;
-          touchIcon = 'touch-pinch';
-        } else if (toolType === 'wheel') {
-          mouseButtonIcon = 'mousebutton-wheel';
-          touchIcon = null;
-        }
-
-        // Update our target button
-        if (toolName === toolBtn.getAttribute('data-tool')) {
-          toolBtn.className = '';
-          toolBtn.classList.add('active');
-          if (mouseButtonIcon) {
-            toolBtn.classList.add(mouseButtonIcon);
-          }
-          if (touchIcon) {
-            toolBtn.classList.add(touchIcon);
-          }
-          // Remove relevant classes from other buttons
-        } else {
-          if (mouseButtonIcon && toolBtn.classList.contains(mouseButtonIcon)) {
-            toolBtn.classList.remove(mouseButtonIcon);
-          }
-          if (touchIcon && toolBtn.classList.contains(touchIcon)) {
-            toolBtn.classList.remove(touchIcon);
-          }
-          if (
-            toolBtn.classList.length === 1 &&
-            toolBtn.classList[0] === 'active'
-          ) {
-            toolBtn.classList.remove('active');
-          }
-        }
-      });
-    };
-
-    const convertMouseEventWhichToButtons = which => {
-      switch (which) {
-        // no button
-        case 0:
-          return 0;
-        // left
-        case 1:
-          return 1;
-        // middle
-        case 2:
-          return 4;
-        // right
-        case 3:
-          return 2;
       }
-      return 0;
-    };
+    });
+  };
 
-    // Segmentation Module API //
-
-    const { configuration, getters, setters } = cornerstoneTools.getModule(
-      'segmentation'
-    );
-
-    let activeLabelmapIndex = 0;
-
-    function brushApiCall(opperation) {
-      switch (opperation) {
-        case 'next-segment':
-          setters.incrementActiveSegmentIndex(element);
-          cornerstone.updateImage(element);
-          break;
-        case 'previous-segment':
-          setters.decrementActiveSegmentIndex(element);
-          cornerstone.updateImage(element);
-          break;
-        case 'switch-labelmap':
-          if (activeLabelmapIndex === 0) {
-            activeLabelmapIndex = 1;
-          } else {
-            activeLabelmapIndex = 0;
-          }
-
-          setters.activeLabelmapIndex(element, activeLabelmapIndex);
-
-          const label = document.getElementById('active-label-map-label');
-          label.innerHTML = 'Active Labelmap: ' + activeLabelmapIndex;
-
-          cornerstone.updateImage(element);
-
-          break;
-
-        case 'toggle-segment-1':
-          const visible = setters.toggleSegmentVisibility(element, 1);
-
-          console.log(visible);
-
-          const visibilityLabel = document.getElementById(
-            'toggle-segment-1-label'
-          );
-          visibilityLabel.innerHTML = visible ? 'visible' : 'hidden';
-
-          cornerstone.updateImage(element);
-          break;
-        default:
-          return;
-      }
+  const convertMouseEventWhichToButtons = which => {
+    switch (which) {
+      // no button
+      case 0:
+        return 0;
+      // left
+      case 1:
+        return 1;
+      // middle
+      case 2:
+        return 4;
+      // right
+      case 3:
+        return 2;
     }
+    return 0;
+  };
 
-    // Display Outline
-    const outlineDisplay = document.getElementById('display-outline');
+  // Segmentation Module API //
 
-    outlineDisplay.addEventListener('input', event => {
-      configuration.renderOutline = event.target.checked;
-      cornerstone.updateImage(element);
-    });
+  const { configuration, getters, setters } = cornerstoneTools.getModule(
+    'segmentation'
+  );
 
-    // Display Fill
-    const fillDisplay = document.getElementById('display-fill');
+  let activeLabelmapIndex = 0;
 
-    fillDisplay.addEventListener('input', event => {
-      configuration.renderFill = event.target.checked;
-      cornerstone.updateImage(element);
-    });
+  function brushApiCall(opperation) {
+    switch (opperation) {
+      case 'next-segment':
+        setters.incrementActiveSegmentIndex(element);
+        cornerstone.updateImage(element);
+        break;
+      case 'previous-segment':
+        setters.decrementActiveSegmentIndex(element);
+        cornerstone.updateImage(element);
+        break;
+      case 'switch-labelmap':
+        if (activeLabelmapIndex === 0) {
+          activeLabelmapIndex = 1;
+        } else {
+          activeLabelmapIndex = 0;
+        }
 
-    // Display Inactive
-    const inactiveDisplay = document.getElementById('display-inactive');
+        setters.activeLabelmapIndex(element, activeLabelmapIndex);
 
-    inactiveDisplay.addEventListener('input', event => {
-      configuration.shouldRenderInactiveLabelmaps = event.target.checked;
-      cornerstone.updateImage(element);
-    });
+        const label = document.getElementById('active-label-map-label');
+        label.innerHTML = 'Active Labelmap: ' + activeLabelmapIndex;
 
-    // API Sliders
-    // Active Fill
-    const alphaSlider = document.getElementById('fill-alpha');
+        cornerstone.updateImage(element);
 
-    alphaSlider.defaultValue = Math.floor(configuration.fillAlpha * 255);
-    alphaSlider.addEventListener('input', event => {
-      const normalisedAlpha = event.target.value / 255.0;
+        break;
 
-      configuration.fillAlpha = normalisedAlpha;
-      cornerstone.updateImage(element);
-    });
+      case 'toggle-segment-1':
+        const visible = setters.toggleSegmentVisibility(element, 1);
 
-    // Active Outline
-    const outlineAlphaSlider = document.getElementById('outline-alpha');
+        console.log(visible);
 
-    outlineAlphaSlider.defaultValue = Math.floor(
-      configuration.outlineAlpha * 255
-    );
-    outlineAlphaSlider.addEventListener('input', event => {
-      const normalisedAlpha = event.target.value / 255.0;
+        const visibilityLabel = document.getElementById(
+          'toggle-segment-1-label'
+        );
+        visibilityLabel.innerHTML = visible ? 'visible' : 'hidden';
 
-      configuration.outlineAlpha = normalisedAlpha;
-      cornerstone.updateImage(element);
-    });
-
-    // Inactive Fill
-    const inactiveAlphaSlider = document.getElementById('fill-alpha-inactive');
-
-    inactiveAlphaSlider.defaultValue = Math.floor(
-      configuration.fillAlphaInactive * 255
-    );
-    inactiveAlphaSlider.addEventListener('input', event => {
-      const normalisedAlpha = event.target.value / 255.0;
-
-      configuration.fillAlphaInactive = normalisedAlpha;
-      cornerstone.updateImage(element);
-    });
-
-    // Inactive Outline
-    const inactiveOutlineAlphaSlider = document.getElementById(
-      'outline-alpha-inactive'
-    );
-
-    inactiveOutlineAlphaSlider.defaultValue = Math.floor(
-      configuration.outlineAlphaInactive * 255
-    );
-    inactiveOutlineAlphaSlider.addEventListener('input', event => {
-      const normalisedAlpha = event.target.value / 255.0;
-
-      configuration.outlineAlphaInactive = normalisedAlpha;
-      cornerstone.updateImage(element);
-    });
-
-    // Segmentation Tool API
-    const freehandScissorsTool = cornerstoneTools.getToolForElement(
-      element,
-      'FreehandScissors'
-    );
-    const rectangleScissorsTool = cornerstoneTools.getToolForElement(
-      element,
-      'RectangleScissors'
-    );
-    const circleScissorsTool = cornerstoneTools.getToolForElement(
-      element,
-      'CircleScissors'
-    );
-
-    const changeScissorStrategyElement = document.getElementById(
-      'change-scissor-strategy'
-    );
-
-    changeScissorStrategyElement.value = 'fillInside';
-
-    function changeScissorStrategy(value) {
-      console.log(value);
-      switch (value) {
-        case 'fillInside':
-          freehandScissorsTool.setActiveStrategy('FILL_INSIDE');
-          rectangleScissorsTool.setActiveStrategy('FILL_INSIDE');
-          circleScissorsTool.setActiveStrategy('FILL_INSIDE');
-          break;
-        case 'eraseInside':
-          freehandScissorsTool.setActiveStrategy('ERASE_INSIDE');
-          rectangleScissorsTool.setActiveStrategy('ERASE_INSIDE');
-          circleScissorsTool.setActiveStrategy('ERASE_INSIDE');
-          break;
-        case 'fillOutside':
-          freehandScissorsTool.setActiveStrategy('FILL_OUTSIDE');
-          rectangleScissorsTool.setActiveStrategy('FILL_OUTSIDE');
-          circleScissorsTool.setActiveStrategy('FILL_OUTSIDE');
-          break;
-        case 'eraseOutside':
-          freehandScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
-          rectangleScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
-          circleScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
-          break;
-      }
+        cornerstone.updateImage(element);
+        break;
+      default:
+        return;
     }
-  </script>
+  }
+
+  // Display Outline
+  const outlineDisplay = document.getElementById('display-outline');
+
+  outlineDisplay.addEventListener('input', event => {
+    configuration.renderOutline = event.target.checked;
+    cornerstone.updateImage(element);
+  });
+
+  // Display Fill
+  const fillDisplay = document.getElementById('display-fill');
+
+  fillDisplay.addEventListener('input', event => {
+    configuration.renderFill = event.target.checked;
+    cornerstone.updateImage(element);
+  });
+
+  // Display Inactive
+  const inactiveDisplay = document.getElementById('display-inactive');
+
+  inactiveDisplay.addEventListener('input', event => {
+    configuration.shouldRenderInactiveLabelmaps = event.target.checked;
+    cornerstone.updateImage(element);
+  });
+
+  // API Sliders
+  // Active Fill
+  const alphaSlider = document.getElementById('fill-alpha');
+
+  alphaSlider.defaultValue = Math.floor(configuration.fillAlpha * 255);
+  alphaSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value / 255.0;
+
+    configuration.fillAlpha = normalisedAlpha;
+    cornerstone.updateImage(element);
+  });
+
+  // Active Outline
+  const outlineAlphaSlider = document.getElementById('outline-alpha');
+
+  outlineAlphaSlider.defaultValue = Math.floor(
+    configuration.outlineAlpha * 255
+  );
+  outlineAlphaSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value / 255.0;
+
+    configuration.outlineAlpha = normalisedAlpha;
+    cornerstone.updateImage(element);
+  });
+
+  // Inactive Fill
+  const inactiveAlphaSlider = document.getElementById('fill-alpha-inactive');
+
+  inactiveAlphaSlider.defaultValue = Math.floor(
+    configuration.fillAlphaInactive * 255
+  );
+  inactiveAlphaSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value / 255.0;
+
+    configuration.fillAlphaInactive = normalisedAlpha;
+    cornerstone.updateImage(element);
+  });
+
+  // Inactive Outline
+  const inactiveOutlineAlphaSlider = document.getElementById(
+    'outline-alpha-inactive'
+  );
+
+  inactiveOutlineAlphaSlider.defaultValue = Math.floor(
+    configuration.outlineAlphaInactive * 255
+  );
+  inactiveOutlineAlphaSlider.addEventListener('input', event => {
+    const normalisedAlpha = event.target.value / 255.0;
+
+    configuration.outlineAlphaInactive = normalisedAlpha;
+    cornerstone.updateImage(element);
+  });
+
+  // Segmentation Tool API
+  const freehandScissorsTool = cornerstoneTools.getToolForElement(
+    element,
+    'FreehandScissors'
+  );
+  const rectangleScissorsTool = cornerstoneTools.getToolForElement(
+    element,
+    'RectangleScissors'
+  );
+  const circleScissorsTool = cornerstoneTools.getToolForElement(
+    element,
+    'CircleScissors'
+  );
+
+  const changeScissorStrategyElement = document.getElementById(
+    'change-scissor-strategy'
+  );
+
+  changeScissorStrategyElement.value = 'fillInside';
+
+  function changeScissorStrategy(value) {
+    console.log(value);
+    switch (value) {
+      case 'fillInside':
+        freehandScissorsTool.setActiveStrategy('FILL_INSIDE');
+        rectangleScissorsTool.setActiveStrategy('FILL_INSIDE');
+        circleScissorsTool.setActiveStrategy('FILL_INSIDE');
+        break;
+      case 'eraseInside':
+        freehandScissorsTool.setActiveStrategy('ERASE_INSIDE');
+        rectangleScissorsTool.setActiveStrategy('ERASE_INSIDE');
+        circleScissorsTool.setActiveStrategy('ERASE_INSIDE');
+        break;
+      case 'fillOutside':
+        freehandScissorsTool.setActiveStrategy('FILL_OUTSIDE');
+        rectangleScissorsTool.setActiveStrategy('FILL_OUTSIDE');
+        circleScissorsTool.setActiveStrategy('FILL_OUTSIDE');
+        break;
+      case 'eraseOutside':
+        freehandScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
+        rectangleScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
+        circleScissorsTool.setActiveStrategy('ERASE_OUTSIDE');
+        break;
+    }
+  }
+
+  Mousetrap.bind(['command+z', 'ctrl+z'], function () {
+    console.log('UNDO');
+    setters.undo(element)
+  });
+  Mousetrap.bind(['command+y', 'ctrl+y'], function () {
+    console.log('REDO');
+    setters.redo(element)
+  });
+</script>
+
 </html>

--- a/netlify-example/metaDataProvider.js
+++ b/netlify-example/metaDataProvider.js
@@ -36,6 +36,36 @@
           columnPixelSpacing: 0.78,
           rowPixelSpacing: 0.78,
         };
+      } else if (
+        imageId ===
+        'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.11.dcm'
+      ) {
+        return {
+          frameOfReferenceUID:
+            '1.3.6.1.4.1.25403.52237031786.3872.20100510032220.6',
+          rows: 512,
+          columns: 512,
+          rowCosines: [1, 0, 0],
+          columnCosines: [0, 1, 0],
+          imagePositionPatient: [-249.51172, -460.51172, -615.5],
+          columnPixelSpacing: 0.9765625,
+          rowPixelSpacing: 0.9765625,
+        };
+      } else if (
+        imageId ===
+        'dicomweb://s3.amazonaws.com/lury/PTCTStudy/1.3.6.1.4.1.25403.52237031786.3872.20100510032220.12.dcm'
+      ) {
+        return {
+          frameOfReferenceUID:
+            '1.3.6.1.4.1.25403.52237031786.3872.20100510032220.6',
+          rows: 512,
+          columns: 512,
+          rowCosines: [1, 0, 0],
+          columnCosines: [0, 1, 0],
+          imagePositionPatient: [-249.51172, -460.51172, -612.5],
+          columnPixelSpacing: 0.9765625,
+          rowPixelSpacing: 0.9765625,
+        };
       }
     }
   }

--- a/src/mixins/segmentation/freehandSegmentationMixin.js
+++ b/src/mixins/segmentation/freehandSegmentationMixin.js
@@ -2,6 +2,7 @@ import external from '../../externalModules.js';
 import { getModule } from '../../store';
 import { getLogger } from '../../util/logger.js';
 import { draw, drawJoinedLines, getNewContext } from '../../drawing';
+import { getDiffBetweenPixelData } from '../../util/segmentation';
 
 const logger = getLogger('tools:ScissorsTool');
 
@@ -98,9 +99,12 @@ function _applyStrategy(evt) {
   const points = this.handles.points;
   const { element } = evt.detail;
 
-  const { labelmap2D, labelmap3D } = getters.labelmap2D(element);
+  const { labelmap2D, labelmap3D, currentImageIdIndex } = getters.labelmap2D(
+    element
+  );
 
   const pixelData = labelmap2D.pixelData;
+  const previousPixeldata = pixelData.slice();
 
   const operationData = {
     points,
@@ -110,6 +114,13 @@ function _applyStrategy(evt) {
   };
 
   this.applyActiveStrategy(evt, operationData);
+
+  const operation = {
+    imageIdIndex: currentImageIdIndex,
+    diff: getDiffBetweenPixelData(previousPixeldata, pixelData),
+  };
+
+  setters.pushState(this.element, [operation]);
 
   // Invalidate the brush tool data so it is redrawn
   setters.updateSegmentsOnLabelmap2D(labelmap2D);

--- a/src/store/modules/segmentationModule/addLabelmap3D.js
+++ b/src/store/modules/segmentationModule/addLabelmap3D.js
@@ -15,5 +15,7 @@ export default function addLabelmap3D(brushStackState, labelmapIndex, size) {
     activeSegmentIndex: 1,
     colorLUTIndex: 0,
     segmentsHidden: [],
+    undo: [],
+    redo: [],
   };
 }

--- a/src/store/modules/segmentationModule/configuration.js
+++ b/src/store/modules/segmentationModule/configuration.js
@@ -12,6 +12,7 @@ const configuration = {
   outlineAlpha: 0.7,
   outlineAlphaInactive: 0.35,
   outlineWidth: 3,
+  storeHistory: true,
 };
 
 export default configuration;

--- a/src/store/modules/segmentationModule/getLabelmaps3D.js
+++ b/src/store/modules/segmentationModule/getLabelmaps3D.js
@@ -38,3 +38,24 @@ export default function getLabelmaps3D(elementOrEnabledElementUID) {
     currentImageIdIndex: stackData.currentImageIdIndex,
   };
 }
+
+/**
+ * Returns a single `Labelmap3D` object associated with the series displayed
+ * in the element.
+ *
+ * @param  {HTMLElement|string} elementOrEnabledElementUID   The cornerstone enabled
+ *                                                    element or its UUID.
+ * @param  {number} [labelmapIndex] The index of the `Labelmap3D` to retrieve. Defaults to
+ *                                  the `activeLabelmapIndex`.
+ * @returns {Object}              A `Labelmap3D` object.
+ */
+export function getLabelmap3D(elementOrEnabledElementUID, labelmapIndex) {
+  const { labelmaps3D, activeLabelmapIndex } = getLabelmaps3D(
+    elementOrEnabledElementUID
+  );
+
+  labelmapIndex =
+    labelmapIndex !== undefined ? labelmapIndex : activeLabelmapIndex;
+
+  return labelmaps3D[labelmapIndex];
+}

--- a/src/store/modules/segmentationModule/history.js
+++ b/src/store/modules/segmentationModule/history.js
@@ -1,0 +1,71 @@
+import { getLabelmap3D } from './getLabelmaps3D';
+import { getLogger } from '../../../util/logger';
+import external from '../../../externalModules';
+
+const logger = getLogger('util:segmentation:labelmap3DHistory');
+
+function pushState(element, operations, labelmapIndex) {
+  const labelmap3D = getLabelmap3D(element, labelmapIndex);
+
+  labelmap3D.undo.push(operations);
+  labelmap3D.redo = [];
+}
+
+function undo(element, labelmapIndex) {
+  const labelmap3D = getLabelmap3D(element, labelmapIndex);
+  const { undo, redo } = labelmap3D;
+
+  if (!undo.length) {
+    logger.warn('No undos left.');
+    return;
+  }
+
+  // Pop last set of operations from undo.
+  const operations = undo.pop();
+
+  // Undo operations.
+  applyState(labelmap3D, operations, 1);
+
+  // Push set of operations to redo.
+  redo.push(operations);
+
+  external.cornerstone.updateImage(element);
+}
+
+function redo(element, labelmapIndex) {
+  const labelmap3D = getLabelmap3D(element, labelmapIndex);
+  const { undo, redo } = labelmap3D;
+
+  if (!redo.length) {
+    logger.warn('No redos left.');
+    return;
+  }
+
+  // Pop last set of operations from redo.
+  const operations = redo.pop();
+
+  // Redo operations.
+  applyState(labelmap3D, operations, 2);
+
+  // Push set of operations to undo.
+  undo.push(operations);
+
+  external.cornerstone.updateImage(element);
+}
+
+export { pushState, undo, redo };
+
+function applyState(labelmap3D, operations, replaceIndex) {
+  const { labelmaps2D } = labelmap3D;
+
+  operations.forEach(operation => {
+    const { imageIdIndex, diff } = operation;
+    const labelmap2D = labelmaps2D[imageIdIndex];
+    const pixelData = labelmap2D.pixelData;
+
+    for (let i = 0; i < diff.length; i++) {
+      const diffI = diff[i];
+      pixelData[diffI[0]] = diffI[replaceIndex];
+    }
+  });
+}

--- a/src/store/modules/segmentationModule/history.test.js
+++ b/src/store/modules/segmentationModule/history.test.js
@@ -1,0 +1,225 @@
+import { getLabelmap3D } from './getLabelmaps3D';
+import external from '../../../externalModules';
+import { getDiffBetweenPixelData } from '../../../util/segmentation';
+import { pushState, undo, redo } from './history';
+
+let mockLabelmap3D;
+let mockElement = {};
+
+jest.mock('./getLabelmaps3D', () => ({
+  getLabelmap3D: (element, labelmapIndex) => {
+    return mockLabelmap3D;
+  },
+}));
+
+jest.mock('../../../externalModules.js', () => ({
+  cornerstone: {
+    updateImage: jest.fn(),
+  },
+}));
+
+describe('history.js', () => {
+  beforeEach(() => {
+    resetLabelmap3D();
+  });
+
+  describe('pushState', () => {
+    it("Should push the applied operation to the Labelmap3D's undo stack.", () => {
+      const labelmap3D = getLabelmap3D();
+      const frames = [0];
+      const data = [{ segmentIndex: 1, pixels: [0] }];
+      const operations = emulateSegmentationToolApplication(frames, data);
+
+      pushState(mockElement, operations);
+
+      expect(labelmap3D.undo.length).toBe(1);
+    });
+
+    it("Should push a set of simulataneous operations to multiple frames to the Labelmap3D's undo stack as one entry.", () => {
+      const labelmap3D = getLabelmap3D();
+      const frames = [4, 5, 6];
+      const data = [
+        { segmentIndex: 1, pixels: [0] },
+        { segmentIndex: 1, pixels: [0] },
+        { segmentIndex: 1, pixels: [0] },
+      ];
+      const operations = emulateSegmentationToolApplication(frames, data);
+
+      pushState(mockElement, operations);
+
+      expect(labelmap3D.undo.length).toBe(1);
+      expect(labelmap3D.undo[0].length).toBe(3);
+    });
+
+    it("Should invalidate the Labelmap3D's redo stack when pushing new state.", () => {
+      const labelmap3D = getLabelmap3D();
+      const frames = [0];
+      const data = [{ segmentIndex: 1, pixels: [0] }];
+      const operations = emulateSegmentationToolApplication(frames, data);
+
+      pushState(mockElement, operations);
+
+      undo(mockElement);
+
+      pushState(mockElement, operations);
+
+      expect(labelmap3D.undo.length).toBe(1);
+      expect(labelmap3D.redo.length).toBe(0);
+    });
+  });
+
+  describe('undo', () => {
+    it('Should undo an operation and have it pushed to the redo stack.', () => {
+      const labelmap3D = getLabelmap3D();
+      const frames = [0];
+      const data = [{ segmentIndex: 1, pixels: [0] }];
+      const operations = emulateSegmentationToolApplication(frames, data);
+
+      pushState(mockElement, operations);
+
+      undo(mockElement);
+
+      expect(labelmap3D.undo.length).toBe(0);
+      expect(labelmap3D.redo.length).toBe(1);
+    });
+
+    it('Should perform 1000 random operations to the labelmap, undo all the operations and return to a blank canvas.', () => {
+      const labelmap3D = getLabelmap3D();
+
+      function getRandomFrame() {
+        return Math.floor(Math.random() * Math.floor(16));
+      }
+
+      function getRandomPixel() {
+        return Math.floor(Math.random() * Math.floor(256));
+      }
+
+      function getRandomSegmentIndex() {
+        // Including zero which is "erase"
+        return Math.floor(Math.random() * Math.floor(65536));
+      }
+
+      const numberOfOperations = 1000;
+
+      // Sample random operations and perform them.
+      for (let i = 0; i < numberOfOperations; i++) {
+        const frames = [getRandomFrame()];
+        const data = [
+          {
+            segmentIndex: getRandomSegmentIndex(),
+            pixels: [
+              getRandomPixel(),
+              getRandomPixel(),
+              getRandomPixel(),
+              getRandomPixel(),
+            ],
+          },
+        ];
+        const operations = emulateSegmentationToolApplication(frames, data);
+
+        pushState(mockElement, operations);
+      }
+
+      while (labelmap3D.undo.length > 0) {
+        undo(mockElement);
+      }
+
+      const uInt16ViewOfLabelmap3D = new Uint16Array(labelmap3D.buffer);
+      let hasNonZeroElement = uInt16ViewOfLabelmap3D.some(voxel => voxel !== 0);
+
+      expect(labelmap3D.undo.length).toBe(0);
+      expect(labelmap3D.redo.length).toBe(numberOfOperations);
+      expect(hasNonZeroElement).toBe(false);
+    });
+  });
+
+  describe('redo', () => {
+    it('Should undo an operation and redo it to get the same result.', () => {
+      const labelmap3D = getLabelmap3D();
+      const frames = [3, 4];
+      const data = [
+        { segmentIndex: 1, pixels: [0, 45, 234] },
+        { segmentIndex: 1, pixels: [15, 23, 25] },
+      ];
+      const operations = emulateSegmentationToolApplication(frames, data);
+
+      pushState(mockElement, operations);
+
+      const copyOfStateAfterOperation = new Uint16Array(
+        labelmap3D.buffer
+      ).slice();
+
+      undo(mockElement);
+
+      redo(mockElement, operations);
+
+      const viewOnBuffer = new Uint16Array(labelmap3D.buffer);
+
+      let hasDifferentPixel = false;
+
+      for (let i = 0; i < viewOnBuffer.length; i++) {
+        if (viewOnBuffer[i] !== copyOfStateAfterOperation[i]) {
+          hasDifferentPixel = true;
+        }
+      }
+
+      expect(labelmap3D.undo.length).toBe(1);
+      expect(labelmap3D.redo.length).toBe(0);
+      expect(hasDifferentPixel).toBe(false);
+    });
+  });
+});
+
+function resetLabelmap3D() {
+  const width = 16;
+  const height = 16;
+  const sliceLength = width * height;
+  const numberOfFrames = 16;
+
+  mockLabelmap3D = {
+    buffer: new ArrayBuffer(width * height * numberOfFrames * 2),
+    labelmaps2D: [],
+    metadata: [],
+    activeSegmentIndex: 1,
+    colorLUTIndex: 0,
+    segmentsHidden: [],
+    undo: [],
+    redo: [],
+  };
+
+  const labelmaps2D = mockLabelmap3D.labelmaps2D;
+  const buffer = mockLabelmap3D.buffer;
+
+  for (let imageIdIndex = 0; imageIdIndex < numberOfFrames; imageIdIndex++) {
+    const byteOffset = sliceLength * 2 * imageIdIndex; // 2 bytes/pixel
+
+    const pixelData = new Uint16Array(buffer, byteOffset, sliceLength);
+
+    labelmaps2D.push({ pixelData, segmentsOnLabelmap: [] });
+  }
+}
+
+function emulateSegmentationToolApplication(frames, data) {
+  const labelmap3D = getLabelmap3D();
+  const labelmaps2D = labelmap3D.labelmaps2D;
+
+  const operations = [];
+
+  for (let i = 0; i < frames.length; i++) {
+    const imageIdIndex = frames[i];
+    const { segmentIndex, pixels } = data[i];
+    const { pixelData } = labelmaps2D[imageIdIndex];
+    const previousPixelData = pixelData.slice();
+
+    pixels.forEach(pixel => {
+      pixelData[pixel] = segmentIndex;
+    });
+
+    operations.push({
+      imageIdIndex,
+      diff: getDiffBetweenPixelData(previousPixelData, pixelData),
+    });
+  }
+
+  return operations;
+}

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -22,7 +22,7 @@ import {
   setLabelmap3DForElement,
 } from './setLabelmap3D.js';
 import getLabelmapStats from './getLabelmapStats';
-import getLabelmaps3D from './getLabelmaps3D';
+import getLabelmaps3D, { getLabelmap3D } from './getLabelmaps3D';
 import getLabelmap2D, { getLabelmap2DByImageIdIndex } from './getLabelmap2D';
 import getSegmentOfActiveLabelmapAtEvent from './getSegmentOfActiveLabelmapAtEvent';
 import setColorLUT, {
@@ -37,6 +37,7 @@ import deleteSegment from './deleteSegment';
 
 import state from './state';
 import configuration from './configuration';
+import { pushState, undo, redo } from './history';
 
 /**
  * A map of `firstImageId` to associated `BrushStackState`, where
@@ -65,6 +66,9 @@ import configuration from './configuration';
  * @property {number} colorLUTIndex The index of the color LUT to use when displaying this `Labelmap3D`.
  * @property {boolean[]} segmentsHidden The visibility of segments on this labelmap.
  * If an element is `true`, the element is hidden. If it `false|undefined`, the segment is visible.
+ * @property {Object[]} undo A history of operations that can be reversed.
+ * @property {Object[]} redo A history of reverted operations, so that an undo can be reversed.
+ *                           Is cleared when changes are made to the labelmap.
  */
 
 /**
@@ -90,6 +94,7 @@ export default {
   onRegisterCallback,
   getters: {
     metadata: getMetadata,
+    labelmap3D: getLabelmap3D,
     labelmaps3D: getLabelmaps3D,
     activeLabelmapIndex: getActiveLabelmapIndex,
     activeSegmentIndex: getActiveSegmentIndex,
@@ -128,5 +133,8 @@ export default {
         configuration.maxRadius
       );
     },
+    pushState,
+    undo,
+    redo,
   },
 };

--- a/src/store/modules/segmentationModule/setLabelmap3D.js
+++ b/src/store/modules/segmentationModule/setLabelmap3D.js
@@ -93,6 +93,8 @@ function setLabelmap3DByFirstImageId(
     activeSegmentIndex: 1,
     colorLUTIndex: 0,
     segmentsHidden: [],
+    undo: [],
+    redo: [],
   };
 
   const labelmaps2D = brushStackState.labelmaps3D[labelmapIndex].labelmaps2D;

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -135,9 +135,9 @@ class BaseBrushTool extends BaseTool {
     };
 
     if (configuration.storeHistory) {
-      const previousPixeldata = labelmap2D.pixelData.slice();
+      const previousPixelData = labelmap2D.pixelData.slice();
 
-      this.paintEventData.previousPixeldata = previousPixeldata;
+      this.paintEventData.previousPixelData = previousPixelData;
     }
   }
 
@@ -172,11 +172,11 @@ class BaseBrushTool extends BaseTool {
     labelmap2D.segmentsOnLabelmap = segmentsOnLabelmap;
 
     if (configuration.storeHistory) {
-      const { previousPixeldata } = this.paintEventData;
+      const { previousPixelData } = this.paintEventData;
       const newPixelData = labelmap2D.pixelData;
       const operation = {
         imageIdIndex: currentImageIdIndex,
-        diff: getDiffBetweenPixelData(previousPixeldata, newPixelData),
+        diff: getDiffBetweenPixelData(previousPixelData, newPixelData),
       };
 
       setters.pushState(this.element, [operation]);

--- a/src/tools/segmentation/BrushTool.js
+++ b/src/tools/segmentation/BrushTool.js
@@ -10,7 +10,7 @@ import { getLogger } from '../../util/logger.js';
 
 const logger = getLogger('tools:BrushTool');
 
-const segmentationModule = getModule('segmentation');
+const { getters, configuration, state } = getModule('segmentation');
 
 /**
  * @public
@@ -65,10 +65,10 @@ export default class BrushTool extends BaseBrushTool {
     }
 
     // Draw the hover overlay on top of the pixel data
-    const radius = segmentationModule.configuration.radius;
+    const radius = configuration.radius;
     const context = eventData.canvasContext;
     const element = eventData.element;
-    const color = segmentationModule.getters.brushColor(element, this._drawing);
+    const color = getters.brushColor(element, this._drawing);
 
     context.setTransform(1, 0, 0, 1, 0, 0);
 
@@ -108,7 +108,7 @@ export default class BrushTool extends BaseBrushTool {
       return;
     }
 
-    const radius = segmentationModule.configuration.radius;
+    const radius = configuration.radius;
     const pointerArray = getCircle(radius, rows, columns, x, y);
 
     const { labelmap2D, labelmap3D, shouldErase } = this.paintEventData;
@@ -116,7 +116,7 @@ export default class BrushTool extends BaseBrushTool {
     // Draw / Erase the active color.
     drawBrushPixels(
       pointerArray,
-      labelmap2D,
+      labelmap2D.pixelData,
       labelmap3D.activeSegmentIndex,
       columns,
       shouldErase

--- a/src/util/segmentation/drawBrush.js
+++ b/src/util/segmentation/drawBrush.js
@@ -4,7 +4,7 @@ import eraseIfSegmentIndex from './eraseIfSegmentIndex.js';
  * DrawBrushPixels - Adds or removes labels to a labelmap.
  *
  * @param  {number[]} pointerArray      The array of pixels to paint.
- * @param  {Object} labelmap2D          The `Labelmap2D` object to paint to.
+ * @param  {Object} labelmap2D          The `pixelData` array to paint to.
  * @param  {number} segmentIndex        The segment being drawn.
  * @param  {number} columns             The number of columns in the image.
  * @param  {boolean} shouldErase = false Whether we should erase rather than color pixels.
@@ -12,13 +12,12 @@ import eraseIfSegmentIndex from './eraseIfSegmentIndex.js';
  */
 function drawBrushPixels(
   pointerArray,
-  labelmap2D,
+  pixelData,
   segmentIndex,
   columns,
   shouldErase = false
 ) {
   const getPixelIndex = (x, y) => y * columns + x;
-  const pixelData = labelmap2D.pixelData;
 
   pointerArray.forEach(point => {
     const spIndex = getPixelIndex(...point);

--- a/src/util/segmentation/getDiffBetweenPixelData.js
+++ b/src/util/segmentation/getDiffBetweenPixelData.js
@@ -1,0 +1,14 @@
+export default function getDiffBetweenPixelData(
+  previousPixelData,
+  newPixelData
+) {
+  const diff = [];
+
+  for (let i = 0; i < previousPixelData.length; i++) {
+    if (previousPixelData[i] !== newPixelData[i]) {
+      diff.push([i, previousPixelData[i], newPixelData[i]]);
+    }
+  }
+
+  return diff;
+}

--- a/src/util/segmentation/index.js
+++ b/src/util/segmentation/index.js
@@ -11,6 +11,7 @@ import getCircle from './getCircle';
 import getPixelPathBetweenPixels from './getPixelPathBetweenPixels';
 import isSameSegment from './isSameSegment';
 import triggerLabelmapModifiedEvent from './triggerLabelmapModifiedEvent';
+import getDiffBetweenPixelData from './getDiffBetweenPixelData';
 
 export {
   drawBrushPixels,
@@ -28,4 +29,5 @@ export {
   getPixelPathBetweenPixels,
   isSameSegment,
   triggerLabelmapModifiedEvent,
+  getDiffBetweenPixelData,
 };


### PR DESCRIPTION
A history of undo and redo actions are stored per `labelmap3D`.

- All core tools in the lib now save a diff to the undo stack after usage (for brush tools, after the brush stroke).

- Two public methods added to the segmentation module:
  - `setters.undo(element, labelmapIndex)` - Undoes one action, and adds to the redo stack. If `labelmapIndex` is not set the `activeLabelmapIndex` is used.
  - `setters.redo(element, labelmapIndex)` - Redoes one action, and adds to the undo stack. If `labelmapIndex` is not set the `activeLabelmapIndex` is used.

- Diffs are calculated for each `Labelmap2D` affected, if multiple frames are affected, you just store an array of the diffs for each. This gives very simple API for all 2D tools, and 3D tools.
- Diffs poped and pushed between undo and redo stacks. The redo stack is invalidated upon a new action.
- Most actions currently in cornerstoneTools are currently 2D, so storing time scales on slice length (i.e. `width * height`), spherical brush is `width * height` * the number of slices painted on.

Scope to compress changes per-slice + multithread easily in the future, to have better support for large-scale 3D operations if improved performance is required.

[live demo here](https://deploy-preview-1059--cornerstone-tools.netlify.com/netlify-example/brush/). `ctrl/cmd + z` is undo and `ctrl/cmd + y` is redo.