### PR TITLE
Fix #1065, use cornerstoneTools without stacks.

### DIFF
--- a/src/eventDispatchers/imageRenderedEventDispatcher.js
+++ b/src/eventDispatchers/imageRenderedEventDispatcher.js
@@ -1,4 +1,5 @@
 import { state, getModule } from './../store/index.js';
+import { getToolState } from '../stateManagement/toolState';
 import onImageRenderedBrushEventHandler from '../eventListeners/onImageRenderedBrushEventHandler.js';
 import external from './../externalModules.js';
 
@@ -18,9 +19,12 @@ const onImageRendered = function(evt) {
         tool.mode === 'enabled')
   );
 
+  // Must be using stacks in order to use segmentation tools.
+  const stackToolState = getToolState(element, 'stack');
   if (
-    segmentationConfiguration.renderFill ||
-    segmentationConfiguration.renderOutline
+    stackToolState &&
+    (segmentationConfiguration.renderFill ||
+      segmentationConfiguration.renderOutline)
   ) {
     onImageRenderedBrushEventHandler(evt);
   }

--- a/src/store/modules/segmentationModule/getBrushColor.js
+++ b/src/store/modules/segmentationModule/getBrushColor.js
@@ -2,6 +2,10 @@ import { getToolState } from '../../../stateManagement/toolState.js';
 import state from './state';
 import getElement from './getElement';
 
+import { getLogger } from '../../../util/logger';
+
+const logger = getLogger('store:modules:segmentationModule:getBrushColor');
+
 /**
  * Returns the brush color as a rgba CSS color for the active segment of the active
  * `Labelmap3D` for the `BrushStackState` displayed on the element.
@@ -22,6 +26,15 @@ export default function getBrushColor(
   }
 
   const stackState = getToolState(element, 'stack');
+
+  if (!stackState) {
+    logger.error(
+      'Consumers must define stacks in their application if using segmentations in cornerstoneTools.'
+    );
+
+    return;
+  }
+
   const stackData = stackState.data[0];
   const firstImageId = stackData.imageIds[0];
 

--- a/src/store/modules/segmentationModule/getLabelmap2D.js
+++ b/src/store/modules/segmentationModule/getLabelmap2D.js
@@ -5,6 +5,10 @@ import addLabelmap2D from './addLabelmap2D';
 import external from '../../../externalModules';
 import state from './state';
 
+import { getLogger } from '../../../util/logger';
+
+const logger = getLogger('store:modules:segmentationModule:getLabelmap2D');
+
 /**
  * Returns the active `labelmap3D` and the `currentImageIdIndex`. If a labelmap does
  * not get exist, creates a new one. Generates a `labelmap2D` for the `currentImageIndex`
@@ -23,6 +27,15 @@ export default function getLabelmap2D(elementOrEnabledElementUID) {
 
   const cornerstone = external.cornerstone;
   const stackState = getToolState(element, 'stack');
+
+  if (!stackState) {
+    logger.error(
+      'Consumers must define stacks in their application if using segmentations in cornerstoneTools.'
+    );
+
+    return;
+  }
+
   const stackData = stackState.data[0];
 
   const enabledElement = cornerstone.getEnabledElement(element);

--- a/src/store/modules/segmentationModule/getLabelmaps3D.js
+++ b/src/store/modules/segmentationModule/getLabelmaps3D.js
@@ -2,6 +2,10 @@ import { getToolState } from '../../../stateManagement/toolState.js';
 import getElement from './getElement';
 import state from './state';
 
+import { getLogger } from '../../../util/logger';
+
+const logger = getLogger('store:modules:segmentationModule:getLabelmaps3D');
+
 /**
  * Returns the `Labelmap3D` objects associated with the series displayed
  * in the element, the `activeLabelmapIndex` and the `currentImageIdIndex`.
@@ -19,6 +23,15 @@ export default function getLabelmaps3D(elementOrEnabledElementUID) {
   }
 
   const stackState = getToolState(element, 'stack');
+
+  if (!stackState) {
+    logger.error(
+      'Consumers must define stacks in their application if using segmentations in cornerstoneTools.'
+    );
+
+    return;
+  }
+
   const stackData = stackState.data[0];
 
   const firstImageId = stackData.imageIds[0];


### PR DESCRIPTION
Segmentation tools still require stacks to operate, but this fixes issues such as #1065 .