### PR TITLE
fix(FreehandRoiSculptorTool.js): Use merged props value over default

### DIFF
--- a/src/tools/FreehandRoiSculptorTool.js
+++ b/src/tools/FreehandRoiSculptorTool.js
@@ -38,7 +38,7 @@ export default class FreehandRoiSculptorTool extends BaseTool {
 
     this.updateOnMouseMove = true;
     this.isMultiPartTool = true;
-    this.referencedToolName = defaultProps.referencedToolName;
+    this.referencedToolName = this.initialConfiguration.referencedToolName;
 
     this._active = false;
 


### PR DESCRIPTION

The FreehandRoiSculptor tool needs to be able to reference the state of the FreehandRoiTool to modify measurements. This reference is configured via the `referencedToolName` prop. The current implementation defines this as configurable API but then uses the default value instead of the merged value.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

The `FreehandRoiSculptor` tool uses the default `referencedToolName` instead of the result from merging `props` and `defaultProps`.


* **What is the new behavior (if this is a feature change)?**

Now uses the merged value.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
