### PR TITLE
fix(SphericalBrushTool.js): Consistent implementation of props and defaultProps

### DIFF
--- a/src/tools/segmentation/SphericalBrushTool.js
+++ b/src/tools/segmentation/SphericalBrushTool.js
@@ -29,7 +29,7 @@ export default class SphericalBrushTool extends BrushTool {
       configuration: { alwaysEraseOnClick: false },
     };
 
-    super(defaultProps);
+    super(props, defaultProps);
 
     this.touchDragCallback = this._paint.bind(this);
   }


### PR DESCRIPTION

Pass the user defined props to super in SphericalBrushTool

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

The implementation of `SphericalBrushTool` wasn't passing the user defined `props` to `super` so settings could not be overridden.

* **What is the new behavior (if this is a feature change)?**

Pass props and default props to super.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

n/a

* **Other information**:
