### PR TITLE
Fix DragProbeTool

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
         <li><a href="#" data-tool="Wwwc">WWWC</a></li>
         <li><a href="#" data-tool="WwwcRegion">WWWCRegion</a></li>
         <li><a href="#" data-tool="Zoom">Zoom</a></li>
+        <li><a href="#" data-tool="DragProbe">DragProbe</a></li>
       </ul>
       <ul class="tool-category" data-tool-category="double-tap">
         <li>

--- a/src/tools/DragProbeTool.js
+++ b/src/tools/DragProbeTool.js
@@ -85,7 +85,7 @@ export default class DragProbeTool extends BaseTool {
  * @param  {Object} evt Image rendered event
  * @returns {void}
  */
-const defaultStrategy = evt => {
+function defaultStrategy(evt) {
   const config = this.configuration;
   const cornerstone = external.cornerstone;
   const eventData = evt.detail;
@@ -143,7 +143,7 @@ const defaultStrategy = evt => {
     );
     drawTextBox(context, text, textCoords.x, textCoords.y, color);
   });
-};
+}
 
 /**
  * Minimal strategy will position a circle and use the center of the circle to calculate and display probe data.
@@ -151,7 +151,7 @@ const defaultStrategy = evt => {
  * @param  {Object} evt Image rendered event
  * @returns {void}
  */
-const minimalStrategy = evt => {
+function minimalStrategy(evt) {
   const config = this.configuration;
   const cornerstone = external.cornerstone;
   const eventData = evt.detail;
@@ -259,4 +259,4 @@ const minimalStrategy = evt => {
       color
     );
   });
-};
+}

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -42,12 +42,12 @@ export default class RotateTool extends BaseTool {
 
   dragCallback(evt) {
     evt.detail.viewport.initialRotation = this.initialRotation;
-    this.applyActiveStrategy(evt, this.configuration);
+    this.applyActiveStrategy(evt);
     external.cornerstone.setViewport(evt.detail.element, evt.detail.viewport);
   }
 }
 
-const defaultStrategy = evt => {
+function defaultStrategy(evt) {
   const eventData = evt.detail;
   const { element, viewport } = eventData;
   const initialRotation = viewport.initialRotation;
@@ -82,7 +82,7 @@ const defaultStrategy = evt => {
   }
 
   viewport.rotation = initialRotation + angleInfo.angle;
-};
+}
 
 const horizontalStrategy = evt => {
   const eventData = evt.detail;


### PR DESCRIPTION
`DragProbeTool`'s strategies were defined as arrow functions, which made them not callable with the correct context, replaced with regular function declarations.

Added `DragProbeTool` to the index.html demo under the 'drag' tab.