### PR TITLE
EVENTS.LABELMAP_MODIFIED throttle

### DIFF
--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -3,7 +3,10 @@ import EVENTS from './../../events.js';
 import external from './../../externalModules.js';
 import isToolActive from './../../store/isToolActive.js';
 import { getModule } from './../../store/index.js';
-import { getDiffBetweenPixelData } from '../../util/segmentation';
+import {
+  getDiffBetweenPixelData,
+  triggerLabelmapModifiedEvent,
+} from '../../util/segmentation';
 
 const { configuration, getters, setters } = getModule('segmentation');
 
@@ -181,6 +184,8 @@ class BaseBrushTool extends BaseTool {
 
       setters.pushState(this.element, [operation]);
     }
+
+    triggerLabelmapModifiedEvent(this.element);
   }
 
   // ===================================================================

--- a/src/tools/segmentation/BrushTool.js
+++ b/src/tools/segmentation/BrushTool.js
@@ -1,11 +1,7 @@
 import external from './../../externalModules.js';
 import { BaseBrushTool } from '../base';
 import store, { getModule } from './../../store/index.js';
-import {
-  drawBrushPixels,
-  getCircle,
-  triggerLabelmapModifiedEvent,
-} from '../../util/segmentation/index.js';
+import { drawBrushPixels, getCircle } from '../../util/segmentation/index.js';
 import { getLogger } from '../../util/logger.js';
 
 const logger = getLogger('tools:BrushTool');
@@ -121,8 +117,6 @@ export default class BrushTool extends BaseBrushTool {
       columns,
       shouldErase
     );
-
-    triggerLabelmapModifiedEvent(element);
 
     external.cornerstone.updateImage(evt.detail.element);
   }

--- a/src/tools/segmentation/SphericalBrushTool.js
+++ b/src/tools/segmentation/SphericalBrushTool.js
@@ -327,6 +327,10 @@ export default class SphericalBrushTool extends BrushTool {
       }
     }
 
-    setters.pushState(this.element, operations);
+    if (configuration.storeHistory) {
+      setters.pushState(this.element, operations);
+    }
+
+    triggerLabelmapModifiedEvent(this.element);
   }
 }


### PR DESCRIPTION
Emit `EVENTS.LABELMAP_MODIFIED` only at the end of a brush stroke, to prevent spamming of this event. 