### PR TITLE
feat: 🎸 Adds a getKeyPressData function will

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -46,6 +46,7 @@ import isPointInImage from './util/isPointInImage';
 import isPointInPolygon from './util/isPointInPolygon';
 import throttle from './util/throttle';
 import { wait, waitForEnabledElementImageToLoad } from './util/wait';
+import getKeyPressData from './util/getKeyPressData';
 
 import drawTextBox, { textBoxWidth } from './drawing/drawTextBox.js';
 import drawArrow from './drawing/drawArrow.js';
@@ -165,6 +166,7 @@ export const lib = {
   'util/throttle': throttle,
   'util/wait': wait,
   'util/waitForEnabledElementImageToLoad': waitForEnabledElementImageToLoad,
+  'util/getKeyPressData': getKeyPressData,
 
   // Whole tool specific util packages
   'util/ellipseUtils': ellipseUtils,

--- a/src/util/getKeyPressData.js
+++ b/src/util/getKeyPressData.js
@@ -1,0 +1,27 @@
+import store from '../store/';
+import external from '../externalModules';
+
+export default function getKeyPressData(e) {
+  const cornerstone = external.cornerstone;
+  const element = e.currentTarget;
+  const enabledElement = cornerstone.getEnabledElement(element);
+
+  if (!enabledElement.image) {
+    return;
+  }
+
+  const currentPointsImage = store.state.mousePositionImage;
+
+  return {
+    event: window.event || e, // Old IE support
+    element,
+    viewport: cornerstone.getViewport(element),
+    image: enabledElement.image,
+    currentPoints: {
+      image: currentPointsImage,
+      canvas: cornerstone.pixelToCanvas(element, currentPointsImage),
+    },
+    keyCode: e.keyCode,
+    which: e.which,
+  };
+}

--- a/src/util/getKeyPressData.js
+++ b/src/util/getKeyPressData.js
@@ -6,7 +6,7 @@ export default function getKeyPressData(e) {
   const element = e.currentTarget;
   const enabledElement = cornerstone.getEnabledElement(element);
 
-  if (!enabledElement.image) {
+  if (!enabledElement || !enabledElement.image) {
     return;
   }
 


### PR DESCRIPTION
Adds a util function that consumes a native `keydown`, `keyup` or `keypress` event and returns information about the cornerstone element and the position of the mouse cursor. Useful for "do something to this hovered annotation" functions at the app level.


```
element.addEventListener('keydown', (evt) => {
  console.log(cornerstoneTools.importInternal('util/getKeyPressData')(evt))
});
```