### PR TITLE
Configuration for multiple modules on init.

### DIFF
--- a/docs/latest/index.md
+++ b/docs/latest/index.md
@@ -79,7 +79,7 @@ cornerstoneTools.external.cornerstoneMath = cornerstoneMath;
 cornerstoneTools.init();
 ```
 
-The `cornerstoneTools.init();` call accepts a configuration object if you would like to deviate from default behaviors:
+The `cornerstoneTools.init();` call accepts a configuration object if you would like to deviate from default behaviors of `cornerstoneTool`'s `globalConfiguration`:
 
 ```js
 cornerstoneTools.init({
@@ -106,6 +106,25 @@ cornerstoneTools.init({
    */
   showSVGCursors: false,
 });
+```
+
+If you wish to change modules other than the `globalConfiguration` module, you may pass an array of named module configuration like so:
+
+```js
+cornerstoneTools.init([
+  {
+    moduleName: 'globalConfiguration',
+    configuration: {
+      showSVGCursors: true,
+    },
+  },
+  {
+    moduleName: 'segmentation',
+    configuration: {
+      outlineWidth: 2,
+    },
+  },
+]);
 ```
 
 You can go further and configure textStyle, toolStyle, toolColors, etc:

--- a/index.html
+++ b/index.html
@@ -166,7 +166,20 @@
 <script src="netlify-example/imageLoader.js"></script>
 
 <script>
-  cornerstoneTools.init({ showSVGCursors: true });
+  cornerstoneTools.init([
+    {
+      moduleName: 'globalConfiguration',
+      configuration: {
+        showSVGCursors: true
+      }
+    },
+    {
+      moduleName: 'segmentation',
+      configuration: {
+        outlineWidth: 2
+      }
+    }
+  ]);
   const imageIds = ['example://1', 'example://2', 'example://3'];
   const stack = {
     currentImageIdIndex: 0,

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -438,7 +438,7 @@
 
   // Segmentation Module API //
 
-  const { configuration, getters, setters } = cornerstoneTools.getModule(
+  const segmentationModule = cornerstoneTools.getModule(
     'segmentation'
   );
 
@@ -447,11 +447,11 @@
   function brushApiCall(opperation) {
     switch (opperation) {
       case 'next-segment':
-        setters.incrementActiveSegmentIndex(element);
+        segmentationModule.setters.incrementActiveSegmentIndex(element);
         cornerstone.updateImage(element);
         break;
       case 'previous-segment':
-        setters.decrementActiveSegmentIndex(element);
+        segmentationModule.setters.decrementActiveSegmentIndex(element);
         cornerstone.updateImage(element);
         break;
       case 'switch-labelmap':
@@ -461,7 +461,7 @@
           activeLabelmapIndex = 0;
         }
 
-        setters.activeLabelmapIndex(element, activeLabelmapIndex);
+        segmentationModule.setters.activeLabelmapIndex(element, activeLabelmapIndex);
 
         const label = document.getElementById('active-label-map-label');
         label.innerHTML = 'Active Labelmap: ' + activeLabelmapIndex;
@@ -471,7 +471,7 @@
         break;
 
       case 'toggle-segment-1':
-        const visible = setters.toggleSegmentVisibility(element, 1);
+        const visible = segmentationModule.setters.toggleSegmentVisibility(element, 1);
 
         console.log(visible);
 
@@ -483,7 +483,7 @@
         cornerstone.updateImage(element);
         break;
       case 'calculate-segment-1-stats':
-        getters.labelmapStats(element, 1).then(result => {
+        segmentationModule.getters.labelmapStats(element, 1).then(result => {
           const statsLabel = document.getElementById(
             'calculate-segment-1-stats-label'
           );
@@ -516,7 +516,7 @@
   const outlineDisplay = document.getElementById('display-outline');
 
   outlineDisplay.addEventListener('input', event => {
-    configuration.renderOutline = event.target.checked;
+    segmentationModule.configuration.renderOutline = event.target.checked;
     cornerstone.updateImage(element);
   });
 
@@ -524,7 +524,7 @@
   const fillDisplay = document.getElementById('display-fill');
 
   fillDisplay.addEventListener('input', event => {
-    configuration.renderFill = event.target.checked;
+    segmentationModule.configuration.renderFill = event.target.checked;
     cornerstone.updateImage(element);
   });
 
@@ -532,7 +532,7 @@
   const inactiveDisplay = document.getElementById('display-inactive');
 
   inactiveDisplay.addEventListener('input', event => {
-    configuration.shouldRenderInactiveLabelmaps = event.target.checked;
+    segmentationModule.configuration.shouldRenderInactiveLabelmaps = event.target.checked;
     cornerstone.updateImage(element);
   });
 
@@ -544,7 +544,7 @@
   alphaSlider.addEventListener('input', event => {
     const normalisedAlpha = event.target.value / 255.0;
 
-    configuration.fillAlpha = normalisedAlpha;
+    segmentationModule.configuration.fillAlpha = normalisedAlpha;
     cornerstone.updateImage(element);
   });
 
@@ -552,12 +552,12 @@
   const outlineAlphaSlider = document.getElementById('outline-alpha');
 
   outlineAlphaSlider.defaultValue = Math.floor(
-    configuration.outlineAlpha * 255
+    segmentationModule.configuration.outlineAlpha * 255
   );
   outlineAlphaSlider.addEventListener('input', event => {
     const normalisedAlpha = event.target.value / 255.0;
 
-    configuration.outlineAlpha = normalisedAlpha;
+    segmentationModule.configuration.outlineAlpha = normalisedAlpha;
     cornerstone.updateImage(element);
   });
 
@@ -565,12 +565,12 @@
   const inactiveAlphaSlider = document.getElementById('fill-alpha-inactive');
 
   inactiveAlphaSlider.defaultValue = Math.floor(
-    configuration.fillAlphaInactive * 255
+    segmentationModule.configuration.fillAlphaInactive * 255
   );
   inactiveAlphaSlider.addEventListener('input', event => {
     const normalisedAlpha = event.target.value / 255.0;
 
-    configuration.fillAlphaInactive = normalisedAlpha;
+    segmentationModule.configuration.fillAlphaInactive = normalisedAlpha;
     cornerstone.updateImage(element);
   });
 
@@ -580,12 +580,12 @@
   );
 
   inactiveOutlineAlphaSlider.defaultValue = Math.floor(
-    configuration.outlineAlphaInactive * 255
+    segmentationModule.configuration.outlineAlphaInactive * 255
   );
   inactiveOutlineAlphaSlider.addEventListener('input', event => {
     const normalisedAlpha = event.target.value / 255.0;
 
-    configuration.outlineAlphaInactive = normalisedAlpha;
+    segmentationModule.configuration.outlineAlphaInactive = normalisedAlpha;
     cornerstone.updateImage(element);
   });
 
@@ -637,11 +637,11 @@
 
   Mousetrap.bind(['command+z', 'ctrl+z'], function () {
     console.log('UNDO');
-    setters.undo(element)
+    segmentationModule.setters.undo(element)
   });
   Mousetrap.bind(['command+y', 'ctrl+y'], function () {
     console.log('REDO');
-    setters.redo(element)
+    segmentationModule.setters.redo(element)
   });
 </script>
 

--- a/src/eventDispatchers/imageRenderedEventDispatcher.js
+++ b/src/eventDispatchers/imageRenderedEventDispatcher.js
@@ -4,7 +4,6 @@ import onImageRenderedBrushEventHandler from '../eventListeners/onImageRenderedB
 import external from './../externalModules.js';
 
 const segmentationModule = getModule('segmentation');
-const segmentationConfiguration = segmentationModule.configuration;
 
 const onImageRendered = function(evt) {
   const eventData = evt.detail;
@@ -21,6 +20,8 @@ const onImageRendered = function(evt) {
 
   // Must be using stacks in order to use segmentation tools.
   const stackToolState = getToolState(element, 'stack');
+
+  const segmentationConfiguration = segmentationModule.configuration;
 
   if (
     stackToolState &&

--- a/src/eventListeners/internals/renderSegmentation.js
+++ b/src/eventListeners/internals/renderSegmentation.js
@@ -2,7 +2,7 @@ import { getModule } from '../../store/index.js';
 import renderSegmentationFill from './renderSegmentationFill';
 import renderSegmentationOutline from './renderSegmentationOutline';
 
-const { configuration } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 /**
  * Renders the segmentation based on the brush configuration and
@@ -50,6 +50,8 @@ export default function renderSegmentation(
  * @returns  {boolean} True if the segmentation should be filled.
  */
 function shouldRenderFill(isActiveLabelMap) {
+  const { configuration } = segmentationModule;
+
   return (
     configuration.renderFill &&
     ((isActiveLabelMap && configuration.fillAlpha !== 0) ||
@@ -65,6 +67,8 @@ function shouldRenderFill(isActiveLabelMap) {
  * @returns  {boolean} True if the segmentation should be outlined.
  */
 function shouldRenderOutline(isActiveLabelMap) {
+  const { configuration } = segmentationModule;
+
   return (
     configuration.renderOutline &&
     ((isActiveLabelMap && configuration.outlineAlpha !== 0) ||

--- a/src/eventListeners/internals/renderSegmentationFill.js
+++ b/src/eventListeners/internals/renderSegmentationFill.js
@@ -6,7 +6,7 @@ import {
 } from '../../drawing/index.js';
 import external from '../../externalModules';
 
-const { state, configuration } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 export default function renderSegmentationFill(
   evt,
@@ -31,6 +31,7 @@ export default function renderSegmentationFill(
  * @returns {HTMLCanvasElement}
  */
 export function getLabelmapCanvas(evt, labelmap3D, labelmap2D) {
+  const { state } = segmentationModule;
   const eventData = evt.detail;
   const { image } = eventData;
   const cols = image.width;
@@ -77,6 +78,7 @@ export function getLabelmapCanvas(evt, labelmap3D, labelmap2D) {
  * @returns {null}
  */
 export function renderFill(evt, labelmapCanvas, isActiveLabelMap) {
+  const { configuration } = segmentationModule;
   const eventData = evt.detail;
   const context = getNewContext(eventData.canvasContext.canvas);
 

--- a/src/eventListeners/internals/renderSegmentationOutline.js
+++ b/src/eventListeners/internals/renderSegmentationOutline.js
@@ -3,7 +3,7 @@ import external from '../../externalModules.js';
 import { getNewContext, draw, drawLines } from '../../drawing/index.js';
 import { disableLogger } from '../../index.js';
 
-const { state, configuration } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 export default function renderSegmentationOutline(
   evt,
@@ -12,6 +12,7 @@ export default function renderSegmentationOutline(
   labelmapIndex,
   isActiveLabelMap
 ) {
+  const { configuration } = segmentationModule;
   const outline = getOutline(
     evt,
     labelmap3D,
@@ -37,6 +38,7 @@ export function renderOutline(
   colorLUTIndex,
   isActiveLabelMap = true
 ) {
+  const { configuration, state } = segmentationModule;
   const eventData = evt.detail;
   const { element, canvasContext } = eventData;
 

--- a/src/eventListeners/onImageRenderedBrushEventHandler.js
+++ b/src/eventListeners/onImageRenderedBrushEventHandler.js
@@ -1,7 +1,7 @@
 import { getModule } from '../store/index.js';
 import renderSegmentation from './internals/renderSegmentation.js';
 
-const { configuration, getters } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 /**
  * Finds which segmentations need to be rendered based on the configuration and
@@ -13,6 +13,7 @@ const { configuration, getters } = getModule('segmentation');
 export default function(evt) {
   const eventData = evt.detail;
   const element = eventData.element;
+  const { configuration, getters } = segmentationModule;
 
   const {
     activeLabelmapIndex,

--- a/src/events.js
+++ b/src/events.js
@@ -212,6 +212,11 @@ const EVENTS = {
    *  @type {String}
    */
   LABELMAP_MODIFIED: 'cornersontetoolslabelmapmodified',
+
+  /**
+   *  @type {String}
+   */
+  CONFIGURATION_MODIFIED: 'cornersontetoolsconfigurationmodified',
 };
 
 export default EVENTS;

--- a/src/events.js
+++ b/src/events.js
@@ -212,11 +212,6 @@ const EVENTS = {
    *  @type {String}
    */
   LABELMAP_MODIFIED: 'cornersontetoolslabelmapmodified',
-
-  /**
-   *  @type {String}
-   */
-  CONFIGURATION_MODIFIED: 'cornersontetoolsconfigurationmodified',
 };
 
 export default EVENTS;

--- a/src/init.js
+++ b/src/init.js
@@ -12,21 +12,38 @@ import windowResizeHandler from './eventListeners/windowResizeHandler.js';
  * @method
  * @name init
  *
- * @param {Object} [configuration = {}] The global configuration to apply.
+ * @param {Object|Object[]} [defaultConfiguration = {}] The configuration to apply. Assumed globalConfiguration
+ * only one value, otherwise moduleName, configuration entires in an array.
  * @returns {Object} A configured CornerstoneTools instance with top level API members.
  */
-export default function(configuration = {}) {
+export default function(defaultConfiguration = {}) {
   _addCornerstoneEventListeners();
   _initModules();
 
-  // Apply global configuration
   const globalConfigurationModule = getModule('globalConfiguration');
 
-  globalConfigurationModule.configuration = Object.assign(
-    {},
-    globalConfigurationModule.configuration,
-    configuration
-  );
+  if (Array.isArray(defaultConfiguration)) {
+    defaultConfiguration.forEach(configurationEntry => {
+      const { moduleName, configuration } = configurationEntry;
+
+      const module = getModule(moduleName);
+
+      if (module) {
+        module.configuration = Object.assign(
+          {},
+          module.configuration,
+          configuration
+        );
+      }
+    });
+  } else {
+    // defaultConfiguration is an object, default to assigning it to globalConfiguration.
+    globalConfigurationModule.configuration = Object.assign(
+      {},
+      globalConfigurationModule.configuration,
+      defaultConfiguration
+    );
+  }
 
   if (globalConfigurationModule.configuration.autoResizeViewports) {
     windowResizeHandler.enable();

--- a/src/store/modules/cursorModule.js
+++ b/src/store/modules/cursorModule.js
@@ -1,3 +1,5 @@
+import external from '../../externalModules';
+
 const configuration = {
   iconSize: 16,
   viewBox: {
@@ -25,6 +27,7 @@ const getters = {
 };
 
 export default {
+  configuration,
   getters,
   setters,
 };

--- a/src/store/modules/segmentationModule/activeSegmentIndex.js
+++ b/src/store/modules/segmentationModule/activeSegmentIndex.js
@@ -1,7 +1,7 @@
 import getElement from './getElement';
 import { getToolState } from '../../../stateManagement/toolState.js';
 import state from './state';
-import configuration from './configuration';
+import { getModule } from '../../index.js';
 
 /**
  * Returns the `activeSegmentIndex` for the active `Labelmap3D` for the `BrushStackState` displayed on the element.
@@ -68,6 +68,8 @@ function setActiveSegmentIndex(elementOrEnabledElementUID, segmentIndex) {
   const activeLabelmapIndex = brushStackState.activeLabelmapIndex;
   const labelmap3D = brushStackState.labelmaps3D[activeLabelmapIndex];
 
+  const { configuration } = getModule('segmentation');
+
   if (segmentIndex <= 0) {
     segmentIndex = 1;
   } else if (segmentIndex > configuration.segmentsPerLabelmap) {
@@ -119,6 +121,7 @@ function decrementActiveSegmentIndex(elementOrEnabledElementUID) {
  * @returns {null}
  */
 function _changeActiveSegmentIndex(element, increaseOrDecrease = 'increase') {
+  const { configuration } = getModule('segmentation');
   const stackState = getToolState(element, 'stack');
   const stackData = stackState.data[0];
   const firstImageId = stackData.imageIds[0];

--- a/src/store/modules/segmentationModule/colorLUT.js
+++ b/src/store/modules/segmentationModule/colorLUT.js
@@ -83,15 +83,11 @@ export function getColorLUT(labelmap3DOrColorLUTIndex) {
 function _checkColorLUTLength(colorLUT, segmentsPerLabelmap) {
   if (colorLUT.length < segmentsPerLabelmap) {
     logger.warn(
-      `The provided colorLUT only provides ${
-        colorLUT.length
-      } labels, whereas segmentsPerLabelmap is set to ${segmentsPerLabelmap}. Autogenerating the rest.`
+      `The provided colorLUT only provides ${colorLUT.length} labels, whereas segmentsPerLabelmap is set to ${segmentsPerLabelmap}. Autogenerating the rest.`
     );
   } else if (colorLUT.length > segmentsPerLabelmap) {
     logger.warn(
-      `segmentsPerLabelmap is set to ${segmentsPerLabelmap}, and the provided colorLUT provides ${
-        colorLUT.length
-      }. Using the first ${segmentsPerLabelmap} colors from the LUT.`
+      `segmentsPerLabelmap is set to ${segmentsPerLabelmap}, and the provided colorLUT provides ${colorLUT.length}. Using the first ${segmentsPerLabelmap} colors from the LUT.`
     );
   }
 }

--- a/src/store/modules/segmentationModule/colorLUT.js
+++ b/src/store/modules/segmentationModule/colorLUT.js
@@ -1,7 +1,7 @@
 import external from '../../../externalModules';
 import { getLogger } from '../../../util/logger';
 import state from './state';
-import configuration from './configuration';
+import { getModule } from '../../index.js';
 
 const logger = getLogger('store:modules:segmentationModule:setColorLUT');
 
@@ -13,6 +13,7 @@ const logger = getLogger('store:modules:segmentationModule:setColorLUT');
  * @returns {null}
  */
 export default function setColorLUT(colorLUTIndex, colorLUT = []) {
+  const { configuration } = getModule('segmentation');
   const segmentsPerLabelmap = configuration.segmentsPerLabelmap;
 
   if (colorLUT) {
@@ -82,11 +83,15 @@ export function getColorLUT(labelmap3DOrColorLUTIndex) {
 function _checkColorLUTLength(colorLUT, segmentsPerLabelmap) {
   if (colorLUT.length < segmentsPerLabelmap) {
     logger.warn(
-      `The provided colorLUT only provides ${colorLUT.length} labels, whereas segmentsPerLabelmap is set to ${segmentsPerLabelmap}. Autogenerating the rest.`
+      `The provided colorLUT only provides ${
+        colorLUT.length
+      } labels, whereas segmentsPerLabelmap is set to ${segmentsPerLabelmap}. Autogenerating the rest.`
     );
   } else if (colorLUT.length > segmentsPerLabelmap) {
     logger.warn(
-      `segmentsPerLabelmap is set to ${segmentsPerLabelmap}, and the provided colorLUT provides ${colorLUT.length}. Using the first ${segmentsPerLabelmap} colors from the LUT.`
+      `segmentsPerLabelmap is set to ${segmentsPerLabelmap}, and the provided colorLUT provides ${
+        colorLUT.length
+      }. Using the first ${segmentsPerLabelmap} colors from the LUT.`
     );
   }
 }

--- a/src/store/modules/segmentationModule/defaultConfiguration.js
+++ b/src/store/modules/segmentationModule/defaultConfiguration.js
@@ -1,5 +1,5 @@
 // Segmentation module configuration.
-const configuration = {
+const defaultConfiguration = {
   renderOutline: true,
   renderFill: true,
   shouldRenderInactiveLabelmaps: true,
@@ -15,4 +15,4 @@ const configuration = {
   storeHistory: true,
 };
 
-export default configuration;
+export default defaultConfiguration;

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -36,8 +36,9 @@ import getSegmentsOnPixelData from './getSegmentsOnPixeldata';
 import deleteSegment from './deleteSegment';
 
 import state from './state';
-import configuration from './configuration';
+import configuration from './defaultConfiguration';
 import { pushState, undo, redo } from './history';
+import setRadius from './setRadius';
 
 /**
  * A map of `firstImageId` to associated `BrushStackState`, where
@@ -127,12 +128,7 @@ export default {
     colorLUTIndexForLabelmap3D: setColorLUTIndexForLabelmap3D,
     colorForSegmentIndexOfColorLUT: setColorForSegmentIndexOfColorLUT,
     activeLabelmapIndex: setActiveLabelmapIndex,
-    radius: newRadius => {
-      configuration.radius = Math.min(
-        Math.max(newRadius, configuration.minRadius),
-        configuration.maxRadius
-      );
-    },
+    radius: setRadius,
     pushState,
     undo,
     redo,

--- a/src/store/modules/segmentationModule/setLabelmap3D.js
+++ b/src/store/modules/segmentationModule/setLabelmap3D.js
@@ -2,7 +2,6 @@ import getElement from './getElement';
 import { getToolState } from '../../../stateManagement/toolState.js';
 import state from './state';
 import getSegmentsOnPixelData from './getSegmentsOnPixeldata';
-import external from '../../../externalModules';
 import { triggerLabelmapModifiedEvent } from '../../../util/segmentation';
 
 /**

--- a/src/store/modules/segmentationModule/setRadius.js
+++ b/src/store/modules/segmentationModule/setRadius.js
@@ -1,0 +1,10 @@
+import { getModule } from '../../index';
+
+export default function setRadius(newRadius) {
+  const { configuration } = getModule('segmentation');
+
+  configuration.radius = Math.min(
+    Math.max(newRadius, configuration.minRadius),
+    configuration.maxRadius
+  );
+}

--- a/src/tools/base/BaseBrushTool.js
+++ b/src/tools/base/BaseBrushTool.js
@@ -8,7 +8,7 @@ import {
   triggerLabelmapModifiedEvent,
 } from '../../util/segmentation';
 
-const { configuration, getters, setters } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 /**
  * @abstract
@@ -118,6 +118,7 @@ class BaseBrushTool extends BaseTool {
   _startPainting(evt) {
     const eventData = evt.detail;
     const element = eventData.element;
+    const { configuration, getters } = segmentationModule;
 
     const {
       labelmap2D,
@@ -153,6 +154,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   _endPainting(evt) {
+    const { configuration, setters } = segmentationModule;
     const { labelmap2D, currentImageIdIndex } = this.paintEventData;
 
     // Grab the labels on the slice.
@@ -319,6 +321,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   increaseBrushSize() {
+    const { configuration, setters } = segmentationModule;
     const oldRadius = configuration.radius;
     let newRadius = Math.floor(oldRadius * 1.2);
 
@@ -339,6 +342,7 @@ class BaseBrushTool extends BaseTool {
    * @returns {void}
    */
   decreaseBrushSize() {
+    const { configuration, setters } = segmentationModule;
     const oldRadius = configuration.radius;
     const newRadius = Math.floor(oldRadius * 0.8);
 

--- a/src/tools/segmentation/BrushTool.js
+++ b/src/tools/segmentation/BrushTool.js
@@ -6,7 +6,7 @@ import { getLogger } from '../../util/logger.js';
 
 const logger = getLogger('tools:BrushTool');
 
-const { configuration } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 /**
  * @public
@@ -37,6 +37,7 @@ export default class BrushTool extends BaseBrushTool {
    * @returns {void}
    */
   _paint(evt) {
+    const { configuration } = segmentationModule;
     const eventData = evt.detail;
     const element = eventData.element;
     const { rows, columns } = eventData.image;

--- a/src/tools/segmentation/SphericalBrushTool.js
+++ b/src/tools/segmentation/SphericalBrushTool.js
@@ -12,7 +12,7 @@ import { getDiffBetweenPixelData } from '../../util/segmentation';
 
 const logger = getLogger('tools:SphericalBrushTool');
 
-const { getters, setters, configuration } = getModule('segmentation');
+const segmentationModule = getModule('segmentation');
 
 /**
  * @public
@@ -44,6 +44,7 @@ export default class SphericalBrushTool extends BaseBrushTool {
    * @returns {void}
    */
   _startPainting(evt) {
+    const { configuration, getters } = segmentationModule;
     const eventData = evt.detail;
     const { element, image } = eventData;
     const { cornerstone } = external;
@@ -137,6 +138,7 @@ export default class SphericalBrushTool extends BaseBrushTool {
    * @returns {void}
    */
   _paint(evt) {
+    const { getters } = segmentationModule;
     const eventData = evt.detail;
     const element = eventData.element;
     const image = eventData.image;
@@ -290,6 +292,7 @@ export default class SphericalBrushTool extends BaseBrushTool {
   _endPainting(evt) {
     const { labelmap3D, imagesInRange } = this.paintEventData;
     const operations = [];
+    const { configuration, setters } = segmentationModule;
 
     for (let i = 0; i < imagesInRange.length; i++) {
       const { imageIdIndex } = imagesInRange[i];


### PR DESCRIPTION
Allows an app to pass an array of configuration to `cornerstoneTools` on `init()`.