### PR TITLE
fix: The RotateTool does not work on mobile devices.

### DIFF
--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -50,11 +50,15 @@ export default class RotateTool extends BaseTool {
 function defaultStrategy(evt) {
   const eventData = evt.detail;
   const { element, viewport } = eventData;
-  const initialRotation = viewport.initialRotation;
+  const initialRotation = viewport.initialRotation ? viewport.initialRotation : 0;
 
   // Calculate the center of the image
   const rect = element.getBoundingClientRect(element);
   const { clientWidth: width, clientHeight: height } = element;
+
+  if (!eventData.startPoints) {
+    eventData.startPoints = eventData.currentPoints
+  }
 
   const initialPoints = {
     x: eventData.startPoints.client.x,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: The RotateTool does not work on mobile devices.


* **What is the current behavior?** (You can also link to an open issue here)
The RotateTool does not work on mobile devices.  It will throw an error: "Uncaught TypeError: Cannot read property 'client' of undefined". And viewport.initialRotation is undefined.


* **What is the new behavior (if this is a feature change)?**
The RotateTool works fine on mobile devices.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
I modified function defaultStrategy(evt) in RotateTool.js.