### PR TITLE
Trigger modified after getText and textChange callbacks

### DIFF
--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -263,6 +263,12 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
 
             measurementData.active = false;
             external.cornerstone.updateImage(element);
+
+            triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
+              toolType: this.name,
+              element,
+              measurementData,
+            });
           }, evt.detail);
         }
         external.cornerstone.updateImage(element);
@@ -296,6 +302,7 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
       ) {
         data.active = true;
         external.cornerstone.updateImage(element);
+
         // Allow relabelling via a callback
         this.configuration.changeTextCallback(
           data,
@@ -312,15 +319,21 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     }
   }
 
-  _doneChangingTextCallback(element, data, updatedText, deleteTool) {
+  _doneChangingTextCallback(element, measurementData, updatedText, deleteTool) {
     if (deleteTool === true) {
-      removeToolState(element, this.name, data);
+      removeToolState(element, this.name, measurementData);
     } else {
-      data.text = updatedText;
+      measurementData.text = updatedText;
     }
 
-    data.active = false;
+    measurementData.active = false;
     external.cornerstone.updateImage(element);
+
+    triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
+      toolType: this.name,
+      element,
+      measurementData,
+    });
   }
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfils these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behaviour?** (You can also link to an open issue here)
Currently, the annotation label only updates in the measurement table if the user intentionally changes the position of the annotation to force a modified event to be triggered causing the table to update with the correct new value.

* **What is the new behaviour (if this is a feature change)?**
Now those events are being triggered, updating the table properly if the annotation has changed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.

* **Other information**:
