### PR TITLE
fix #1123 latest version debug mode crash

### DIFF
--- a/src/util/debugLib/index.js
+++ b/src/util/debugLib/index.js
@@ -156,7 +156,7 @@ function formatArgs(args) {
     this.namespace +
     (this.useColors ? ' %c' : ' ') +
     args[0] +
-    (this.useColors ? '%c ' : ' ')}+${debugLib.humanize(this.diff)}`;
+    (this.useColors ? '%c ' : ' ')}+${setupDebug.humanize(this.diff)}`;
 
   if (!this.useColors) {
     return;
@@ -195,7 +195,7 @@ function formatArgs(args) {
  * @api public
  */
 
-debugLib.log = console.debug || console.log || function() {};
+debugLib.log = console.log || function() {};
 /**
  * Save `namespaces`.
  *


### PR DESCRIPTION
Developer tools in Google chrome.Logging level support Verbose/Info/Warnings/Errors.

* **Please check if the PR fulfills these requirements**
- [ X ] The commit message follows our guidelines
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#1123 


* **What is the new behavior (if this is a feature change)?**
N/A


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A


* **Other information**:
i still wonder why remove lib debug. @dannyrb  this can also be solved by use old way. import debugLib from 'debug'


