### PR TITLE
feat(imageIdSpecificStateManager.js): Methods for managing toolState via imageId

### DIFF
--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -34,20 +34,23 @@ function newImageIdSpecificToolStateManager() {
 
   // Here we add tool state, this is done by tools as well
   // As modules that restore saved state
-  function addImageIdSpecificToolState(element, toolType, data) {
+  function addElementToolState(element, toolType, data) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
     // If we don't have an image for this element exit early
     if (!enabledElement.image) {
       return;
     }
+    addImageIdToolState(enabledElement.image.imageId, toolType, data);
+  }
 
+  function addImageIdToolState(imageId, toolType, data) {
     // If we don't have any tool state for this imageId, add an empty object
-    if (toolState.hasOwnProperty(enabledElement.image.imageId) === false) {
-      toolState[enabledElement.image.imageId] = {};
+    if (toolState.hasOwnProperty(imageId) === false) {
+      toolState[imageId] = {};
     }
 
-    const imageIdToolState = toolState[enabledElement.image.imageId];
+    const imageIdToolState = toolState[imageId];
 
     // If we don't have tool state for this type of tool, add an empty object
     if (imageIdToolState.hasOwnProperty(toolType) === false) {
@@ -62,49 +65,60 @@ function newImageIdSpecificToolStateManager() {
     toolData.data.push(data);
   }
 
-  // Here you can get state - used by tools as well as modules
-  // That save state persistently
-  function getImageIdSpecificToolState(element, toolType) {
+  function getElementToolState(element, toolType) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
-    // If we don't have any tool state for this imageId, return undefined
 
-    if (
-      !enabledElement.image ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
+    // If the element does not have an image return undefined.
+    if (!enabledElement.image) {
       return;
     }
 
-    const imageIdToolState = toolState[enabledElement.image.imageId];
+    return getImageIdToolState(enabledElement.image.imageId, toolType);
+  }
+
+  // Here you can get state - used by tools as well as modules
+  // That save state persistently
+  function getImageIdToolState(imageId, toolType) {
+    // If we don't have any tool state for this imageId, return undefined
+    if (toolState.hasOwnProperty(imageId) === false) {
+      return;
+    }
+
+    const imageIdToolState = toolState[imageId];
 
     // If we don't have tool state for this type of tool, return undefined
     if (imageIdToolState.hasOwnProperty(toolType) === false) {
       return;
     }
 
-    const toolData = imageIdToolState[toolType];
-
-    return toolData;
+    return imageIdToolState[toolType];
   }
 
   // Clears all tool data from this toolStateManager.
-  function clearImageIdSpecificToolStateManager(element) {
+  function clearElementToolState(element) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
-    if (
-      !enabledElement.image ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
+    if (!enabledElement.image) {
+      return;
+    }
+    clearImageIdToolState(enabledElement.imageId);
+  }
+
+  function clearImageIdToolState(imageId) {
+    if (toolState.hasOwnProperty(imageId) === false) {
       return;
     }
 
-    delete toolState[enabledElement.image.imageId];
+    delete toolState[imageId];
   }
 
   return {
-    get: getImageIdSpecificToolState,
-    add: addImageIdSpecificToolState,
-    clear: clearImageIdSpecificToolStateManager,
+    get: getElementToolState,
+    add: addElementToolState,
+    clear: clearElementToolState,
+    getImageIdToolState,
+    addImageIdToolState,
+    clearImageIdToolState,
     saveImageIdToolState,
     restoreImageIdToolState,
     saveToolState,


### PR DESCRIPTION
Expose [get|add|clear]ImageIdToolstate methods which allow managing imageId specific toolState without needing an element with the image loaded.

#1150

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

3 new methods on the `ImageIdSpecificToolStateManager` for managing toolState without needing an element.

```
    getImageIdToolState,
    addImageIdToolState,
    clearImageIdToolState,
```

The signature for these matches that of the exising `add, get, clear` methods except that the first argument is an `imageId` instead of an element.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
