### PR TITLE
fix: pointInFreehand calculation error(cornerstonejs#1160)

### DIFF
--- a/src/util/freehand/pointInFreehand.js
+++ b/src/util/freehand/pointInFreehand.js
@@ -78,7 +78,10 @@ function isLineRightOfPoint(point, lp1, lp2) {
 
   // If the lp1.x and lp2.x enclose point.x check gradient of line and see if
   // Point is above or below the line to calculate if it inside.
-  if (Math.sign(lPointY.gradient) * point.y > lPointY.value) {
+  if (
+    Math.sign(lPointY.gradient) * point.y >
+    Math.sign(lPointY.gradient) * lPointY.value
+  ) {
     return true;
   }
 
@@ -99,7 +102,7 @@ function isLineRightOfPoint(point, lp1, lp2) {
 function lineSegmentAtPoint(point, lp1, lp2) {
   const dydx = (lp2.y - lp1.y) / (lp2.x - lp1.x);
   const fx = {
-    value: lp1.x + dydx * (point.x - lp1.x),
+    value: lp1.y + dydx * (point.x - lp1.x),
     gradient: dydx,
   };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#1160 


* **What is the new behavior (if this is a feature change)?**
N/A


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A


* **Other information**:
The pointInFreehand has a calculation error in the lineSegmentAtPoint and the isLineRightOfPoint;
> ```javascript
> /**
>  * Returns the y value of the line segment at the x value of the point.
>  * @private
>  * @method
>  * @name lineSegmentAtPoint
>  *
>  * @param {Object} point The point being queried.
>  * @param {Object} lp1 The first point of the line segment.
>  * @param {Object} lp2 The second point of the line segment.
>  * @returns {Object} An object containing the y value as well as the gradient of the line segment.
>  */ 
> function lineSegmentAtPoint(point, lp1, lp2) {
>   const dydx = (lp2.y - lp1.y) / (lp2.x - lp1.x);
>   const fx = {
>     value: lp1.x + dydx * (point.x - lp1.x),
>     gradient: dydx,
>   };
> 
>   return fx;
> }
> ```

After calculation，find errors quickly in `fx.value`. The correct answer is `lp1.y + dydx * (point.x - lp1.x)`

Then get the correct answer.
But I found a calculation error again when it judged whether the line segment is to the right of the point.

> ```javascript
>   const lPointY = lineSegmentAtPoint(point, lp1, lp2);
> 
>   // If the lp1.x and lp2.x enclose point.x check gradient of line and see if
>   // Point is above or below the line to calculate if it inside.
>   if (Math.sign(lPointY.gradient) * point.y > lPointY.value) {
>     return true;
>   }
> ```

The correct answer is
```javascript
  const lPointY = lineSegmentAtPoint(point, lp1, lp2);

  if (Math.sign(lPointY.gradient)  > 0 && point.y > lPointY.value) {
    return true;
  }
  if (Math.sign(lPointY.gradient)  < 0 && point.y < lPointY.value) {
    return true;
  }
```
Can also be written as
```javascript
  const lPointY = lineSegmentAtPoint(point, lp1, lp2);

  if (Math.sign(lPointY.gradient)  * point.y > Math.sign(lPointY.gradient)  * lPointY.value) {
    return true;
  }
```
