### PR TITLE
Optional Float32 segments

### DIFF
--- a/docs/latest/modules/segmentation.md
+++ b/docs/latest/modules/segmentation.md
@@ -26,9 +26,9 @@ Each `Labelmap3D` object can contain multiple non-overlapping segments. To use h
 
 A `Labelmap3D` is a single, non-overlapping labelmap with the following properties:
 
-- `buffer`: An `ArrayBuffer` where the labels for each voxel are stored sequentially in increasing x, y, z. It has the same orientation as the stack, so increasing `z` is increasing `imageIdIndex` in the stack. Each label is stored as 2 bytes, allowing for up to `65535` unique segments (+ 0 being empty/unlabelled).
+- `buffer`: An `ArrayBuffer` where the labels for each voxel are stored sequentially in increasing x, y, z. It has the same orientation as the stack, so increasing `z` is increasing `imageIdIndex` in the stack. By default, each label is stored as 2 bytes (encoded as Uint16Array), allowing for up to `65535` unique segments (+ 0 being empty/unlabelled). By setting the segmentation configuration property `arrayType` to `Float32Array` you can instead store the labelmap as a format more harmonious with `vtkjs`. `vtkjs` has to convert non-`Float32Array`s when generating textures to pass to the GPU, and this is very costly. If you are using vtkjs in your application its highly recommended to use `Float32Array`s for segmentations for decreased texture building times. This is especially noticable when using the `vtkjs` paint widget, for example.
 - `labelmaps2D`: An array of `labelmap2D` views on the `buffer`, indexed by in-stack `imageIdIndex`. The `labelmaps2D` array is initially empty, and each view is defined only if data is added to it, and should be removed if set empty (all zero labels). This makes it easy for the segmentation renderer, I/O libraries such as [`dcmjs`](https://github.com/dcmjs-org/dcmjs), and tools to localise the extent of segments without having to scan through every label in the stack.
-- `metadata`: An array of metadata objects per segment. Metadata is optional and its form is application specific. You may want a simple name for your label in your UI, or you may want more complex objects referencing standard libraries for anatomical region. The metadata is not used internally for `cornerstoneTools`, but acts a logical place to keep such data for your application.
+- `metadata`: An array of metadata objects per segment. Metadata is optional and its form is application specific. You may want a simple name for your label in your UI, or you may want more complex objects referencing standard libraries for anatomical region. The metadata is not used internally by `cornerstoneTools`, but acts an optional logical place to keep such data for your application.
 - `activeSegmentIndex`: The index of the segment to be created/modified when using `BaseBrushTool`s or segmentation tools, when th labelmap is active.
 - `colorLUTIndex`: The index of the colorLUT to use when rendering the labelmap.
 - `segmentsHidden`: An array of segments to hide from the canvas. Initially empty to save space, set an index to `true` to hide the corresponding segment.
@@ -37,8 +37,8 @@ A `Labelmap3D` is a single, non-overlapping labelmap with the following properti
 
 A `Labelmap2D` is a 2D view of one frame of the segmentation, it is the object primarily interacted with from the cornerstone canvas, and has the following properties:
 
-- `pixelData`: a `Uint16Array` view of a portion of the parent `Labelmap3D`'s `buffer`, corresponding to the frame.
-- `segmentsOnLabelmap`: An array of segments present in the `pixelData`. Whenever a tool or external manipulates the `pixelData` viewed by th `Labelmap2D`, this list should be updated. This is generally very cheap to do on the fly, e.g. after a scissor action or after a full brush stroke, but speeds up IO dramatically when compressing data to DICOMSEG, for instance, as you can work out how much memory needs to be allocated with very simple checks.
+- `pixelData`: a `Uint16Array` or `Float32Array` view of a portion of the parent `Labelmap3D`'s `buffer`, corresponding to the frame. Array type depends on the segmentation module's `arrayType` setting.
+- `segmentsOnLabelmap`: An array of segments present in the `pixelData`. Whenever a tool or external manipulates the `pixelData` viewed by the `Labelmap2D`, this list should be updated. This is generally very cheap to do on the fly, e.g. after a scissor action or after a full brush stroke, but speeds up IO dramatically when compressing data to DICOMSEG, for instance, as you can work out how much memory needs to be allocated with very simple checks.
 
 ### Usage within cornerstoneTools
 

--- a/src/store/modules/segmentationModule/addLabelmap2D.js
+++ b/src/store/modules/segmentationModule/addLabelmap2D.js
@@ -1,3 +1,8 @@
+import ARRAY_TYPES from './arrayTypes';
+import { getModule } from '../../index.js';
+
+const { UINT_16_ARRAY, FLOAT_32_ARRAY } = ARRAY_TYPES;
+
 /**
  * Adds a `Labelmap2D` view of one frame of a `Labelmap3D`.
  *
@@ -15,14 +20,34 @@ export default function addLabelmap2D(
   rows,
   columns
 ) {
+  const { configuration } = getModule('segmentation');
   const sliceLength = rows * columns;
-  const byteOffset = sliceLength * 2 * imageIdIndex; // 2 bytes/pixel
 
-  const pixelData = new Uint16Array(
-    brushStackState.labelmaps3D[labelmapIndex].buffer,
-    byteOffset,
-    sliceLength
-  );
+  const elementOffset = sliceLength * imageIdIndex;
+
+  let pixelData;
+
+  switch (configuration.arrayType) {
+    case UINT_16_ARRAY:
+      pixelData = new Uint16Array(
+        brushStackState.labelmaps3D[labelmapIndex].buffer,
+        elementOffset * 2, // 2 bytes/voxel
+        sliceLength
+      );
+
+      break;
+
+    case FLOAT_32_ARRAY:
+      pixelData = new Float32Array(
+        brushStackState.labelmaps3D[labelmapIndex].buffer,
+        elementOffset * 4, // 4 bytes/voxel
+        sliceLength
+      );
+      break;
+
+    default:
+      throw new Error(`Unsupported Array Type ${configuration.arrayType}`);
+  }
 
   brushStackState.labelmaps3D[labelmapIndex].labelmaps2D[imageIdIndex] = {
     pixelData,

--- a/src/store/modules/segmentationModule/addLabelmap3D.js
+++ b/src/store/modules/segmentationModule/addLabelmap3D.js
@@ -1,3 +1,8 @@
+import ARRAY_TYPES from './arrayTypes';
+import { getModule } from '../../index.js';
+
+const { UINT_16_ARRAY, FLOAT_32_ARRAY } = ARRAY_TYPES;
+
 /**
  * AddLabelmap3D - Adds a `Labelmap3D` object to the `BrushStackState` object.
  *
@@ -7,9 +12,26 @@
  * @returns {null}
  */
 export default function addLabelmap3D(brushStackState, labelmapIndex, size) {
-  // Buffer size is multiplied by 2 as we are using 2 bytes/voxel for 65536 segments.
+  const { configuration } = getModule('segmentation');
+  let bytesPerVoxel;
+
+  switch (configuration.arrayType) {
+    case UINT_16_ARRAY:
+      bytesPerVoxel = 2;
+
+      break;
+
+    case FLOAT_32_ARRAY:
+      bytesPerVoxel = 4;
+      break;
+
+    default:
+      throw new Error(`Unsupported Array Type ${configuration.arrayType}`);
+  }
+
+  // Buffer size is multiplied by bytesPerVoxel to allocate enough space.
   brushStackState.labelmaps3D[labelmapIndex] = {
-    buffer: new ArrayBuffer(size * 2),
+    buffer: new ArrayBuffer(size * bytesPerVoxel),
     labelmaps2D: [],
     metadata: [],
     activeSegmentIndex: 1,

--- a/src/store/modules/segmentationModule/arrayTypes.js
+++ b/src/store/modules/segmentationModule/arrayTypes.js
@@ -1,0 +1,6 @@
+const ARRAY_TYPES = {
+  UINT_16_ARRAY: 0,
+  FLOAT_32_ARRAY: 1,
+};
+
+export default ARRAY_TYPES;

--- a/src/store/modules/segmentationModule/colorLUT.js
+++ b/src/store/modules/segmentationModule/colorLUT.js
@@ -1,4 +1,3 @@
-import external from '../../../externalModules';
 import { getLogger } from '../../../util/logger';
 import state from './state';
 import { getModule } from '../../index.js';

--- a/src/store/modules/segmentationModule/defaultConfiguration.js
+++ b/src/store/modules/segmentationModule/defaultConfiguration.js
@@ -1,3 +1,7 @@
+import ARRAY_TYPES from './arrayTypes';
+
+const { UINT_16_ARRAY } = ARRAY_TYPES;
+
 // Segmentation module configuration.
 const defaultConfiguration = {
   renderOutline: true,
@@ -6,13 +10,14 @@ const defaultConfiguration = {
   radius: 10,
   minRadius: 1,
   maxRadius: 50,
-  segmentsPerLabelmap: 65535, // Max is 65535 due to using 16-bit Unsigned ints.
   fillAlpha: 0.2,
   fillAlphaInactive: 0.1,
   outlineAlpha: 0.7,
   outlineAlphaInactive: 0.35,
   outlineWidth: 3,
   storeHistory: true,
+  segmentsPerLabelmap: 65535, // Max is 65535 due to using 16-bit Unsigned ints.
+  arrayType: UINT_16_ARRAY,
 };
 
 export default defaultConfiguration;

--- a/src/store/modules/segmentationModule/getLabelmapBuffers.js
+++ b/src/store/modules/segmentationModule/getLabelmapBuffers.js
@@ -2,6 +2,10 @@ import getElement from './getElement';
 import { getToolState } from '../../../stateManagement/toolState.js';
 import getLabelmaps3D from './getLabelmaps3D';
 import state from './state';
+import ARRAY_TYPES from './arrayTypes';
+import { getModule } from '../../index.js';
+
+const { UINT_16_ARRAY, FLOAT_32_ARRAY } = ARRAY_TYPES;
 
 /**
  * GetLabelmapBuffers - Returns the `buffer` of each `Labelmap3D` associated
@@ -28,6 +32,27 @@ function getLabelmapBuffers(elementOrEnabledElementUID, labelmapIndex) {
     return [];
   }
 
+  const { configuration } = getModule('segmentation');
+
+  let type;
+  let bytesPerVoxel;
+
+  switch (configuration.arrayType) {
+    case UINT_16_ARRAY:
+      type = 'Uint16Array';
+      bytesPerVoxel = '2';
+
+      break;
+
+    case FLOAT_32_ARRAY:
+      type = 'Float32Array';
+      bytesPerVoxel = '4';
+      break;
+
+    default:
+      throw new Error(`Unsupported Array Type ${configuration.arrayType}`);
+  }
+
   const colorLutTables = state.colorLutTables;
 
   if (labelmapIndex !== undefined) {
@@ -36,7 +61,8 @@ function getLabelmapBuffers(elementOrEnabledElementUID, labelmapIndex) {
     if (labelmap3D) {
       return {
         labelmapIndex,
-        bytesPerVoxel: 2,
+        bytesPerVoxel,
+        type,
         buffer: labelmap3D.buffer,
         colorLUT: colorLutTables[labelmap3D.colorLUTIndex],
       };

--- a/src/store/modules/segmentationModule/getSegmentsOnPixeldata.js
+++ b/src/store/modules/segmentationModule/getSegmentsOnPixeldata.js
@@ -1,6 +1,6 @@
 /**
  * Returns an array of the segment indicies present on the `pixelData`.
- * @param  {UInt16Array} pixelData The pixel data array.
+ * @param  {UInt16Array|Float32Array} pixelData The pixel data array.
  */
 export default function getSegmentsOnPixelData(pixelData) {
   const segmentSet = new Set(pixelData);

--- a/src/store/modules/segmentationModule/index.js
+++ b/src/store/modules/segmentationModule/index.js
@@ -58,7 +58,7 @@ import setRadius from './setRadius';
  * A 3D labelmap object which stores the labelmap data for an entire stack of cornerstone images.
  *
  * @typedef {Object} Labelmap3D An object defining a 3D labelmap.
- * @property {ArrayBuffer}  buffer An array buffer to store the pixel data of the `Labelmap3D` (2 bytes/voxel).
+ * @property {ArrayBuffer}  buffer An array buffer to store the pixel data of the `Labelmap3D` (2 bytes/voxel for Uint16 and 4 bytes/voxel for Float32).
  * @property {Labelmap2D[]} labelmaps2D array of `labelmap2D` views on the `buffer`, indexed by in-stack
  *                          image positions.
  * @property {Object[]} metadata An array of metadata per segment. Metadata is optional and its form is
@@ -76,7 +76,7 @@ import setRadius from './setRadius';
  * A 2D labelmap object which accesses only one frame's worth of data from its parent `Labelmap3D`.
  *
  * @typedef {Object} Labelmap2D An object defining a 2D view on a section of a `Labelmap3D`'s `buffer`.
- * @property {Uint16Array} pixelData A 2D view on a section of the parent `Labelmap3D`'s `buffer`.
+ * @property {Uint16Array|Float32Array} pixelData A 2D view on a section of the parent `Labelmap3D`'s `buffer`.
  * @property {number[]} segmentsOnLabelmap An array of segments present in the `pixelData`.
  */
 

--- a/src/tools/segmentation/strategies/correction.js
+++ b/src/tools/segmentation/strategies/correction.js
@@ -63,7 +63,7 @@ export default function correction(evt, operationData) {
  * Snap the freehand points to the labelmap grid and attach a label for each node.
  *
  * @param  {Object[]} points An array of points drawn by the user.
- * @param  {UInt16Array} pixelData The 2D labelmap.
+ * @param  {UInt16Array|Float32Array} pixelData The 2D labelmap.
  * @param  {Object} evt The cornerstone event.
  * @returns {Object[]}
  */
@@ -142,8 +142,8 @@ function checkIfSimpleScissorOperation(nodes, segmentIndex) {
  * The algorithm is described in full length in Tobias Heimann's diploma thesis (MBI Technical Report 145, p. 37 - 40).
  *
  * @param  {Object} operation The operation.
- * @param  {UInt16Array} pixelData The 2D labelmap.
- * @param  {UInt16Array} workingLabelMap A copy of the labelmap for processing purposes.
+ * @param  {UInt16Array|Float32Array} pixelData The 2D labelmap.
+ * @param  {UInt16Array|Float32Array} workingLabelMap A copy of the labelmap for processing purposes.
  * @param  {number} segmentIndex The label of the tool being used.
  * @param  {Object} evt The cornerstone event.
  */


### PR DESCRIPTION
Optional Float32Array storage for segmentations.

By setting the segmentation configuration property `arrayType` to `Float32Array` you can instead store the labelmap as a format more harmonious with `vtkjs`. `vtkjs` has to convert non-`Float32Array`s when generating textures to pass to the GPU, and this is very costly. If you are using vtkjs in your application its highly recommended to use `Float32Array`s for segmentations for decreased texture building times. 