### PR TITLE
fix: OverlayTool now considers overlay initial position

### DIFF
--- a/src/tools/OverlayTool.js
+++ b/src/tools/OverlayTool.js
@@ -104,7 +104,7 @@ export default class OverlayTool extends BaseTool {
       }
 
       // Draw the overlay layer onto the canvas
-      canvasContext.drawImage(layerCanvas, 0, 0);
+      canvasContext.drawImage(layerCanvas, overlay.x, overlay.y);
     });
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The initial position for DICOM overlays is now considered in OverlayTool.


* **What is the current behavior?** (You can also link to an open issue here)
The origin of DICOM overlays from the overlayPlaneModule was fixed to 0,0.


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
