### PR TITLE
fix: Stop throwing errors when calling removeToolState if toolData or…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,8 @@
   "[markdown]": {
     "editor.wordWrap": "wordWrapColumn",
     "editor.wordWrapColumn": 80
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
   }
 }

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -80,6 +80,11 @@ function getToolState(element, toolType) {
 function removeToolState(element, toolType, data) {
   const toolStateManager = getElementToolStateManager(element);
   const toolData = toolStateManager.get(element, toolType);
+
+  if (!toolData || !toolData.data || !toolData.data.length) {
+    return;
+  }
+
   // Find this tool data
   let indexOfData = -1;
 

--- a/src/tools/OverlayTool.js
+++ b/src/tools/OverlayTool.js
@@ -104,10 +104,12 @@ export default class OverlayTool extends BaseTool {
       }
 
       // Guard against non-number values
-      const overlayX = (!isNaN(parseFloat(overlay.x)) && isFinite(overlay.x)) ? overlay.x : 0;
-      const overlayY = (!isNaN(parseFloat(overlay.y)) && isFinite(overlay.y)) ? overlay.y : 0; 
-
+      const overlayX =
+        !isNaN(parseFloat(overlay.x)) && isFinite(overlay.x) ? overlay.x : 0;
+      const overlayY =
+        !isNaN(parseFloat(overlay.y)) && isFinite(overlay.y) ? overlay.y : 0;
       // Draw the overlay layer onto the canvas
+
       canvasContext.drawImage(layerCanvas, overlayX, overlayY);
     });
   }


### PR DESCRIPTION
… toolData.data do not exist

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It prevents errors if removeToolState is called when no toolData is present.


* **What is the current behavior?** (You can also link to an open issue here)
An error will be thrown when toolData.data is accessed, but toolData is undefined.


* **What is the new behavior (if this is a feature change)?**
It will exit early, avoiding the issue.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
