### PR TITLE
Event cancelling for manipulators

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -4,6 +4,7 @@ import { addToolState } from '../../stateManagement/toolState.js';
 import { moveHandle, moveNewHandle } from '../../manipulators/index.js';
 import { getLogger } from '../../util/logger.js';
 import triggerEvent from '../../util/triggerEvent.js';
+import uuidv4 from '../../util/uuidv4.js';
 
 const logger = getLogger('eventDispatchers:mouseEventHandlers');
 
@@ -21,6 +22,8 @@ export default function(evt, tool) {
   }
 
   // Associate this data with this imageId so we can render it and manipulate it
+  // NOTE: Should we move `uuidv4` association to `addToolState`?
+  measurementData.uuid = uuidv4();
   addToolState(element, tool.name, measurementData);
 
   external.cornerstone.updateImage(element);

--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -4,7 +4,6 @@ import { addToolState } from '../../stateManagement/toolState.js';
 import { moveHandle, moveNewHandle } from '../../manipulators/index.js';
 import { getLogger } from '../../util/logger.js';
 import triggerEvent from '../../util/triggerEvent.js';
-import uuidv4 from '../../util/uuidv4.js';
 
 const logger = getLogger('eventDispatchers:mouseEventHandlers');
 
@@ -21,9 +20,6 @@ export default function(evt, tool) {
     return;
   }
 
-  // Associate this data with this imageId so we can render it and manipulate it
-  // NOTE: Should we move `uuidv4` association to `addToolState`?
-  measurementData.uuid = uuidv4();
   addToolState(element, tool.name, measurementData);
 
   external.cornerstone.updateImage(element);

--- a/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
@@ -9,6 +9,7 @@ import {
 } from '../../stateManagement/toolState.js';
 import triggerEvent from '../../util/triggerEvent.js';
 import { getLogger } from '../../util/logger.js';
+import uuidv4 from '../../util/uuidv4.js';
 
 const logger = getLogger('eventDispatchers:touchEventHandlers');
 
@@ -26,6 +27,8 @@ export default function(evt, tool) {
     return;
   }
 
+  // NOTE: Should we move `uuidv4` association to `addToolState`?
+  measurementData.uuid = uuidv4();
   addToolState(element, tool.name, measurementData);
 
   // Todo: Looks like we're handling the "up" of the tap?

--- a/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
@@ -9,7 +9,6 @@ import {
 } from '../../stateManagement/toolState.js';
 import triggerEvent from '../../util/triggerEvent.js';
 import { getLogger } from '../../util/logger.js';
-import uuidv4 from '../../util/uuidv4.js';
 
 const logger = getLogger('eventDispatchers:touchEventHandlers');
 
@@ -27,8 +26,6 @@ export default function(evt, tool) {
     return;
   }
 
-  // NOTE: Should we move `uuidv4` association to `addToolState`?
-  measurementData.uuid = uuidv4();
   addToolState(element, tool.name, measurementData);
 
   // Todo: Looks like we're handling the "up" of the tap?

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -8,8 +8,11 @@ import { state } from './../store/index.js';
 import getActiveTool from '../util/getActiveTool';
 import BaseAnnotationTool from '../tools/base/BaseAnnotationTool';
 import { getLogger } from '../util/logger.js';
+import { getModule } from '../store';
 
 const logger = getLogger('manipulators:moveAllHandles');
+
+const manipulatorStateModule = getModule('manipulatorState');
 
 const _dragEvents = {
   mouse: [EVENTS.MOUSE_DRAG],
@@ -86,6 +89,19 @@ export default function(
     );
   };
 
+  manipulatorStateModule.setters.addActiveManipulatorForElement(
+    element,
+    _cancelEventHandler.bind(
+      null,
+      annotation,
+      options,
+      interactionType,
+      { dragHandler, upOrEndHandler },
+      element,
+      doneMovingCallback
+    )
+  );
+
   annotation.active = true;
   state.isToolLocked = true;
 
@@ -156,6 +172,25 @@ function _dragHandler(
   evt.stopPropagation();
 }
 
+function _cancelEventHandler(
+  annotation,
+  options = {},
+  interactionType,
+  { dragHandler, upOrEndHandler },
+  element,
+  doneMovingCallback
+) {
+  _endHandler(
+    annotation,
+    options,
+    interactionType,
+    { dragHandler, upOrEndHandler },
+    element,
+    doneMovingCallback,
+    false
+  );
+}
+
 function _upOrEndHandler(
   toolName,
   annotation,
@@ -166,8 +201,37 @@ function _upOrEndHandler(
   doneMovingCallback
 ) {
   const eventData = evt.detail;
-  const element = evt.detail.element;
+  const { element } = eventData;
+  manipulatorStateModule.setters.removeActiveManipulatorForElement(element);
 
+  // If any handle is outside the image, delete the tool data
+  if (
+    options.deleteIfHandleOutsideImage &&
+    anyHandlesOutsideImage(eventData, annotation.handles)
+  ) {
+    removeToolState(element, toolName, annotation);
+  }
+
+  _endHandler(
+    annotation,
+    options,
+    interactionType,
+    { dragHandler, upOrEndHandler },
+    element,
+    doneMovingCallback,
+    true
+  );
+}
+
+function _endHandler(
+  annotation,
+  options = {},
+  interactionType,
+  { dragHandler, upOrEndHandler },
+  element,
+  doneMovingCallback,
+  success = true
+) {
   annotation.active = false;
   annotation.invalidated = true;
   state.isToolLocked = false;
@@ -180,23 +244,15 @@ function _upOrEndHandler(
     element.removeEventListener(eventType, upOrEndHandler);
   });
 
-  // If any handle is outside the image, delete the tool data
-  if (
-    options.deleteIfHandleOutsideImage &&
-    anyHandlesOutsideImage(eventData, annotation.handles)
-  ) {
-    removeToolState(element, toolName, annotation);
-  }
-
   if (typeof options.doneMovingCallback === 'function') {
     logger.warn(
       '`options.doneMovingCallback` has been depricated. See https://github.com/cornerstonejs/cornerstoneTools/pull/915 for details.'
     );
-    options.doneMovingCallback();
+    options.doneMovingCallback(success);
   }
 
   if (typeof doneMovingCallback === 'function') {
-    doneMovingCallback();
+    doneMovingCallback(success);
   }
 
   external.cornerstone.updateImage(element);

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -21,6 +21,9 @@ const _moveEndEvents = {
   touch: [EVENTS.TOUCH_END, EVENTS.TOUCH_PINCH, EVENTS.TAP],
 };
 
+// Factory function
+// begin, end, cancel
+
 /**
  * Move a new handle
  *
@@ -127,6 +130,18 @@ function _moveHandler(
   });
 
   // Or... Handle "CANCEL"
+  // TODO: instead of annotation uuid, evt.cornerstoneElement.uuid
+  // TODO: Add module setter/command that cancels all or per cornerstoneEnabledElement
+  // TODO: -- Expose/document "Setters" for this cancel behavior?
+  // TODO: In a module, use the hook called by `removeEnabledElement` to deregister
+  // TODO: SETUP IN all other manipulators
+  // TODO: cancelManipulations if `cornerstonenewimage` event is fired
+
+  // When cancelling... What is our active tool?
+  // `isToolLocked` ... Track which (annotation) tool is being manipulated
+  // If not "completed", removeToolState (maybe an `isComplete` flag)
+  // 5 locations: MEASUREMENT_COMPLETED
+  // Firing event... Sets `isCompleted` flag for annotation uuid
   setters.addInFlightManipulatorThing(
     annotation.uuid,
     _cancelEventHandlers.bind(

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -2,6 +2,7 @@ import EVENTS from '../events.js';
 import external from '../externalModules.js';
 import { globalImageIdSpecificToolStateManager } from './imageIdSpecificStateManager.js';
 import triggerEvent from '../util/triggerEvent.js';
+import uuidv4 from '../util/uuidv4.js';
 
 /**
  * Returns the toolstate for a specific element.
@@ -37,6 +38,7 @@ function getElementToolStateManager(element) {
 function addToolState(element, toolType, measurementData) {
   const toolStateManager = getElementToolStateManager(element);
 
+  measurementData.uuid = measurementData.uuid || uuidv4();
   toolStateManager.add(element, toolType, measurementData);
 
   const eventType = EVENTS.MEASUREMENT_ADDED;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 // Modules
 import segmentation from './modules/segmentationModule';
+import manipulatorState from './modules/manipulatorStateModule';
 import cursor from './modules/cursorModule.js';
 import globalConfiguration from './modules/globalConfigurationModule.js';
 import external from '../externalModules.js';
@@ -28,12 +29,6 @@ export const state = {
   //
 };
 
-// ActiveManipulations
-
-const _internalState = {
-  inFlightManipulatorsForJamesDannyAndBruno: {},
-};
-
 export const getters = {
   mouseTools: () =>
     state.tools.filter(tool =>
@@ -51,44 +46,11 @@ export const getters = {
     ),
 };
 
-export const setters = {
-  addInFlightManipulatorThing: (annotationUuid, cancelFn) => {
-    const inFlightManipulators =
-      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
-
-    inFlightManipulators[annotationUuid] = cancelFn;
-  },
-  // Single
-  removeInFlightManipulatorThing: annotationUuid => {
-    const inFlightManipulators =
-      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
-
-    const cancelFn = inFlightManipulators[annotationUuid]();
-
-    if (cancelFn) {
-      cancelFn();
-    }
-
-    delete inFlightManipulators[annotationUuid];
-  },
-  // All
-  cancelAllInFlightManipulatorThings: () => {
-    const inFlightManipulators =
-      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
-    const allInFlightAnnotationUuids = Object.keys(inFlightManipulators);
-
-    allInFlightAnnotationUuids.forEach(uuid =>
-      setters.removeInFlightManipulatorThing(uuid)
-    );
-  },
-};
-
-// CsTools.store.state.setters.cancelAllInFlightManipulatorThings
-
 export const modules = {
   segmentation,
   cursor,
   globalConfiguration,
+  manipulatorState,
 };
 
 export function getModule(moduleName) {
@@ -99,5 +61,4 @@ export default {
   modules,
   state,
   getters,
-  setters,
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,6 +25,11 @@ export const state = {
   preventHandleOutsideImage: false,
   // Cursor
   svgCursorUrl: null,
+  //
+};
+
+const _internalState = {
+  inFlightManipulatorsForJamesDannyAndBruno: {},
 };
 
 export const getters = {
@@ -44,7 +49,39 @@ export const getters = {
     ),
 };
 
-export const setters = {};
+export const setters = {
+  addInFlightManipulatorThing: (annotationUuid, cancelFn) => {
+    const inFlightManipulators =
+      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
+
+    inFlightManipulators[annotationUuid] = cancelFn;
+  },
+  // Single
+  removeInFlightManipulatorThing: annotationUuid => {
+    const inFlightManipulators =
+      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
+
+    const cancelFn = inFlightManipulators[annotationUuid]();
+
+    if (cancelFn) {
+      cancelFn();
+    }
+
+    delete inFlightManipulators[annotationUuid];
+  },
+  // All
+  cancelAllInFlightManipulatorThings: () => {
+    const inFlightManipulators =
+      _internalState.inFlightManipulatorsForJamesDannyAndBruno;
+    const allInFlightAnnotationUuids = Object.keys(inFlightManipulators);
+
+    allInFlightAnnotationUuids.forEach(uuid =>
+      setters.removeInFlightManipulatorThing(uuid)
+    );
+  },
+};
+
+// CsTools.store.state.setters.cancelAllInFlightManipulatorThings
 
 export const modules = {
   segmentation,
@@ -60,4 +97,5 @@ export default {
   modules,
   state,
   getters,
+  setters,
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -28,6 +28,8 @@ export const state = {
   //
 };
 
+// ActiveManipulations
+
 const _internalState = {
   inFlightManipulatorsForJamesDannyAndBruno: {},
 };

--- a/src/store/modules/manipulatorStateModule.js
+++ b/src/store/modules/manipulatorStateModule.js
@@ -1,0 +1,97 @@
+import external from '../../externalModules';
+
+const state = { activeManipulators: {} };
+
+function addActiveManipulatorForElement(element, cancelFn) {
+  const enabledElement = external.cornerstone.getEnabledElement(element);
+  const enabledElementUUID = enabledElement.uuid;
+
+  state.activeManipulators[enabledElementUUID] = cancelFn;
+}
+
+function removeActiveManipulatorForElement(element) {
+  const enabledElement = external.cornerstone.getEnabledElement(element);
+  const enabledElementUUID = enabledElement.uuid;
+  const { activeManipulators } = state;
+
+  delete activeManipulators[enabledElementUUID];
+}
+
+function cancelActiveManipulatorsForElement(element) {
+  const enabledElement = external.cornerstone.getEnabledElement(element);
+  const enabledElementUUID = enabledElement.uuid;
+  _cancelActiveManipulatorsForElementUUID(enabledElementUUID);
+}
+
+function _cancelActiveManipulatorsForElementUUID(enabledElementUUID) {
+  const { activeManipulators } = state;
+  const cancelFn = activeManipulators[enabledElementUUID];
+
+  if (typeof cancelFn === 'function') {
+    cancelFn();
+  }
+
+  delete activeManipulators[enabledElementUUID];
+}
+
+function cancelActiveManipulators() {
+  const { activeManipulators } = state;
+
+  Object.keys(activeManipulators).forEach(enabledElementUUID =>
+    _cancelActiveManipulatorsForElementUUID(enabledElementUUID)
+  );
+}
+
+function _cornerstoneNewImageHandler(evt) {
+  const eventData = evt.detail;
+  const { element } = eventData;
+
+  removeActiveManipulatorForElement(element);
+}
+
+function removeEnabledElementCallback(element) {
+  const { NEW_IMAGE } = external.cornerstone.EVENTS;
+
+  element.removeEventListener(NEW_IMAGE, _cornerstoneNewImageHandler);
+  removeActiveManipulatorForElement(element);
+}
+
+//
+
+// const enabledElements = cornerstoneTools.store.state.enabledElements;
+
+// const cancelActiveManipulatorsForElement = cornerstoneTools.getModule(
+//   'manipulatorState'
+// ).setters.cancelActiveManipulatorsForElement;
+
+// enabledElements.forEach(element => {
+//   element.addEventListener('keydown', evt => {
+//     if (evt.keyCode === 27) {
+//       cancelActiveManipulatorsForElement(element);
+//     }
+//   });
+// });
+
+///
+
+function enabledElementCallback(element) {
+  const { NEW_IMAGE } = external.cornerstone.EVENTS;
+
+  element.removeEventListener(NEW_IMAGE, _cornerstoneNewImageHandler);
+  element.addEventListener(NEW_IMAGE, _cornerstoneNewImageHandler);
+}
+
+export default {
+  setters: {
+    // add/remove
+    addActiveManipulatorForElement,
+    removeActiveManipulatorForElement,
+
+    // cancel
+    cancelActiveManipulatorsForElement,
+    cancelActiveManipulators,
+  },
+  state,
+  enabledElementCallback,
+  removeEnabledElementCallback,
+};

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -4,6 +4,7 @@ import BaseAnnotationTool from '../base/BaseAnnotationTool.js';
 import {
   addToolState,
   getToolState,
+  removeToolState,
 } from './../../stateManagement/toolState.js';
 import toolStyle from './../../stateManagement/toolStyle.js';
 import toolColors from './../../stateManagement/toolColors.js';
@@ -303,8 +304,17 @@ export default class AngleTool extends BaseAnnotationTool {
       measurementData.handles.middle,
       this.options,
       interactionType,
-      () => {
+      success => {
         measurementData.active = false;
+
+        if (!success) {
+          removeToolState(element, this.name, measurementData);
+
+          this.preventNewMeasurement = false;
+
+          return;
+        }
+
         measurementData.handles.end.active = true;
 
         external.cornerstone.updateImage(element);
@@ -317,10 +327,15 @@ export default class AngleTool extends BaseAnnotationTool {
           measurementData.handles.end,
           this.options,
           interactionType,
-          () => {
-            measurementData.active = false;
+          success => {
+            if (success) {
+              measurementData.active = false;
+              external.cornerstone.updateImage(element);
+            } else {
+              removeToolState(element, this.name, measurementData);
+            }
+
             this.preventNewMeasurement = false;
-            external.cornerstone.updateImage(element);
           }
         );
       }

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -252,25 +252,30 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
       measurementData.handles.end,
       this.options,
       interactionType,
-      () => {
-        if (measurementData.text === undefined) {
-          this.configuration.getTextCallback(text => {
-            if (text) {
-              measurementData.text = text;
-            } else {
-              removeToolState(element, this.name, measurementData);
-            }
+      success => {
+        if (success) {
+          if (measurementData.text === undefined) {
+            this.configuration.getTextCallback(text => {
+              if (text) {
+                measurementData.text = text;
+              } else {
+                removeToolState(element, this.name, measurementData);
+              }
 
-            measurementData.active = false;
-            external.cornerstone.updateImage(element);
+              measurementData.active = false;
+              external.cornerstone.updateImage(element);
 
-            triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
-              toolType: this.name,
-              element,
-              measurementData,
-            });
-          }, evt.detail);
+              triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
+                toolType: this.name,
+                element,
+                measurementData,
+              });
+            }, evt.detail);
+          }
+        } else {
+          removeToolState(element, this.name, measurementData);
         }
+
         external.cornerstone.updateImage(element);
       }
     );

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -5,6 +5,7 @@ import textStyle from './../../stateManagement/textStyle.js';
 import {
   addToolState,
   getToolState,
+  removeToolState,
 } from './../../stateManagement/toolState.js';
 import toolStyle from './../../stateManagement/toolStyle.js';
 import toolColors from './../../stateManagement/toolColors.js';
@@ -270,7 +271,14 @@ export default class CobbAngleTool extends BaseAnnotationTool {
 
     let measurementData;
     let toMoveHandle;
-    let doneMovingCallback;
+    let doneMovingCallback = success => {
+      // doneMovingCallback for first measurement.
+      if (!success) {
+        removeToolState(element, this.name, measurementData);
+
+        return;
+      }
+    };
 
     // Search for incomplete measurements
     const element = evt.detail.element;
@@ -295,7 +303,14 @@ export default class CobbAngleTool extends BaseAnnotationTool {
       };
       toMoveHandle = measurementData.handles.end2;
       this.hasIncomplete = false;
-      doneMovingCallback = () => {
+      doneMovingCallback = success => {
+        // doneMovingCallback for second measurement
+        if (!success) {
+          removeToolState(element, this.name, measurementData);
+
+          return;
+        }
+
         const eventType = EVENTS.MEASUREMENT_COMPLETED;
         const eventData = {
           toolType: this.name,

--- a/src/util/uuidv4.js
+++ b/src/util/uuidv4.js
@@ -1,0 +1,8 @@
+export default function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    let r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Add in event cancelling for manipulators.

Paste this in the netlify demo console and then you can use ESC (at least on Chrome) to test `moveNewHandle`, `moveHandle` and `moveAllHandles`:

```
const cancelActiveManipulatorsForElement = cornerstoneTools.getModule(
  'manipulatorState'
).setters.cancelActiveManipulatorsForElement;

const enabledElements = cornerstoneTools.store.state.enabledElements;

enabledElements.forEach(element => {
  element.addEventListener('keydown', evt => {
    if (evt.keyCode === 27) {
      cancelActiveManipulatorsForElement(element);
    }
  });
});
```

Only cancelation of `moveNewHandle` will solve these issues.

Note that not all tools use manipulators, other tools would ideally be switched to use them (e.g. freehand tool, bidirectional tool).