### PR TITLE
fix: Unset voiLUT when using WWWC or WWWCRegion tool

### DIFF
--- a/src/tools/WwwcRegionTool.js
+++ b/src/tools/WwwcRegionTool.js
@@ -220,6 +220,9 @@ const _applyWWWCRegion = function(evt, config) {
   );
   viewport.voi.windowCenter = minMaxMean.mean;
 
+  // Unset any existing VOI LUT
+  viewport.voiLUT = undefined;
+
   external.cornerstone.setViewport(element, viewport);
   external.cornerstone.updateImage(element);
 };

--- a/src/tools/WwwcTool.js
+++ b/src/tools/WwwcTool.js
@@ -71,4 +71,7 @@ function basicLevelingStrategy(evt) {
     eventData.viewport.voi.windowWidth += deltaY;
     eventData.viewport.voi.windowCenter += deltaX;
   }
+
+  // Unset any existing VOI LUT
+  eventData.viewport.voiLUT = undefined;
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When applying window/level changes, we also set voiLUT to undefined to ensure any existing voiLUT is disabled.

* **What is the current behavior?** (You can also link to an open issue here)
The VOI LUT remains applied, so W/L changes do not take effect, which confuses the user.


* **What is the new behavior (if this is a feature change)?**
The VOI LUT is disabled, and W/L proceeds as normal.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
