### PR TITLE
Fix moveNewHandle

### DIFF
--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -60,6 +60,8 @@ export default function(
     options
   );
 
+  options.hasMoved = false;
+
   const { element } = eventData;
 
   annotation.active = true;
@@ -134,6 +136,8 @@ function _moveHandler(
   evt
 ) {
   const { currentPoints, image, element, buttons } = evt.detail;
+
+  options.hasMoved = true;
 
   const page = currentPoints.page;
   const fingerOffset = -57;
@@ -217,6 +221,10 @@ function _moveEndHandler(
 ) {
   const eventData = evt.detail;
   const { element, currentPoints } = eventData;
+
+  if (options.hasMoved === false) {
+    return;
+  }
 
   const page = currentPoints.page;
   const fingerOffset = -57;

--- a/src/store/modules/manipulatorStateModule.js
+++ b/src/store/modules/manipulatorStateModule.js
@@ -56,8 +56,6 @@ function removeEnabledElementCallback(element) {
   removeActiveManipulatorForElement(element);
 }
 
-//
-
 // const enabledElements = cornerstoneTools.store.state.enabledElements;
 
 // const cancelActiveManipulatorsForElement = cornerstoneTools.getModule(
@@ -72,7 +70,7 @@ function removeEnabledElementCallback(element) {
 //   });
 // });
 
-///
+// /
 
 function enabledElementCallback(element) {
   const { NEW_IMAGE } = external.cornerstone.EVENTS;

--- a/src/store/modules/manipulatorStateModule.js
+++ b/src/store/modules/manipulatorStateModule.js
@@ -56,22 +56,6 @@ function removeEnabledElementCallback(element) {
   removeActiveManipulatorForElement(element);
 }
 
-// const enabledElements = cornerstoneTools.store.state.enabledElements;
-
-// const cancelActiveManipulatorsForElement = cornerstoneTools.getModule(
-//   'manipulatorState'
-// ).setters.cancelActiveManipulatorsForElement;
-
-// enabledElements.forEach(element => {
-//   element.addEventListener('keydown', evt => {
-//     if (evt.keyCode === 27) {
-//       cancelActiveManipulatorsForElement(element);
-//     }
-//   });
-// });
-
-// /
-
 function enabledElementCallback(element) {
   const { NEW_IMAGE } = external.cornerstone.EVENTS;
 


### PR DESCRIPTION
#1195 broke click-move-click behavior for any tool using `moveNewHandle`, this fixes that.


Paste this in the console to test:

```
 const enabledElements = cornerstoneTools.store.state.enabledElements;

 const cancelActiveManipulatorsForElement = cornerstoneTools.getModule(
   'manipulatorState'
 ).setters.cancelActiveManipulatorsForElement;

 enabledElements.forEach(element => {
   element.addEventListener('keydown', evt => {
     if (evt.keyCode === 27) {
      cancelActiveManipulatorsForElement(element);
     }
   });
 });
```