### PR TITLE
fix: 🐛 Fixes moveNewHandle for click-move-click interaction

### DIFF
--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -65,6 +65,7 @@ export default function(
   const { element } = eventData;
 
   annotation.active = true;
+
   handle.active = true;
   state.isToolLocked = true;
 


### PR DESCRIPTION
cosmetic change to trigger publish messed up in previous PR. Nothing to see here.