### PR TITLE
fix: Divergence on toolType/toolName naming convention

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,8 +58,8 @@
 -   [dropObject][54]
 -   [dropTextbox][55]
 -   [dropHandle][56]
--   [toolType][57]
--   [toolType][58]
+-   [toolName][57]
+-   [toolName][58]
 -   [insertOrDelete][59]
 -   [deletePoint][60]
 -   [insertPoint][61]
@@ -106,14 +106,15 @@
 -   [getToolOptions][102]
 -   [setToolOptions][103]
 -   [clearToolOptions][104]
--   [clearToolOptionsByToolType][105]
--   [clearToolOptionsByElement][106]
+-   [clearToolOptionsByToolName][105]
+-   [clearToolOptionsByToolType][106]
+-   [clearToolOptionsByElement][107]
 
 ## setContextToDisplayFontSize
 
 Sets the canvas context transformation matrix so it is scaled to show text
 more cleanly even if the image is scaled up.  See
-[https://github.com/cornerstonejs/cornerstoneTools/wiki/DrawingText][107]
+[https://github.com/cornerstonejs/cornerstoneTools/wiki/DrawingText][108]
 for more information
 
 **Parameters**
@@ -122,7 +123,7 @@ for more information
 -   `context`  
 -   `fontSize`  
 
-Returns **{fontSize: [number][108], lineHeight: [number][108], fontScale: [number][108]}** 
+Returns **{fontSize: [number][109], lineHeight: [number][109], fontScale: [number][109]}** 
 
 ## triggerEvent
 
@@ -131,10 +132,10 @@ Trigger a CustomEvent
 **Parameters**
 
 -   `el` **EventTarget** The element or EventTarget to trigger the event upon
--   `type` **[String][109]** The event type name
--   `detail` **([Object][110] | null)** =null The event data to be sent (optional, default `null`)
+-   `type` **[String][110]** The event type name
+-   `detail` **([Object][111] | null)** =null The event data to be sent (optional, default `null`)
 
-Returns **[Boolean][111]** The return value is false if at least one event listener called preventDefault(). Otherwise it returns true.
+Returns **[Boolean][112]** The return value is false if at least one event listener called preventDefault(). Otherwise it returns true.
 
 ## convertToVector3
 
@@ -142,7 +143,7 @@ Convert an Array to a cornerstoneMath.Vector3
 
 **Parameters**
 
--   `arrayOrVector3` **([Array][112] | cornerstoneMath.Vector3)** Input array or Vector3
+-   `arrayOrVector3` **([Array][113] | cornerstoneMath.Vector3)** Input array or Vector3
 
 Returns **cornerstoneMath.Vector3** 
 
@@ -208,10 +209,10 @@ Stops an already playing clip.
 
 **Parameters**
 
--   `vector` **[Array][112]** A Frame Time Vector (0018,1065) as specified in section C.7.6.5.1.2 of DICOM standard.
--   `speed` **[Number][108]** A speed factor which will be applied to each element of the resulting array.
+-   `vector` **[Array][113]** A Frame Time Vector (0018,1065) as specified in section C.7.6.5.1.2 of DICOM standard.
+-   `speed` **[Number][109]** A speed factor which will be applied to each element of the resulting array.
 
-Returns **[Array][112]** An array with timeouts for each animation frame.
+Returns **[Array][113]** An array with timeouts for each animation frame.
 
 ## stopClipWithData
 
@@ -219,7 +220,7 @@ Returns **[Array][112]** An array with timeouts for each animation frame.
 
 **Parameters**
 
--   `playClipData` **[Object][110]** The data from playClip that needs to be stopped.
+-   `playClipData` **[Object][111]** The data from playClip that needs to be stopped.
 
 Returns **any** void
 
@@ -237,7 +238,7 @@ Returns **any** void
 
 Initialises a new freehand data object
 
-Returns **[Object][110]** measurementData - data object
+Returns **[Object][111]** measurementData - data object
 
 ## pointNearTool
 
@@ -245,10 +246,10 @@ Returns true if the mouse cursor is near a handle
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
--   `toolIndex` **[Number][108]** the ID of the tool
+-   `eventData` **[Object][111]** data object associated with an event.
+-   `toolIndex` **[Number][109]** the ID of the tool
 
-Returns **[Boolean][111]** 
+Returns **[Boolean][112]** 
 
 ## pointNearHandle
 
@@ -256,10 +257,10 @@ Returns a handle of a particular tool if it is close to the mouse cursor
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
--   `toolIndex` **[Number][108]** the ID of the tool
+-   `eventData` **[Object][111]** data object associated with an event.
+-   `toolIndex` **[Number][109]** the ID of the tool
 
-Returns **([Number][108] \| [Object][110] \| [Boolean][111])** 
+Returns **([Number][109] \| [Object][111] \| [Boolean][112])** 
 
 ## pointNearHandleAllTools
 
@@ -267,9 +268,9 @@ Returns a handle if it is close to the mouse cursor (all tools)
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
+-   `eventData` **[Object][111]** data object associated with an event.
 
-Returns **[Object][110]** 
+Returns **[Object][111]** 
 
 ## mouseDownActivateCallback
 
@@ -278,7 +279,7 @@ the event is not caught by mouseDownCallback
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## startDrawing
 
@@ -287,7 +288,7 @@ from existing handles.
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
+-   `eventData` **[Object][111]** data object associated with an event.
 
 ## addPointPencilMode
 
@@ -296,8 +297,8 @@ distance between points, then add a point.
 
 **Parameters**
 
--   `eventData` **[Object][110]** Data object associated with an event.
--   `dataHandles` **[Object][110]** Data object associated with the tool.
+-   `eventData` **[Object][111]** Data object associated with an event.
+-   `dataHandles` **[Object][111]** Data object associated with the tool.
 
 ## addPoint
 
@@ -305,7 +306,7 @@ Adds a point on mouse click in polygon mode.
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
+-   `eventData` **[Object][111]** data object associated with an event.
 
 ## endDrawing
 
@@ -313,8 +314,8 @@ Ends the active drawing loop and completes the polygon.
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
--   `handleNearby` **[Object][110]** the handle nearest to the mouse cursor.
+-   `eventData` **[Object][111]** data object associated with an event.
+-   `handleNearby` **[Object][111]** the handle nearest to the mouse cursor.
 
 ## mouseDownActive
 
@@ -326,8 +327,8 @@ distance between points, then add a point.
 -   `e`  
 -   `toolData`  
 -   `currentTool`  
--   `eventData` **[Object][110]** data object associated with an event.
--   `dataHandles` **[Object][110]** data object associated with the tool.
+-   `eventData` **[Object][111]** data object associated with an event.
+-   `dataHandles` **[Object][111]** data object associated with the tool.
 
 ## mouseDownCallback
 
@@ -335,7 +336,7 @@ Event handler for MOUSE_DOWN event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## mouseDownCallback
 
@@ -359,7 +360,7 @@ Event handler for MOUSE_MOVE event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## mouseMoveActive
 
@@ -367,8 +368,8 @@ Event handler called by mouseMoveCallback when the tool is currently active.
 
 **Parameters**
 
--   `eventData` **[Object][110]** data object associated with an event.
--   `toolData` **[Object][110]** data object associated with the freehand tool.
+-   `eventData` **[Object][111]** data object associated with an event.
+-   `toolData` **[Object][111]** data object associated with the freehand tool.
 
 ## checkInvalidHandleLocation
 
@@ -376,9 +377,9 @@ Returns true if the proposed location of a new handle is invalid.
 
 **Parameters**
 
--   `data` **[Object][110]** data object associated with the tool.
+-   `data` **[Object][111]** data object associated with the tool.
 
-Returns **[Boolean][111]** 
+Returns **[Boolean][112]** 
 
 ## checkHandlesPencilMode
 
@@ -386,9 +387,9 @@ Returns true if the proposed location of a new handle is invalid (in pencilMode)
 
 **Parameters**
 
--   `data` **[Object][110]** data object associated with the tool.
+-   `data` **[Object][111]** data object associated with the tool.
 
-Returns **[Boolean][111]** 
+Returns **[Boolean][112]** 
 
 ## checkHandlesPolygonMode
 
@@ -396,9 +397,9 @@ Returns true if the proposed location of a new handle is invalid (in polygon mod
 
 **Parameters**
 
--   `data` **[Object][110]** data object associated with the tool.
+-   `data` **[Object][111]** data object associated with the tool.
 
-Returns **[Boolean][111]** 
+Returns **[Boolean][112]** 
 
 ## invalidHandlePencilMode
 
@@ -406,10 +407,10 @@ Returns true if the mouse position is far enough from previous points (in pencil
 
 **Parameters**
 
--   `data` **[Object][110]** data object associated with the tool.
--   `mousePoint` **[Object][110]** the position of the mouse cursor.
+-   `data` **[Object][111]** data object associated with the tool.
+-   `mousePoint` **[Object][111]** the position of the mouse cursor.
 
-Returns **[Boolean][111]** 
+Returns **[Boolean][112]** 
 
 ## mouseDragCallback
 
@@ -417,7 +418,7 @@ Event handler for MOUSE_DRAG event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## mouseUpCallback
 
@@ -425,7 +426,7 @@ Event handler for MOUSE_UP event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## mouseUpCallback
 
@@ -441,7 +442,7 @@ Event handler called by mouseDownCallback when the tool is currently deactive.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## modifyObject
 
@@ -449,8 +450,8 @@ Event handler called by mouseDownPassive which modifies a tool's data.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
--   `nearby` **[Object][110]** Object containing information about a nearby handle.
+-   `e` **[Object][111]** The event.
+-   `nearby` **[Object][111]** Object containing information about a nearby handle.
 
 ## modifyTextBox
 
@@ -458,8 +459,8 @@ Event handler called by mouseDownPassive which modifies a tool's textBox.
 
 **Parameters**
 
--   `element` **[Object][110]** The element associated with the event.
--   `nearby` **[Object][110]** Object containing information about a nearby handle.
+-   `element` **[Object][111]** The element associated with the event.
+-   `nearby` **[Object][111]** Object containing information about a nearby handle.
 
 ## modifyHandle
 
@@ -467,9 +468,9 @@ Event handler called by mouseDownPassive which modifies a tool's handle.
 
 **Parameters**
 
--   `element` **[Object][110]** The element associated with the event.
--   `nearby` **[Object][110]** Object containing information about a nearby handle.
--   `toolData` **[Object][110]** The data associated with the tool.
+-   `element` **[Object][111]** The element associated with the event.
+-   `nearby` **[Object][111]** Object containing information about a nearby handle.
+-   `toolData` **[Object][111]** The data associated with the tool.
 
 ## mouseHover
 
@@ -478,8 +479,8 @@ or it's textBox.
 
 **Parameters**
 
--   `eventData` **[Object][110]** The data assoicated with the event.
--   `toolData` **[Object][110]** The data associated with the tool.
+-   `eventData` **[Object][111]** The data assoicated with the event.
+-   `toolData` **[Object][111]** The data associated with the tool.
 
 ## keyDownCallback
 
@@ -487,7 +488,7 @@ Event handler for KEY_DOWN event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## keyUpCallback
 
@@ -495,7 +496,7 @@ Event handler for KEY_UP event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## getMouseLocation
 
@@ -503,7 +504,7 @@ Gets the current mouse location and stores it in the configuration object.
 
 **Parameters**
 
--   `eventData` **[Object][110]** The data assoicated with the event.
+-   `eventData` **[Object][111]** The data assoicated with the event.
 
 ## numberWithCommas
 
@@ -511,9 +512,9 @@ Adds commas as thousand seperators to a Number to increase readability.
 
 **Parameters**
 
--   `number` **([Number][108] \| [String][109])** A Number or String literal representing a number.
+-   `number` **([Number][109] \| [String][110])** A Number or String literal representing a number.
 
-Returns **[String][109]** A string literal representaton of the number with commas seperating the thousands.
+Returns **[String][110]** A string literal representaton of the number with commas seperating the thousands.
 
 ## onImageRendered
 
@@ -521,7 +522,7 @@ Event handler for IMAGE_RENDERED event.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
+-   `e` **[Object][111]** The event.
 
 ## enable
 
@@ -529,7 +530,7 @@ Attaches event listeners to the element such that is is visible.
 
 **Parameters**
 
--   `element` **[Object][110]** The viewport element to attach event listeners to.
+-   `element` **[Object][111]** The viewport element to attach event listeners to.
 
 ## disable
 
@@ -537,7 +538,7 @@ Disables the reference line tool for the given element.
 
 **Parameters**
 
--   `element` **[Object][110]** The viewport element to attach event listeners to.
+-   `element` **[Object][111]** The viewport element to attach event listeners to.
 
 ## activate
 
@@ -545,7 +546,7 @@ Attaches event listeners to the element such that is is visible, modifiable, and
 
 **Parameters**
 
--   `element` **[Object][110]** The viewport element to attach event listeners to.
+-   `element` **[Object][111]** The viewport element to attach event listeners to.
 -   `mouseButtonMask`  
 
 ## deactivate
@@ -554,7 +555,7 @@ Attaches event listeners to the element such that is is visible and modifiable.
 
 **Parameters**
 
--   `element` **[Object][110]** The viewport element to attach event listeners to.
+-   `element` **[Object][111]** The viewport element to attach event listeners to.
 -   `mouseButtonMask`  
 
 ## removeEventListeners
@@ -563,13 +564,13 @@ Removes event listeners from the element.
 
 **Parameters**
 
--   `element` **[Object][110]** The viewport element to remove event listeners from.
+-   `element` **[Object][111]** The viewport element to remove event listeners from.
 
 ## getConfiguration
 
 Get the configuation object for the freehand tool.
 
-Returns **[Object][110]** configuration - The freehand tool's configuration object.
+Returns **[Object][111]** configuration - The freehand tool's configuration object.
 
 ## setConfiguration
 
@@ -577,7 +578,7 @@ Set the configuation object for the freehand tool.
 
 **Parameters**
 
--   `config` **[Object][110]** The configuration object to set the freehand tool's configuration.
+-   `config` **[Object][111]** The configuration object to set the freehand tool's configuration.
 
 ## 
 
@@ -585,8 +586,8 @@ Moves a part of the freehand tool whilst it is dragged by the mouse.
 
 **Parameters**
 
--   `currentHandle` **[Object][110]** The handle being dragged.
--   `data` **[Object][110]** The data associated with the freehand tool being modified.
+-   `currentHandle` **[Object][111]** The handle being dragged.
+-   `data` **[Object][111]** The data associated with the freehand tool being modified.
 
 ## dragObject
 
@@ -605,7 +606,7 @@ Moves a freehand tool's textBox whilst it is dragged by the mouse.
 
 **Parameters**
 
--   `currentHandle` **[Object][110]** The handle being dragged.
+-   `currentHandle` **[Object][111]** The handle being dragged.
 
 ## dragHandle
 
@@ -613,8 +614,8 @@ Moves a handle of the freehand tool whilst it is dragged by the mouse.
 
 **Parameters**
 
--   `currentHandle` **[Object][110]** The handle being dragged.
--   `data` **[Object][110]** The data associated with the freehand tool being modified.
+-   `currentHandle` **[Object][111]** The handle being dragged.
+-   `data` **[Object][111]** The data associated with the freehand tool being modified.
 
 ## 
 
@@ -622,8 +623,8 @@ Places part of the freehand tool when the mouse button is released.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
--   `toolData` **[Object][110]** The data associated with the freehand tool.
+-   `e` **[Object][111]** The event.
+-   `toolData` **[Object][111]** The data associated with the freehand tool.
 
 ## dropObject
 
@@ -642,8 +643,8 @@ Places a freehand tool's textBox.
 
 **Parameters**
 
--   `eventData` **[Object][110]** Data object associated with the event.
--   `toolData` **[Object][110]** The data associated with the freehand tool.
+-   `eventData` **[Object][111]** Data object associated with the event.
+-   `toolData` **[Object][111]** The data associated with the freehand tool.
 
 ## dropHandle
 
@@ -652,20 +653,20 @@ If the new location is invalid the handle snaps back to its previous position.
 
 **Parameters**
 
--   `eventData` **[Object][110]** Data object associated with the event.
--   `toolData` **[Object][110]** The data associated with the freehand tool.
+-   `eventData` **[Object][111]** Data object associated with the event.
+-   `toolData` **[Object][111]** The data associated with the freehand tool.
 
-## toolType
+## toolName
 
-Type: [string][109]
+Type: [string][110]
 
 **Meta**
 
 -   **author**: JamesAPetts
 
-## toolType
+## toolName
 
-Type: [string][109]
+Type: [string][110]
 
 **Meta**
 
@@ -677,8 +678,8 @@ Inserts or deletes a point from a freehand tool.
 
 **Parameters**
 
--   `e` **[Object][110]** The event.
--   `nearby` **[Object][110]** Object containing information about a nearby handle.
+-   `e` **[Object][111]** The event.
+-   `nearby` **[Object][111]** Object containing information about a nearby handle.
 
 ## deletePoint
 
@@ -686,8 +687,8 @@ Deletes a point from a freehand tool.
 
 **Parameters**
 
--   `eventData` **[Object][110]** The data object associated with the event.
--   `deleteInfo` **[Object][110]** Object containing information about which point to delete.
+-   `eventData` **[Object][111]** The data object associated with the event.
+-   `deleteInfo` **[Object][111]** Object containing information about which point to delete.
 
 ## insertPoint
 
@@ -695,8 +696,8 @@ Inserts a new point into a freehand tool.
 
 **Parameters**
 
--   `eventData` **[Object][110]** The data object associated with the event.
--   `insertInfo` **[Object][110]** Object containing information about where to insert the point.
+-   `eventData` **[Object][111]** The data object associated with the event.
+-   `insertInfo` **[Object][111]** Object containing information about where to insert the point.
 
 ## getInsertionIndex
 
@@ -704,16 +705,16 @@ Gets the handle index of a tool in which to insert the new point.
 
 **Parameters**
 
--   `insertInfo` **[Object][110]** Object containing information about where to insert the point.
+-   `insertInfo` **[Object][111]** Object containing information about where to insert the point.
 
 ## ClickedLineData
 
-Type: [Object][110]
+Type: [Object][111]
 
 **Properties**
 
--   `toolIndex` **[Number][108]** ID of the tool that the line corresponds to.
--   `handleIndexArray` **[Object][110]** An array of the handle indicies that correspond to the line segment.
+-   `toolIndex` **[Number][109]** ID of the tool that the line corresponds to.
+-   `handleIndexArray` **[Object][111]** An array of the handle indicies that correspond to the line segment.
 
 ## constructor
 
@@ -721,19 +722,19 @@ Constructs a linefinder with the eventdata
 
 **Parameters**
 
--   `eventData` **[Object][110]** Data object associated with the event.
+-   `eventData` **[Object][111]** Data object associated with the event.
 
 ## findLine
 
 Looks for lines near the mouse cursor.
 
-Returns **[ClickedLineData][113]** 
+Returns **[ClickedLineData][114]** 
 
 ## \_nearestHandleToPointAllTools
 
 Finds the nearest handle to the mouse cursor for all tools.
 
-Returns **[Object][110]** closestHandle - The handle closest to the point.
+Returns **[Object][111]** closestHandle - The handle closest to the point.
 
 ## \_nearestHandleToPoint
 
@@ -741,9 +742,9 @@ Finds the nearest handle to the mouse cursor for a specific tool.
 
 **Parameters**
 
--   `toolIndex` **[Number][108]** The index of the particular freehand tool.
+-   `toolIndex` **[Number][109]** The index of the particular freehand tool.
 
-Returns **[Object][110]** An object containing information about the closest handle.
+Returns **[Object][111]** An object containing information about the closest handle.
 
 ## \_getCloseLinesInTool
 
@@ -751,9 +752,9 @@ Finds all the lines close to the mouse point for a particular tool.
 
 **Parameters**
 
--   `toolIndex` **[Number][108]** The index of the particular freehand tool.
+-   `toolIndex` **[Number][109]** The index of the particular freehand tool.
 
-Returns **[Object][110]** An array of lines close to the mouse point.
+Returns **[Object][111]** An array of lines close to the mouse point.
 
 ## \_findCorrectLine
 
@@ -761,10 +762,10 @@ Finds the line the user clicked on from an array of close lines.
 
 **Parameters**
 
--   `toolIndex` **[Number][108]** The index of the particular freehand tool.
--   `closeLines` **[Object][110]** An array of lines close to the mouse point.
+-   `toolIndex` **[Number][109]** The index of the particular freehand tool.
+-   `closeLines` **[Object][111]** An array of lines close to the mouse point.
 
-Returns **([ClickedLineData][113] | null)** An instance of ClickedLineData containing information about the line, or null if no line is correct.
+Returns **([ClickedLineData][114] | null)** An instance of ClickedLineData containing information about the line, or null if no line is correct.
 
 ## \_pointProjectsToLineSegment
 
@@ -772,10 +773,10 @@ Returns true if the mouse point projects onto the line segment.
 
 **Parameters**
 
--   `toolIndex` **[Number][108]** The index of the particular freehand tool.
--   `handleIndexArray` **[Object][110]** An array of indicies corresponding to the line segment.
+-   `toolIndex` **[Number][109]** The index of the particular freehand tool.
+-   `handleIndexArray` **[Object][111]** An array of indicies corresponding to the line segment.
 
-Returns **[Boolean][111]** True if the mouse point projects onto the line segment
+Returns **[Boolean][112]** True if the mouse point projects onto the line segment
 
 ## \_getLineOriginToMouseAsVector
 
@@ -783,9 +784,9 @@ Constructs a vector from the direction and magnitude of the line from the the li
 
 **Parameters**
 
--   `p` **[Object][110]** An array of two points respresenting the line segment.
+-   `p` **[Object][111]** An array of two points respresenting the line segment.
 
-Returns **[Object][110]** An array containing the x and y components of the vector.
+Returns **[Object][111]** An array containing the x and y components of the vector.
 
 ## \_distanceOfPointfromLine
 
@@ -793,10 +794,10 @@ Calculates the perpendicular distance of the mouse cursor from a line segment.
 
 **Parameters**
 
--   `handle1` **[FreehandHandleData][114]** The first handle.
--   `handle2` **[FreehandHandleData][114]** The first handle.
+-   `handle1` **[FreehandHandleData][115]** The first handle.
+-   `handle2` **[FreehandHandleData][115]** The first handle.
 
-Returns **[Number][108]** The perpendicular distance of the mouse cursor from the line segment.
+Returns **[Number][109]** The perpendicular distance of the mouse cursor from the line segment.
 
 ## getCanvasPointsFromHandles
 
@@ -804,11 +805,11 @@ Returns the canvas positions from the handle's pixel positions.
 
 **Parameters**
 
--   `handle1` **[FreehandHandleData][114]** The first handle.
--   `handle2` **[FreehandHandleData][114]** The second handle.
--   `element` **[Object][110]** The element on which the handles reside.
+-   `handle1` **[FreehandHandleData][115]** The first handle.
+-   `handle2` **[FreehandHandleData][115]** The second handle.
+-   `element` **[Object][111]** The element on which the handles reside.
 
-Returns **[Object][110]** An array contsining the handle positions in canvas coordinates.
+Returns **[Object][111]** An array contsining the handle positions in canvas coordinates.
 
 ## getLineAsVector
 
@@ -816,9 +817,9 @@ Converts a line segment to a vector.
 
 **Parameters**
 
--   `p` **[Object][110]** An array of two points respresenting the line segment.
+-   `p` **[Object][111]** An array of two points respresenting the line segment.
 
-Returns **[Object][110]** An array containing the x and y components of the vector, as well as a magnitude property.
+Returns **[Object][111]** An array containing the x and y components of the vector, as well as a magnitude property.
 
 ## getNextHandleIndex
 
@@ -826,10 +827,10 @@ Gets the next handl index from a cyclical array of points.
 
 **Parameters**
 
--   `currentIndex` **[Number][108]** The current index.
--   `length` **[Number][108]** The number of handles in the polygon.
+-   `currentIndex` **[Number][109]** The current index.
+-   `length` **[Number][109]** The number of handles in the polygon.
 
-Returns **[Number][108]** The index of the next handle.
+Returns **[Number][109]** The index of the next handle.
 
 ## freeHandArea
 
@@ -848,11 +849,11 @@ Calculates the statistics of all the points within the freehand object.
 
 **Parameters**
 
--   `sp` **[Object][110]** An array of the pixel data.
--   `boundingBox` **[Object][110]** Rectangular box enclosing the polygon.
--   `dataHandles` **[Object][110]** Data object associated with the tool.
+-   `sp` **[Object][111]** An array of the pixel data.
+-   `boundingBox` **[Object][111]** Rectangular box enclosing the polygon.
+-   `dataHandles` **[Object][111]** Data object associated with the tool.
 
-Returns **[Object][110]** statisticsObj - Object containing the derived statistics.
+Returns **[Object][111]** statisticsObj - Object containing the derived statistics.
 
 ## calculateFreehandStatistics
 
@@ -872,11 +873,11 @@ Calculates the sum, squared sum and count of all pixels within the polygon.
 
 **Parameters**
 
--   `sp` **[Object][110]** An array of the pixel data.
--   `boundingBox` **[Object][110]** Rectangular box enclosing the polygon.
--   `dataHandles` **[Object][110]** Data object associated with the tool.
+-   `sp` **[Object][111]** An array of the pixel data.
+-   `boundingBox` **[Object][111]** Rectangular box enclosing the polygon.
+-   `dataHandles` **[Object][111]** Data object associated with the tool.
 
-Returns **[Object][110]** sum - Object containing the sum, squared sum and pixel count.
+Returns **[Object][111]** sum - Object containing the sum, squared sum and pixel count.
 
 ## sumPointIfInFreehand
 
@@ -884,10 +885,10 @@ Adds the pixel to the workingSum if it is within the polygon.
 
 **Parameters**
 
--   `dataHandles` **[Object][110]** Data object associated with the tool.
--   `point` **[Object][110]** The pixel coordinates.
--   `workingSum` **[Object][110]** The working sum, squared sum and pixel count.
--   `pixelValue` **[Object][110]** The pixel value.
+-   `dataHandles` **[Object][111]** Data object associated with the tool.
+-   `point` **[Object][111]** The pixel coordinates.
+-   `workingSum` **[Object][111]** The working sum, squared sum and pixel count.
+-   `pixelValue` **[Object][111]** The pixel value.
 
 ## pointInFreehand
 
@@ -912,11 +913,11 @@ Returns true if the y-position yp is enclosed within y-positions y1 and y2.
 
 **Parameters**
 
--   `yp` **[Number][108]** The y position of point p.
--   `y1` **[Number][108]** The y position of point 1.
--   `y2` **[Number][108]** The y position of point 2.
+-   `yp` **[Number][109]** The y position of point p.
+-   `y1` **[Number][109]** The y position of point 1.
+-   `y2` **[Number][109]** The y position of point 2.
 
-Returns **[Boolean][111]** True if the y-position yp is enclosed within y-positions y1 and y2.
+Returns **[Boolean][112]** True if the y-position yp is enclosed within y-positions y1 and y2.
 
 ## isLineRightOfPoint
 
@@ -924,11 +925,11 @@ Returns true if the line segment is to the right of the point.
 
 **Parameters**
 
--   `point` **[Object][110]** The point being queried.
--   `lp1` **[Object][110]** The first point of the line segment.
--   `lp2` **[Object][110]** The second point of the line segment.
+-   `point` **[Object][111]** The point being queried.
+-   `lp1` **[Object][111]** The first point of the line segment.
+-   `lp2` **[Object][111]** The second point of the line segment.
 
-Returns **[Boolean][111]** True if the line is to the right of the point.
+Returns **[Boolean][112]** True if the line is to the right of the point.
 
 ## lineSegmentAtPoint
 
@@ -936,11 +937,11 @@ Returns the y value of the line segment at the x value of the point.
 
 **Parameters**
 
--   `point` **[Object][110]** The point being queried.
--   `lp1` **[Object][110]** The first point of the line segment.
--   `lp2` **[Object][110]** The second point of the line segment.
+-   `point` **[Object][111]** The point being queried.
+-   `lp1` **[Object][111]** The first point of the line segment.
+-   `lp2` **[Object][111]** The second point of the line segment.
 
-Returns **[Object][110]** An object containing the y value as well as the gradient of the line segment.
+Returns **[Object][111]** An object containing the y value as well as the gradient of the line segment.
 
 ## rayFromPointCrosssesLine
 
@@ -948,11 +949,11 @@ Returns true if a rightwards ray originating from the point crosses the line def
 
 **Parameters**
 
--   `point` **[Object][110]** The point being queried.
--   `handleI` **[Object][110]** The first handle of the line segment.
--   `handleJ` **[Object][110]** The second handle of the line segment.
+-   `point` **[Object][111]** The point being queried.
+-   `handleI` **[Object][111]** The first handle of the line segment.
+-   `handleJ` **[Object][111]** The second handle of the line segment.
 
-Returns **[Boolean][111]** True if a rightwards ray originating from the point crosses the line defined by handleI and handleJ.
+Returns **[Boolean][112]** True if a rightwards ray originating from the point crosses the line defined by handleI and handleJ.
 
 ## newHandle
 
@@ -974,10 +975,10 @@ Determines whether a new handle causes an intersection of the lines of the polyg
 
 **Parameters**
 
--   `candidateHandle` **[Object][110]** The new handle to check.
--   `dataHandles` **[Object][110]** data object associated with the tool.
+-   `candidateHandle` **[Object][111]** The new handle to check.
+-   `dataHandles` **[Object][111]** data object associated with the tool.
 
-Returns **[Boolean][111]** Whether the new line intersects with any other lines of the polygon.
+Returns **[Boolean][112]** Whether the new line intersects with any other lines of the polygon.
 
 ## end
 
@@ -985,9 +986,9 @@ Checks if the last line of a polygon will intersect the other lines of the polgy
 
 **Parameters**
 
--   `dataHandles` **[Object][110]** data object associated with the tool.
+-   `dataHandles` **[Object][111]** data object associated with the tool.
 
-Returns **[Boolean][111]** Whether the last line intersects with any other lines of the polygon.
+Returns **[Boolean][112]** Whether the last line intersects with any other lines of the polygon.
 
 ## modify
 
@@ -995,10 +996,10 @@ Checks whether the modification of a handle's position causes intersection of th
 
 **Parameters**
 
--   `dataHandles` **[Object][110]** data object associated with the tool.
--   `modifiedHandleId` **[Number][108]** The id of the handle being modified.
+-   `dataHandles` **[Object][111]** data object associated with the tool.
+-   `modifiedHandleId` **[Number][109]** The id of the handle being modified.
 
-Returns **[Boolean][111]** Whether the modfication causes any intersections.
+Returns **[Boolean][112]** Whether the modfication causes any intersections.
 
 ## doesIntersectOtherLines
 
@@ -1006,12 +1007,12 @@ Checks whether the line (p1,q1) intersects any of the other lines in the polygon
 
 **Parameters**
 
--   `dataHandles` **[Object][110]** data object associated with the tool.
--   `p1` **[Object][110]** Coordinates of the start of the line.
--   `q1` **[Object][110]** Coordinates of the end of the line.
--   `ignoredHandleIds` **[Object][110]** Ids of handles to ignore (i.e. lines that share a vertex with the line being tested).
+-   `dataHandles` **[Object][111]** data object associated with the tool.
+-   `p1` **[Object][111]** Coordinates of the start of the line.
+-   `q1` **[Object][111]** Coordinates of the end of the line.
+-   `ignoredHandleIds` **[Object][111]** Ids of handles to ignore (i.e. lines that share a vertex with the line being tested).
 
-Returns **[Boolean][111]** Whether the line intersects any of the other lines in the polygon.
+Returns **[Boolean][112]** Whether the line intersects any of the other lines in the polygon.
 
 ## doesIntersect
 
@@ -1019,12 +1020,12 @@ Checks whether the line (p1,q1) intersects the line (p2,q2) via an orientation a
 
 **Parameters**
 
--   `p1` **[Object][110]** Coordinates of the start of the line 2.
--   `q1` **[Object][110]** Coordinates of the end of the line 2.
+-   `p1` **[Object][111]** Coordinates of the start of the line 2.
+-   `q1` **[Object][111]** Coordinates of the end of the line 2.
 -   `p2`  
 -   `q2`  
 
-Returns **[Boolean][111]** Whether lines (p1,q1) and (p2,q2) intersect.
+Returns **[Boolean][112]** Whether lines (p1,q1) and (p2,q2) intersect.
 
 ## orientation
 
@@ -1032,11 +1033,11 @@ Checks the orientation of 3 points.
 
 **Parameters**
 
--   `p` **[Object][110]** First point.
--   `q` **[Object][110]** Second point.
--   `r` **[Object][110]** Third point.
+-   `p` **[Object][111]** First point.
+-   `q` **[Object][111]** Second point.
+-   `r` **[Object][111]** Third point.
 
-Returns **[Number][108]** 0: Colinear, 1: Clockwise, 2: Anticlockwise
+Returns **[Number][109]** 0: Colinear, 1: Clockwise, 2: Anticlockwise
 
 ## onSegment
 
@@ -1044,11 +1045,11 @@ Checks if point q lines on the segment (p,r).
 
 **Parameters**
 
--   `p` **[Object][110]** Point p.
--   `q` **[Object][110]** Point q.
--   `r` **[Object][110]** Point r.
+-   `p` **[Object][111]** Point p.
+-   `q` **[Object][111]** Point q.
+-   `r` **[Object][111]** Point r.
 
-Returns **[Boolean][111]** If q lies on line segment (p,r).
+Returns **[Boolean][112]** If q lies on line segment (p,r).
 
 ## FreehandHandleData
 
@@ -1064,15 +1065,15 @@ Returns **[Boolean][111]** If q lies on line segment (p,r).
 
 ## FreehandHandleData
 
-Type: [Object][110]
+Type: [Object][111]
 
 **Properties**
 
--   `x` **[Number][108]** The x position.
--   `y` **[Number][108]** The y position.
--   `highlight` **[Boolean][111]** Whether the handle should be rendered as the highlighted color.
--   `active` **[Boolean][111]** Whether the handle is active.
--   `lines` **[Object][110]** An array of lines associated with the handle.
+-   `x` **[Number][109]** The x position.
+-   `y` **[Number][109]** The y position.
+-   `highlight` **[Boolean][112]** Whether the handle should be rendered as the highlighted color.
+-   `active` **[Boolean][112]** Whether the handle is active.
+-   `lines` **[Object][111]** An array of lines associated with the handle.
 
 ## dragCallback
 
@@ -1134,45 +1135,57 @@ Records the start point of the click or touch
 
 ## getToolOptions
 
-Retrieve the options object associated with a particular toolType and element
+Retrieve the options object associated with a particular toolName and element
 
 **Parameters**
 
--   `toolType` **[string][109]** Tool type identifier of the target options object
--   `element` **[HTMLElement][115]** Element of the target options object
+-   `toolName` **[string][110]** Tool name identifier of the target options object
+-   `element` **[HTMLElement][116]** Element of the target options object
 
-Returns **[Object][110]** Target options object (empty if not yet set)
+Returns **[Object][111]** Target options object (empty if not yet set)
 
 ## setToolOptions
 
-Set the options object associated with a particular toolType and element
+Set the options object associated with a particular toolName and element
 
 **Parameters**
 
--   `toolType` **[string][109]** Tool type identifier of the target options object
--   `element` **[HTMLElement][115]** Element of the target options object
--   `options` **[Object][110]** Options object to store at target
+-   `toolName` **[string][110]** Tool name identifier of the target options object
+-   `element` **[HTMLElement][116]** Element of the target options object
+-   `options` **[Object][111]** Options object to store at target
 
 Returns **void** 
 
 ## clearToolOptions
 
-Clear the options object associated with a particular toolType and element
+Clear the options object associated with a particular toolName and element
 
 **Parameters**
 
--   `toolType` **[string][109]** Tool type identifier of the target options object
--   `element` **[HTMLElement][115]** Element of the target options object
+-   `toolName` **[string][110]** Tool name identifier of the target options object
+-   `element` **[HTMLElement][116]** Element of the target options object
 
 Returns **void** 
 
-## clearToolOptionsByToolType
+## clearToolOptionsByToolName
 
-Clear the options objects associated with a particular toolType
+Clear the options objects associated with a particular toolName
 
 **Parameters**
 
--   `toolType` **[string][109]** Tool type identifier of the target options objects
+-   `toolName` **[string][110]** Tool type identifier of the target options objects
+
+Returns **void** 
+
+<!-- >>>>> TODO: deprecate -->
+## clearToolOptionsByToolType
+
+Clear the options objects associated with a particular toolType
+Deprecation Notice: This method will be replaced by clearToolOptionsByToolName
+
+**Parameters**
+
+-   `toolType` **[string][110]** Tool type identifier of the target options objects
 
 Returns **void** 
 
@@ -1182,7 +1195,7 @@ Clear the options objects associated with a particular element
 
 **Parameters**
 
--   `element` **[HTMLElement][115]** Element of the target options objects
+-   `element` **[HTMLElement][116]** Element of the target options objects
 
 Returns **void** 
 
@@ -1298,9 +1311,9 @@ Returns **void**
 
 [56]: #drophandle
 
-[57]: #tooltype
+[57]: #toolname
 
-[58]: #tooltype-1
+[58]: #toolname-1
 
 [59]: #insertordelete
 
@@ -1394,24 +1407,26 @@ Returns **void**
 
 [104]: #cleartooloptions
 
-[105]: #cleartooloptionsbytooltype
+[105]: #cleartooloptionsbytoolname
 
-[106]: #cleartooloptionsbyelement
+[106]: #cleartooloptionsbytooltype
 
-[107]: https://github.com/cornerstonejs/cornerstoneTools/wiki/DrawingText
+[107]: #cleartooloptionsbyelement
 
-[108]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[108]: https://github.com/cornerstonejs/cornerstoneTools/wiki/DrawingText
 
-[109]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[109]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[110]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[110]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[111]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[111]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[112]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[112]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[113]: #clickedlinedata
+[113]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[114]: #freehandhandledata
+[114]: #clickedlinedata
 
-[115]: https://developer.mozilla.org/docs/Web/HTML/Element
+[115]: #freehandhandledata
+
+[116]: https://developer.mozilla.org/docs/Web/HTML/Element

--- a/docs/latest/third-party-functionality/item-types.md
+++ b/docs/latest/third-party-functionality/item-types.md
@@ -47,7 +47,7 @@ export default {
 `BaseAnnotationTool`s use `manipulators` to interact with the annotation's `handle`s data in a particular way. If you need to build a custom interaction mechanism you envision using more than once, you may want to make a custom manipulator. A manipulator is just a `function`. They have rather freeform structure, but principally take `eventData` and `toolData` and perform an operation, e.g.:
 
 ```js
-export default function(eventData, toolType, data, handle, someCallback) {
+export default function(eventData, toolName, data, handle, someCallback) {
   // Implementation, Do something with the handle.
   // ...
   someCallback();

--- a/docs/v3/third-party-functionality/item-types.md
+++ b/docs/v3/third-party-functionality/item-types.md
@@ -47,7 +47,7 @@ export default {
 `BaseAnnotationTool`s use `manipulators` to interact with the annotation's `handle`s data in a particular way. If you need to build a custom interaction mechanism you envision using more than once, you may want to make a custom manipulator. A manipulator is just a `function`. They have rather freeform structure, but principally take `eventData` and `toolData` and perform an operation, e.g.:
 
 ```js
-export default function(eventData, toolType, data, handle, someCallback) {
+export default function(eventData, toolName, data, handle, someCallback) {
   // Implementation, Do something with the handle.
   // ...
   someCallback();

--- a/index.html
+++ b/index.html
@@ -104,24 +104,24 @@
       </ul>
       <ul class="tool-category" data-tool-category="multitouch-pinch">
         <li>
-          <a href="#" data-tool="PanMultiTouch" data-tool-type="multitouch">PanMultiTouch</a>
+          <a href="#" data-tool="PanMultiTouch" data-tool-interaction="multitouch">PanMultiTouch</a>
         </li>
         <li>
-          <a href="#" data-tool="ZoomTouchPinch" data-tool-type="pinch">ZoomTouchPinch</a>
+          <a href="#" data-tool="ZoomTouchPinch" data-tool-interaction="pinch">ZoomTouchPinch</a>
         </li>
         <li>
-          <a href="#" data-tool="RotateTouch" data-tool-type="pinch">RotateTouch</a>
+          <a href="#" data-tool="RotateTouch" data-tool-interaction="pinch">RotateTouch</a>
         </li>
         <li>
-          <a href="#" data-tool="StackScrollMultiTouch" data-tool-type="multitouch">StackScrollMultiTouch</a>
+          <a href="#" data-tool="StackScrollMultiTouch" data-tool-interaction="multitouch">StackScrollMultiTouch</a>
         </li>
       </ul>
       <ul class="tool-category" data-tool-category="mousewheel">
         <li>
-          <a href="#" data-tool="StackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a>
+          <a href="#" data-tool="StackScrollMouseWheel" data-tool-interaction="wheel">StackScrollMouseWheel</a>
         </li>
         <li>
-          <a href="#" data-tool="ZoomMouseWheel" data-tool-type="wheel">ZoomMouseWheel</a>
+          <a href="#" data-tool="ZoomMouseWheel" data-tool-interaction="wheel">ZoomMouseWheel</a>
         </li>
       </ul>
       <ul class="tool-category" data-tool-category="overlay">
@@ -130,7 +130,7 @@
             ScaleOverlay <label class="label-on"> ON</label>
             <label class="label-off"> OFF</label>
           </label>
-          <input id="scaleOverlayCheckbox" class="hide" data-tool="ScaleOverlay" data-tool-type="none"
+          <input id="scaleOverlayCheckbox" class="hide" data-tool="ScaleOverlay" data-tool-interaction="none"
             type="checkbox" />
         </li>
         <li>
@@ -138,8 +138,7 @@
             Overlay <label class="label-on"> ON</label>
             <label class="label-off"> OFF</label>
           </label>
-          <input id="overlayCheckbox" class="hide" data-tool="Overlay" data-tool-type="none"
-            type="checkbox" />
+          <input id="overlayCheckbox" class="hide" data-tool="Overlay" data-tool-interaction="none" type="checkbox" />
         </li>
       </ul>
 
@@ -269,7 +268,7 @@
         type,
         // The tool type
         `color: ${color}; font-family: monospace;`,
-        event.detail.toolType || event.detail.toolName,
+        event.detail.toolInteraction || event.detail.toolName,
         '',
         getData(event.detail)
         // event.detail
@@ -336,8 +335,8 @@
         ? evt.buttons
         : convertMouseEventWhichToButtons(evt.which);
 
-      const toolType = evt.target.getAttribute('data-tool-type');
-      setButtonActive(toolName, mouseButtonMask, toolType);
+      const toolInteraction = evt.target.getAttribute('data-tool-interaction');
+      setButtonActive(toolName, mouseButtonMask, toolInteraction);
       cornerstoneTools.setToolActive(toolName, {
         mouseButtonMask,
         isTouchActive: true,
@@ -409,22 +408,22 @@
     });
   };
 
-  const setButtonActive = (toolName, mouseButtonMask, toolType) => {
+  const setButtonActive = (toolName, mouseButtonMask, toolInteraction) => {
     Array.from(toolButtons).forEach(toolBtn => {
       // Classes we need to set & remove
       let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
       let touchIcon = `touch-1`;
 
-      // Update classes depending on the toolType we clicked
-      if (toolType === 'none') {
+      // Update classes depending on the toolInteraction we clicked
+      if (toolInteraction === 'none') {
         return;
-      } else if (toolType === 'multitouch') {
+      } else if (toolInteraction === 'multitouch') {
         mouseButtonIcon = null;
         touchIcon = 'touch-2';
-      } else if (toolType === 'pinch') {
+      } else if (toolInteraction === 'pinch') {
         mouseButtonIcon = null;
         touchIcon = 'touch-pinch';
-      } else if (toolType === 'wheel') {
+      } else if (toolInteraction === 'wheel') {
         mouseButtonIcon = 'mousebutton-wheel';
         touchIcon = null;
       }

--- a/netlify-example/brush/index.html
+++ b/netlify-example/brush/index.html
@@ -330,8 +330,8 @@
         : convertMouseEventWhichToButtons(evt.which);
       // TODO: Let's make this happen automagically for mask/touch conflicts?
       setAllToolsPassive();
-      const toolType = evt.target.getAttribute('data-tool-type');
-      setButtonActive(toolName, mouseButtonMask, toolType);
+      const toolInteraction = evt.target.getAttribute('data-tool-interaction');
+      setButtonActive(toolName, mouseButtonMask, toolInteraction);
       cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
 
       evt.preventDefault();
@@ -369,22 +369,22 @@
     });
   };
 
-  const setButtonActive = (toolName, mouseButtonMask, toolType) => {
+  const setButtonActive = (toolName, mouseButtonMask, toolInteraction) => {
     Array.from(toolButtons).forEach(toolBtn => {
       // Classes we need to set & remove
       let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
       let touchIcon = `touch-1`;
 
-      // Update classes depending on the toolType we clicked
-      if (toolType === 'none') {
+      // Update classes depending on the toolInteraction we clicked
+      if (toolInteraction === 'none') {
         return;
-      } else if (toolType === 'multitouch') {
+      } else if (toolInteraction === 'multitouch') {
         mouseButtonIcon = null;
         touchIcon = 'touch-2';
-      } else if (toolType === 'pinch') {
+      } else if (toolInteraction === 'pinch') {
         mouseButtonIcon = null;
         touchIcon = 'touch-pinch';
-      } else if (toolType === 'wheel') {
+      } else if (toolInteraction === 'wheel') {
         mouseButtonIcon = 'mousebutton-wheel';
         touchIcon = null;
       }

--- a/netlify-example/freehandRoi/index.html
+++ b/netlify-example/freehandRoi/index.html
@@ -20,16 +20,16 @@
 			</ul>
 
 			<!-- Select Active Tool -->
-      <ul class="tool-category active" data-tool-category="tools">
-        <li><a href="#" data-tool="FreehandRoi">FreehandRoi</a></li>
-        <li><a href="#" data-tool="FreehandRoiSculptor">FreehandRoiSculptor</a></li>
-        <li><a href="#" id="saveToolState">Save Freehand</a></li>
-        <li><a href="#" id="clearToolState">Clear Freehand</a></li>
-        <li><a href="#" id="loadToolState">Load Freehand State</a></li>
-      </ul>
+			<ul class="tool-category active" data-tool-category="tools">
+				<li><a href="#" data-tool="FreehandRoi">FreehandRoi</a></li>
+				<li><a href="#" data-tool="FreehandRoiSculptor">FreehandRoiSculptor</a></li>
+				<li><a href="#" id="saveToolState">Save Freehand</a></li>
+				<li><a href="#" id="clearToolState">Clear Freehand</a></li>
+				<li><a href="#" id="loadToolState">Load Freehand State</a></li>
+			</ul>
 			<ul class="tool-category" data-tool-category="mousewheel">
-				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a></li>
-				<li><a href="#" data-tool="ZoomMouseWheel" data-tool-type="wheel">ZoomMouseWheel</a></li>
+				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-interaction="wheel">StackScrollMouseWheel</a></li>
+				<li><a href="#" data-tool="ZoomMouseWheel" data-tool-interaction="wheel">ZoomMouseWheel</a></li>
 			</ul>
 
 			<!-- Our beautiful element targets -->
@@ -187,7 +187,8 @@
 							<td>
 								<input type="range" id="hoverCursorFadeAlpha" min="0" max="255">
 							</td>
-							<td>hoverCursorFadeAlpha - The alpha of the cursor when distant from the region, if showCursorOnHover and limitRadiusOutsideRegion are enabled.</td>
+							<td>hoverCursorFadeAlpha - The alpha of the cursor when distant from the region, if showCursorOnHover and
+								limitRadiusOutsideRegion are enabled.</td>
 						</tr>
 						<tr>
 							<td>
@@ -301,8 +302,8 @@
 			const mouseButtonMask = evt.buttons
 				? evt.buttons
 				: convertMouseEventWhichToButtons(evt.which)
-			const toolType = evt.target.getAttribute('data-tool-type')
-			setButtonActive(toolName, mouseButtonMask, toolType);
+			const toolInteraction = evt.target.getAttribute('data-tool-interaction')
+			setButtonActive(toolName, mouseButtonMask, toolInteraction);
 			cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
 
 			evt.preventDefault();
@@ -335,22 +336,22 @@
 		});
 	}
 
-	const setButtonActive = (toolName, mouseButtonMask, toolType) => {
+	const setButtonActive = (toolName, mouseButtonMask, toolInteraction) => {
 		Array.from(toolButtons).forEach(toolBtn => {
 			// Classes we need to set & remove
 			let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
 			let touchIcon = `touch-1`
 
-			// Update classes depending on the toolType we clicked
-			if (toolType === 'none') {
+			// Update classes depending on the toolInteraction we clicked
+			if (toolInteraction === 'none') {
 				return;
-			} else if (toolType === 'multitouch') {
+			} else if (toolInteraction === 'multitouch') {
 				mouseButtonIcon = null;
 				touchIcon = 'touch-2';
-			} else if (toolType === 'pinch') {
+			} else if (toolInteraction === 'pinch') {
 				mouseButtonIcon = null;
 				touchIcon = 'touch-pinch';
-			} else if (toolType === 'wheel') {
+			} else if (toolInteraction === 'wheel') {
 				mouseButtonIcon = 'mousebutton-wheel';
 				touchIcon = null;
 			}
@@ -403,7 +404,7 @@
 	const freehandRoiTool = cornerstoneTools.getToolForElement(element, 'FreehandRoi');
 	const freehandRoiSculpterTool = cornerstoneTools.getToolForElement(element, 'FreehandRoiSculptor');
 
-	function freehandApiCall (opperation) {
+	function freehandApiCall(opperation) {
 		switch (opperation) {
 			case 'always-show-handles':
 				const alwaysShowHandles = freehandRoiTool.alwaysShowHandles;
@@ -467,24 +468,24 @@
 	});
 
 	hoverCursorFadeAlphaSlider.addEventListener('input', event => {
-		const normalisedAlpha = Number(event.target.value)/255.0;
+		const normalisedAlpha = Number(event.target.value) / 255.0;
 
 		freehandRoiSculptorTool.hoverCursorFadeAlpha = normalisedAlpha;
 	});
 
 	hoverCursorFadeDistanceSlider.addEventListener('input', event => {
 		// Slider transformed from (100 <-> 200) to (1.0 <-> 2.0).
-		const realValue = Math.floor(Number(event.target.value)/100.0);
+		const realValue = Math.floor(Number(event.target.value) / 100.0);
 
 		freehandRoiSculptorTool.hoverCursorFadeDistance = realValue;
 	});
 
-  const saveToolStateButton = document.getElementById('saveToolState');
-  const clearToolStateButton = document.getElementById('clearToolState');
-  const loadToolStateButton = document.getElementById('loadToolState');
-  let toolState = null;
+	const saveToolStateButton = document.getElementById('saveToolState');
+	const clearToolStateButton = document.getElementById('clearToolState');
+	const loadToolStateButton = document.getElementById('loadToolState');
+	let toolState = null;
 
-  saveToolStateButton.addEventListener('click', event => {
+	saveToolStateButton.addEventListener('click', event => {
 		const toolStateString = JSON.stringify(cornerstoneTools.getToolState(element, freehandRoiTool.name));
 
 		if (toolStateString) {
@@ -493,37 +494,37 @@
 		} else {
 			alert("nothing to save!");
 		}
-  });
+	});
 
-  clearToolStateButton.addEventListener('click', event => {
-    cornerstoneTools.clearToolState(element, freehandRoiTool.name);
+	clearToolStateButton.addEventListener('click', event => {
+		cornerstoneTools.clearToolState(element, freehandRoiTool.name);
 
-    cornerstone.updateImage(element);
-  });
+		cornerstone.updateImage(element);
+	});
 
-  loadToolStateButton.addEventListener('click', event => {
-    if (toolState) {
-      cornerstoneTools.clearToolState(element, freehandRoiTool.name);
+	loadToolStateButton.addEventListener('click', event => {
+		if (toolState) {
+			cornerstoneTools.clearToolState(element, freehandRoiTool.name);
 
-      toolState.data.forEach((data) => {
-        cornerstoneTools.addToolState(element, freehandRoiTool.name, data);
-      })
+			toolState.data.forEach((data) => {
+				cornerstoneTools.addToolState(element, freehandRoiTool.name, data);
+			})
 
 			cornerstone.updateImage(element);
 			alert('loaded');
-    } else {
-			alert ('Nothing has been saved!');
+		} else {
+			alert('Nothing has been saved!');
 		}
-  });
+	});
 
-  element.addEventListener('keydown', event => {
-  	if (event.keyCode === 27) {
-	  	freehandRoiTool.cancelDrawing(element);
-  	}
-  	if (event.keyCode === 13) {
-  		freehandRoiTool.completeDrawing(element)
-  	}
-  });
+	element.addEventListener('keydown', event => {
+		if (event.keyCode === 27) {
+			freehandRoiTool.cancelDrawing(element);
+		}
+		if (event.keyCode === 13) {
+			freehandRoiTool.completeDrawing(element)
+		}
+	});
 
 </script>
 

--- a/netlify-example/stack/index.html
+++ b/netlify-example/stack/index.html
@@ -20,8 +20,8 @@
 
 			<!-- Select Active Tool -->
 			<ul class="tool-category active" data-tool-category="tools">
-				<li><a href="#" data-tool="StackScroll" data-tool-type="drag">Mouse stack</a></li>
-				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-type="wheel">StackScrollMouseWheel</a></li>
+				<li><a href="#" data-tool="StackScroll" data-tool-interaction="drag">Mouse stack</a></li>
+				<li><a href="#" data-tool="StackScrollMouseWheel" data-tool-interaction="wheel">StackScrollMouseWheel</a></li>
 			</ul>
 
 			<!-- Our beautiful element targets -->
@@ -103,13 +103,13 @@
 			}
 
 			toolBtn.addEventListener('click', (evt) => {
-				const toolType = evt.target.getAttribute('data-tool-type')
+				const toolInteraction = evt.target.getAttribute('data-tool-interaction')
 				const isInActive = !evt.target.classList.contains('active');
 				if (isInActive) {
-					setButtonActive(toolName, mouseButtonMask, toolType);
+					setButtonActive(toolName, mouseButtonMask, toolInteraction);
 					cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
 				} else {
-					setButtonInActive(evt.target, mouseButtonMask, toolType);
+					setButtonInActive(evt.target, mouseButtonMask, toolInteraction);
 					cornerstoneTools.setToolDisabled(toolName);
 				}
 			});
@@ -176,7 +176,7 @@
 		});
 	}
 
-	const setButtonActive = (toolName, mouseButtonMask, toolType) => {
+	const setButtonActive = (toolName, mouseButtonMask, toolInteraction) => {
 		const toolButtons = document.querySelectorAll('a[data-tool]');
 
 		Array.from(toolButtons).forEach(toolBtn => {
@@ -184,16 +184,16 @@
 			let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
 			let touchIcon = `touch-1`
 
-			// Update classes depending on the toolType we clicked
-			if (toolType === 'none') {
+			// Update classes depending on the toolInteraction we clicked
+			if (toolInteraction === 'none') {
 				return;
-			} else if (toolType === 'multitouch') {
+			} else if (toolInteraction === 'multitouch') {
 				mouseButtonIcon = null;
 				touchIcon = 'touch-2';
-			} else if (toolType === 'pinch') {
+			} else if (toolInteraction === 'pinch') {
 				mouseButtonIcon = null;
 				touchIcon = 'touch-pinch';
-			} else if (toolType === 'wheel') {
+			} else if (toolInteraction === 'wheel') {
 				mouseButtonIcon = 'mousebutton-wheel';
 				touchIcon = null;
 			}
@@ -223,20 +223,20 @@
 		});
 	}
 
-	const setButtonInActive = (toolBtn, mouseButtonMask, toolType) => {
+	const setButtonInActive = (toolBtn, mouseButtonMask, toolInteraction) => {
 		let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
 		let touchIcon = `touch-1`
 
-		// Update classes depending on the toolType we clicked
-		if (toolType === 'none') {
+		// Update classes depending on the toolInteraction we clicked
+		if (toolInteraction === 'none') {
 			return;
-		} else if (toolType === 'multitouch') {
+		} else if (toolInteraction === 'multitouch') {
 			mouseButtonIcon = null;
 			touchIcon = 'touch-2';
-		} else if (toolType === 'pinch') {
+		} else if (toolInteraction === 'pinch') {
 			mouseButtonIcon = null;
 			touchIcon = 'touch-pinch';
-		} else if (toolType === 'wheel') {
+		} else if (toolInteraction === 'wheel') {
 			mouseButtonIcon = 'mousebutton-wheel';
 			touchIcon = null;
 		}

--- a/netlify-example/thirdParty/index.html
+++ b/netlify-example/thirdParty/index.html
@@ -1,340 +1,335 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <!-- support for mobile touch devices -->
-    <meta
-      name="viewport"
-      content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1"
-    />
-    <link rel="stylesheet" href="../reset.css" />
-    <link rel="stylesheet" href="../app.css" />
-    <link rel="stylesheet" href="../icon-classes.css" />
-    <link rel="stylesheet" href="../tool-help.css" />
-  </head>
 
-  <body>
-    <div id="app">
-      <div class="wrapper">
-        <!-- Select Tool Category -->
-        <ul class="tool-category-list">
-          <li><a class="tools" data-category="tools" href="#">Tools</a></li>
-        </ul>
+<head>
+  <!-- support for mobile touch devices -->
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1" />
+  <link rel="stylesheet" href="../reset.css" />
+  <link rel="stylesheet" href="../app.css" />
+  <link rel="stylesheet" href="../icon-classes.css" />
+  <link rel="stylesheet" href="../tool-help.css" />
+</head>
 
-        <!-- Select Active Tool -->
-        <ul class="tool-category active" data-tool-category="tools">
-          <li><a href="#" data-tool="HelloWorldMouse">HelloWorldMouse</a></li>
-        </ul>
+<body>
+  <div id="app">
+    <div class="wrapper">
+      <!-- Select Tool Category -->
+      <ul class="tool-category-list">
+        <li><a class="tools" data-category="tools" href="#">Tools</a></li>
+      </ul>
 
-        <!-- Our beautiful element targets -->
-        <div class="cornerstone-element-wrapper-help">
-          <div
-            class="cornerstone-element-help"
-            data-index="0"
-            oncontextmenu="return false"
-          ></div>
-          <div class="tool-help"></div>
-        </div>
+      <!-- Select Active Tool -->
+      <ul class="tool-category active" data-tool-category="tools">
+        <li><a href="#" data-tool="HelloWorldMouse">HelloWorldMouse</a></li>
+      </ul>
+
+      <!-- Our beautiful element targets -->
+      <div class="cornerstone-element-wrapper-help">
+        <div class="cornerstone-element-help" data-index="0" oncontextmenu="return false"></div>
+        <div class="tool-help"></div>
       </div>
     </div>
-  </body>
+  </div>
+</body>
 
-  <!-- include the hammer.js library for touch gestures-->
-  <script src="https://unpkg.com/hammerjs@2.0.8/hammer.js"></script>
+<!-- include the hammer.js library for touch gestures-->
+<script src="https://unpkg.com/hammerjs@2.0.8/hammer.js"></script>
 
-  <!-- include the cornerstone library -->
-  <script src="https://unpkg.com/cornerstone-core@2.2.6/dist/cornerstone.js"></script>
-  <script src="https://unpkg.com/cornerstone-math@0.1.6/dist/cornerstoneMath.js"></script>
-  <script src="../../dist/cornerstoneTools.js"></script>
-  <script>
-    window.cornerstoneTools ||
-      document.write(
-        '<script src="https://unpkg.com/cornerstone-tools">\x3C/script>'
-      );
-  </script>
-
-  <!-- include special code for these examples which provides images -->
-  <script src="../imageLoader.js"></script>
-
-  <script>
-    //====== Define some thirdParty functionality: ======//
-    // 1) A module
-    const state = {
-      isPolite: true,
-      responses: {
-        polite: 'Hello World!',
-        rude: 'Go away, World.',
-      },
-    };
-
-    const myModule = {
-      state,
-      getters: {
-        response: () => {
-          if (state.isPolite) {
-            return state.responses.polite;
-          } else {
-            return state.responses.rude;
-          }
-        },
-      },
-      setters: {
-        politeResponse: response => {
-          state.responses.polite = response;
-        },
-        rudeResponse: response => {
-          state.responses.rude = response;
-        },
-        moodSwitch: () => {
-          state.isPolite = !state.isPolite;
-        },
-      },
-      onRegisterCallback: () => {
-        console.log('Hello onRegisterCallback.');
-      },
-      enabledElementCallback: enabledElement => {
-        console.log(
-          `module: enabledElementCallback: Hello element ${
-            enabledElement.uuid
-          }.`
-        );
-      },
-    };
-    // 2) A mixin
-    const myMixin = {
-      evenMoreHelloWorldMixin: () => {
-        // Note this would need to be called from somewhere
-        // Within the tool's implementation.
-        console.log('Hello World from the even more hello world mixin!');
-      },
-    };
-
-    // 3) A Tool
-    const BaseTool = cornerstoneTools.importInternal('base/BaseTool');
-
-    class HelloWorldMouseTool extends BaseTool {
-      constructor(name = 'HelloWorldMouse') {
-        super({
-          name,
-          supportedInteractionTypes: ['mouse'],
-          mixins: [
-            'activeOrDisabledBinaryTool', // Mixin from cornerstoneTools source.
-            'evenMoreHelloWorld', // Mixin from the plugin.
-          ],
-        });
-
-        this._helloWorldModule = cornerstoneTools.getModule('helloWorld');
-      }
-
-      preMouseDownCallback(evt) {
-        // Say response
-        console.log(this._helloWorldModule.getters.response());
-
-        // Mood switch
-        this._helloWorldModule.setters.moodSwitch();
-
-        // Call mixin function
-        this.evenMoreHelloWorldMixin();
-      }
-
-      activeCallback(element) {
-        const enabledElement = cornerstone.getEnabledElement(element);
-
-        console.log(`Hello element ${enabledElement.uuid}!`);
-      }
-
-      disabledCallback(element) {
-        const enabledElement = cornerstone.getEnabledElement(element);
-
-        console.log(`Goodbye element ${enabledElement.uuid}!`);
-      }
-    }
-
-    // Register the thirdParty functionality
-    cornerstoneTools.register('module', 'helloWorld', myModule);
-    cornerstoneTools.register('mixin', 'evenMoreHelloWorld', myMixin);
-
-    // Initialise the extended cornerstoneTools library.
-    cornerstoneTools.init();
-
-    const imageIds = ['example://1', 'example://2', 'example://3'];
-    const stack = {
-      currentImageIdIndex: 0,
-      imageIds: imageIds,
-    };
-
-    // Enable & Setup all of our elements
-    const element = document.querySelector('.cornerstone-element-help');
-
-    cornerstone.enable(element);
-
-    element.tabIndex = 0;
-    element.focus();
-
-    cornerstone.loadImage(imageIds[0]).then(function(image) {
-      cornerstone.displayImage(element, image);
-
-      cornerstoneTools.addStackStateManager(element, ['stack']);
-      cornerstoneTools.addToolState(element, 'stack', stack);
-    });
-
-    function setAllToolsPassive() {
-      cornerstoneTools.store.state.tools.forEach(tool => {
-        cornerstoneTools.setToolPassive(tool.name);
-      });
-    }
-
-    // Iterate over all tool-category links
-    const toolCategoryLinks = document.querySelectorAll(
-      'ul.tool-category-list a'
+<!-- include the cornerstone library -->
+<script src="https://unpkg.com/cornerstone-core@2.2.6/dist/cornerstone.js"></script>
+<script src="https://unpkg.com/cornerstone-math@0.1.6/dist/cornerstoneMath.js"></script>
+<script src="../../dist/cornerstoneTools.js"></script>
+<script>
+  window.cornerstoneTools ||
+    document.write(
+      '<script src="https://unpkg.com/cornerstone-tools">\x3C/script>'
     );
-    const toolCategorySections = document.querySelectorAll('ul.tool-category');
-    Array.from(toolCategoryLinks).forEach(link => {
-      //
-      const categoryName = link.getAttribute('data-category');
-      const categoryElement = document.querySelector(
-        `section[data-tool-category="${categoryName}"]`
-      );
+</script>
 
-      // Setup listener
-      link.addEventListener('click', evt => {
-        evt.preventDefault();
-        setToolCategoryActive(categoryName);
-      });
-    });
+<!-- include special code for these examples which provides images -->
+<script src="../imageLoader.js"></script>
 
-    // Iterate over all tool buttons
-    const toolButtons = document.querySelectorAll('a[data-tool]');
-    const toolBtn = document.querySelector('a[data-tool]');
-    const toolName = toolBtn.getAttribute('data-tool');
-    // Add the 3rd party tool (may be locally defined, or from an npm library)
+<script>
+  //====== Define some thirdParty functionality: ======//
+  // 1) A module
+  const state = {
+    isPolite: true,
+    responses: {
+      polite: 'Hello World!',
+      rude: 'Go away, World.',
+    },
+  };
 
-    cornerstoneTools.addTool(HelloWorldMouseTool);
-
-    // Setup button listener
-    // Prevent right click context menu for our menu buttons
-    toolBtn.addEventListener(
-      'contextmenu',
-      event => event.preventDefault(),
-      true
-    );
-    // Prevent middle click opening a new tab on Chrome & FF
-    toolBtn.addEventListener(
-      'auxclick',
-      event => {
-        if (event.button && event.button === 1) {
-          event.preventDefault();
+  const myModule = {
+    state,
+    getters: {
+      response: () => {
+        if (state.isPolite) {
+          return state.responses.polite;
+        } else {
+          return state.responses.rude;
         }
       },
-      false
-    );
-    toolBtn.addEventListener('mousedown', evt => {
-      const mouseButtonMask = evt.buttons
-        ? evt.buttons
-        : convertMouseEventWhichToButtons(evt.which);
-      // TODO: Let's make this happen automagically for mask/touch conflicts?
-      setAllToolsPassive();
-      const toolType = evt.target.getAttribute('data-tool-type');
-      setButtonActive(toolName, mouseButtonMask, toolType);
-      cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
+    },
+    setters: {
+      politeResponse: response => {
+        state.responses.polite = response;
+      },
+      rudeResponse: response => {
+        state.responses.rude = response;
+      },
+      moodSwitch: () => {
+        state.isPolite = !state.isPolite;
+      },
+    },
+    onRegisterCallback: () => {
+      console.log('Hello onRegisterCallback.');
+    },
+    enabledElementCallback: enabledElement => {
+      console.log(
+        `module: enabledElementCallback: Hello element ${
+        enabledElement.uuid
+        }.`
+      );
+    },
+  };
+  // 2) A mixin
+  const myMixin = {
+    evenMoreHelloWorldMixin: () => {
+      // Note this would need to be called from somewhere
+      // Within the tool's implementation.
+      console.log('Hello World from the even more hello world mixin!');
+    },
+  };
 
+  // 3) A Tool
+  const BaseTool = cornerstoneTools.importInternal('base/BaseTool');
+
+  class HelloWorldMouseTool extends BaseTool {
+    constructor(name = 'HelloWorldMouse') {
+      super({
+        name,
+        supportedInteractionTypes: ['mouse'],
+        mixins: [
+          'activeOrDisabledBinaryTool', // Mixin from cornerstoneTools source.
+          'evenMoreHelloWorld', // Mixin from the plugin.
+        ],
+      });
+
+      this._helloWorldModule = cornerstoneTools.getModule('helloWorld');
+    }
+
+    preMouseDownCallback(evt) {
+      // Say response
+      console.log(this._helloWorldModule.getters.response());
+
+      // Mood switch
+      this._helloWorldModule.setters.moodSwitch();
+
+      // Call mixin function
+      this.evenMoreHelloWorldMixin();
+    }
+
+    activeCallback(element) {
+      const enabledElement = cornerstone.getEnabledElement(element);
+
+      console.log(`Hello element ${enabledElement.uuid}!`);
+    }
+
+    disabledCallback(element) {
+      const enabledElement = cornerstone.getEnabledElement(element);
+
+      console.log(`Goodbye element ${enabledElement.uuid}!`);
+    }
+  }
+
+  // Register the thirdParty functionality
+  cornerstoneTools.register('module', 'helloWorld', myModule);
+  cornerstoneTools.register('mixin', 'evenMoreHelloWorld', myMixin);
+
+  // Initialise the extended cornerstoneTools library.
+  cornerstoneTools.init();
+
+  const imageIds = ['example://1', 'example://2', 'example://3'];
+  const stack = {
+    currentImageIdIndex: 0,
+    imageIds: imageIds,
+  };
+
+  // Enable & Setup all of our elements
+  const element = document.querySelector('.cornerstone-element-help');
+
+  cornerstone.enable(element);
+
+  element.tabIndex = 0;
+  element.focus();
+
+  cornerstone.loadImage(imageIds[0]).then(function (image) {
+    cornerstone.displayImage(element, image);
+
+    cornerstoneTools.addStackStateManager(element, ['stack']);
+    cornerstoneTools.addToolState(element, 'stack', stack);
+  });
+
+  function setAllToolsPassive() {
+    cornerstoneTools.store.state.tools.forEach(tool => {
+      cornerstoneTools.setToolPassive(tool.name);
+    });
+  }
+
+  // Iterate over all tool-category links
+  const toolCategoryLinks = document.querySelectorAll(
+    'ul.tool-category-list a'
+  );
+  const toolCategorySections = document.querySelectorAll('ul.tool-category');
+  Array.from(toolCategoryLinks).forEach(link => {
+    //
+    const categoryName = link.getAttribute('data-category');
+    const categoryElement = document.querySelector(
+      `section[data-tool-category="${categoryName}"]`
+    );
+
+    // Setup listener
+    link.addEventListener('click', evt => {
       evt.preventDefault();
-      evt.stopPropagation();
-      evt.stopImmediatePropagation();
-      return false;
+      setToolCategoryActive(categoryName);
     });
+  });
 
-    // Activate first tool
-    cornerstoneTools.setToolActive(cornerstoneTools.store.state.tools[0].name, {
-      mouseButtonMask: 1,
-    });
+  // Iterate over all tool buttons
+  const toolButtons = document.querySelectorAll('a[data-tool]');
+  const toolBtn = document.querySelector('a[data-tool]');
+  const toolName = toolBtn.getAttribute('data-tool');
+  // Add the 3rd party tool (may be locally defined, or from an npm library)
 
-    const setToolCategoryActive = categoryName => {
-      Array.from(toolCategoryLinks).forEach(toolLink => {
-        if (categoryName === toolLink.getAttribute('data-category')) {
-          toolLink.classList.remove('active');
-          toolLink.classList.add('active');
-        } else {
-          toolLink.classList.remove('active');
-        }
-      });
+  cornerstoneTools.addTool(HelloWorldMouseTool);
 
-      Array.from(toolCategorySections).forEach(toolCategorySection => {
-        if (
-          categoryName ===
-          toolCategorySection.getAttribute('data-tool-category')
-        ) {
-          toolCategorySection.classList.remove('active');
-          toolCategorySection.classList.add('active');
-        } else {
-          toolCategorySection.classList.remove('active');
-        }
-      });
-    };
-
-    const setButtonActive = (toolName, mouseButtonMask, toolType) => {
-      Array.from(toolButtons).forEach(toolBtn => {
-        // Classes we need to set & remove
-        let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
-        let touchIcon = `touch-1`;
-
-        // Update classes depending on the toolType we clicked
-        if (toolType === 'none') {
-          return;
-        } else if (toolType === 'multitouch') {
-          mouseButtonIcon = null;
-          touchIcon = 'touch-2';
-        } else if (toolType === 'pinch') {
-          mouseButtonIcon = null;
-          touchIcon = 'touch-pinch';
-        } else if (toolType === 'wheel') {
-          mouseButtonIcon = 'mousebutton-wheel';
-          touchIcon = null;
-        }
-
-        // Update our target button
-        if (toolName === toolBtn.getAttribute('data-tool')) {
-          toolBtn.className = '';
-          toolBtn.classList.add('active');
-          if (mouseButtonIcon) {
-            toolBtn.classList.add(mouseButtonIcon);
-          }
-          if (touchIcon) {
-            toolBtn.classList.add(touchIcon);
-          }
-          // Remove relevant classes from other buttons
-        } else {
-          if (mouseButtonIcon && toolBtn.classList.contains(mouseButtonIcon)) {
-            toolBtn.classList.remove(mouseButtonIcon);
-          }
-          if (touchIcon && toolBtn.classList.contains(touchIcon)) {
-            toolBtn.classList.remove(touchIcon);
-          }
-          if (
-            toolBtn.classList.length === 1 &&
-            toolBtn.classList[0] === 'active'
-          ) {
-            toolBtn.classList.remove('active');
-          }
-        }
-      });
-    };
-
-    const convertMouseEventWhichToButtons = which => {
-      switch (which) {
-        // no button
-        case 0:
-          return 0;
-        // left
-        case 1:
-          return 1;
-        // middle
-        case 2:
-          return 4;
-        // right
-        case 3:
-          return 2;
+  // Setup button listener
+  // Prevent right click context menu for our menu buttons
+  toolBtn.addEventListener(
+    'contextmenu',
+    event => event.preventDefault(),
+    true
+  );
+  // Prevent middle click opening a new tab on Chrome & FF
+  toolBtn.addEventListener(
+    'auxclick',
+    event => {
+      if (event.button && event.button === 1) {
+        event.preventDefault();
       }
-      return 0;
-    };
-  </script>
+    },
+    false
+  );
+  toolBtn.addEventListener('mousedown', evt => {
+    const mouseButtonMask = evt.buttons
+      ? evt.buttons
+      : convertMouseEventWhichToButtons(evt.which);
+    // TODO: Let's make this happen automagically for mask/touch conflicts?
+    setAllToolsPassive();
+    const toolInteraction = evt.target.getAttribute('data-tool-interaction');
+    setButtonActive(toolName, mouseButtonMask, toolInteraction);
+    cornerstoneTools.setToolActive(toolName, { mouseButtonMask });
+
+    evt.preventDefault();
+    evt.stopPropagation();
+    evt.stopImmediatePropagation();
+    return false;
+  });
+
+  // Activate first tool
+  cornerstoneTools.setToolActive(cornerstoneTools.store.state.tools[0].name, {
+    mouseButtonMask: 1,
+  });
+
+  const setToolCategoryActive = categoryName => {
+    Array.from(toolCategoryLinks).forEach(toolLink => {
+      if (categoryName === toolLink.getAttribute('data-category')) {
+        toolLink.classList.remove('active');
+        toolLink.classList.add('active');
+      } else {
+        toolLink.classList.remove('active');
+      }
+    });
+
+    Array.from(toolCategorySections).forEach(toolCategorySection => {
+      if (
+        categoryName ===
+        toolCategorySection.getAttribute('data-tool-category')
+      ) {
+        toolCategorySection.classList.remove('active');
+        toolCategorySection.classList.add('active');
+      } else {
+        toolCategorySection.classList.remove('active');
+      }
+    });
+  };
+
+  const setButtonActive = (toolName, mouseButtonMask, toolInteraction) => {
+    Array.from(toolButtons).forEach(toolBtn => {
+      // Classes we need to set & remove
+      let mouseButtonIcon = `mousebutton-${mouseButtonMask}`;
+      let touchIcon = `touch-1`;
+
+      // Update classes depending on the toolInteraction we clicked
+      if (toolInteraction === 'none') {
+        return;
+      } else if (toolInteraction === 'multitouch') {
+        mouseButtonIcon = null;
+        touchIcon = 'touch-2';
+      } else if (toolInteraction === 'pinch') {
+        mouseButtonIcon = null;
+        touchIcon = 'touch-pinch';
+      } else if (toolInteraction === 'wheel') {
+        mouseButtonIcon = 'mousebutton-wheel';
+        touchIcon = null;
+      }
+
+      // Update our target button
+      if (toolName === toolBtn.getAttribute('data-tool')) {
+        toolBtn.className = '';
+        toolBtn.classList.add('active');
+        if (mouseButtonIcon) {
+          toolBtn.classList.add(mouseButtonIcon);
+        }
+        if (touchIcon) {
+          toolBtn.classList.add(touchIcon);
+        }
+        // Remove relevant classes from other buttons
+      } else {
+        if (mouseButtonIcon && toolBtn.classList.contains(mouseButtonIcon)) {
+          toolBtn.classList.remove(mouseButtonIcon);
+        }
+        if (touchIcon && toolBtn.classList.contains(touchIcon)) {
+          toolBtn.classList.remove(touchIcon);
+        }
+        if (
+          toolBtn.classList.length === 1 &&
+          toolBtn.classList[0] === 'active'
+        ) {
+          toolBtn.classList.remove('active');
+        }
+      }
+    });
+  };
+
+  const convertMouseEventWhichToButtons = which => {
+    switch (which) {
+      // no button
+      case 0:
+        return 0;
+      // left
+      case 1:
+        return 1;
+      // middle
+      case 2:
+        return 4;
+      // right
+      case 3:
+        return 2;
+    }
+    return 0;
+  };
+</script>
+
 </html>

--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -40,6 +40,7 @@ export default function(evt, tool) {
       const eventType = EVENTS.MEASUREMENT_COMPLETED;
       const eventData = {
         toolName: tool.name,
+        toolType: tool.name, // Deprecation notice: toolType will be replaced by toolName
         element,
         measurementData,
       };

--- a/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
@@ -69,6 +69,7 @@ export default function(evt, tool) {
       const eventType = EVENTS.MEASUREMENT_COMPLETED;
       const eventData = {
         toolName: tool.name,
+        toolType: tool.name, // Deprecation notice: toolType will be replaced by toolName
         element,
         measurementData,
       };

--- a/src/eventListeners/touchEventListeners.js
+++ b/src/eventListeners/touchEventListeners.js
@@ -23,7 +23,7 @@ let lastScale = 1.0,
 const pressDelay = 700,
   pressMaxDistance = 5;
 
-const toolName = 'touchInput';
+const inputName = 'touchInput';
 
 function onTouch(e) {
   const element = e.currentTarget || e.srcEvent.currentTarget;
@@ -578,11 +578,13 @@ function enable(element) {
     element.addEventListener(eventType, onTouch, { passive: false });
   });
 
-  const options = getToolOptions(toolName, element);
+  // TODO: Check why we are using tool options if it's not a tool
+  const options = getToolOptions(inputName, element);
 
   options.hammer = mc;
 
-  setToolOptions(toolName, element, options);
+  // TODO: Check why we are using tool options if it's not a tool
+  setToolOptions(inputName, element, options);
 }
 
 function disable(element) {
@@ -594,7 +596,8 @@ function disable(element) {
     element.removeEventListener(eventType, onTouch);
   });
 
-  const options = getToolOptions(toolName, element);
+  // TODO: Check why we are using tool options if it's not a tool
+  const options = getToolOptions(inputName, element);
   const mc = options.hammer;
 
   if (mc) {

--- a/src/eventListeners/touchEventListeners.js
+++ b/src/eventListeners/touchEventListeners.js
@@ -23,7 +23,7 @@ let lastScale = 1.0,
 const pressDelay = 700,
   pressMaxDistance = 5;
 
-const toolType = 'touchInput';
+const toolName = 'touchInput';
 
 function onTouch(e) {
   const element = e.currentTarget || e.srcEvent.currentTarget;
@@ -578,11 +578,11 @@ function enable(element) {
     element.addEventListener(eventType, onTouch, { passive: false });
   });
 
-  const options = getToolOptions(toolType, element);
+  const options = getToolOptions(toolName, element);
 
   options.hammer = mc;
 
-  setToolOptions(toolType, element, options);
+  setToolOptions(toolName, element, options);
 }
 
 function disable(element) {
@@ -594,7 +594,7 @@ function disable(element) {
     element.removeEventListener(eventType, onTouch);
   });
 
-  const options = getToolOptions(toolType, element);
+  const options = getToolOptions(toolName, element);
   const mc = options.hammer;
 
   if (mc) {

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -96,7 +96,10 @@ export default function(
       annotation,
       options,
       interactionType,
-      { dragHandler, upOrEndHandler },
+      {
+        dragHandler,
+        upOrEndHandler,
+      },
       element,
       doneMovingCallback
     )
@@ -162,6 +165,7 @@ function _dragHandler(
   const eventType = EVENTS.MEASUREMENT_MODIFIED;
   const modifiedEventData = {
     toolName,
+    toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
     element,
     measurementData: annotation,
   };
@@ -184,7 +188,10 @@ function _cancelEventHandler(
     annotation,
     options,
     interactionType,
-    { dragHandler, upOrEndHandler },
+    {
+      dragHandler,
+      upOrEndHandler,
+    },
     element,
     doneMovingCallback,
     false
@@ -202,6 +209,7 @@ function _upOrEndHandler(
 ) {
   const eventData = evt.detail;
   const { element } = eventData;
+
   manipulatorStateModule.setters.removeActiveManipulatorForElement(element);
 
   // If any handle is outside the image, delete the tool data
@@ -216,7 +224,10 @@ function _upOrEndHandler(
     annotation,
     options,
     interactionType,
-    { dragHandler, upOrEndHandler },
+    {
+      dragHandler,
+      upOrEndHandler,
+    },
     element,
     doneMovingCallback,
     true

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -80,7 +80,7 @@ export default function(
     interactionType
   );
   // So we don't need to inline the entire `upOrEndHandler` function
-  const upOrEndHandler = evt => {
+  const upOrEndHandler = () => {
     _upOrEndHandler(
       toolName,
       evtDetail,
@@ -192,6 +192,7 @@ function _dragHandler(
   const eventType = EVENTS.MEASUREMENT_MODIFIED;
   const modifiedEventData = {
     toolName,
+    toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
     element,
     measurementData: annotation,
   };
@@ -216,7 +217,10 @@ function _cancelEventHandler(
     handle,
     options,
     interactionType,
-    { dragHandler, upOrEndHandler },
+    {
+      dragHandler,
+      upOrEndHandler,
+    },
     doneMovingCallback,
     false
   );
@@ -233,6 +237,7 @@ function _upOrEndHandler(
   doneMovingCallback
 ) {
   const { element } = evtDetail;
+
   manipulatorStateModule.setters.removeActiveManipulatorForElement(element);
 
   _endHandler(
@@ -242,7 +247,10 @@ function _upOrEndHandler(
     handle,
     options,
     interactionType,
-    { dragHandler, upOrEndHandler },
+    {
+      dragHandler,
+      upOrEndHandler,
+    },
     doneMovingCallback,
     true
   );

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -4,7 +4,7 @@ import anyHandlesOutsideImage from './anyHandlesOutsideImage.js';
 import { removeToolState } from '../stateManagement/toolState.js';
 import triggerEvent from '../util/triggerEvent.js';
 import { clipToBox } from '../util/clip.js';
-import { state, setters } from './../store/index.js';
+import { state } from './../store/index.js';
 import getActiveTool from '../util/getActiveTool';
 import BaseAnnotationTool from '../tools/base/BaseAnnotationTool';
 import { getLogger } from '../util/logger.js';
@@ -31,7 +31,7 @@ const _moveEndEvents = {
  * @method moveNewHandle
  * @memberof Manipulators
  *
- * @param {*} evtDetail
+ * @param {*} eventData
  * @param {*} toolName
  * @param {*} annotation
  * @param {*} handle
@@ -117,7 +117,10 @@ export default function(
       handle,
       options,
       interactionType,
-      { moveHandler, moveEndHandler },
+      {
+        moveHandler,
+        moveEndHandler,
+      },
       element,
       doneMovingCallback
     )
@@ -127,6 +130,15 @@ export default function(
 /**
  * Updates annotation as the "pointer" is moved/dragged
  * Emits `cornerstonetoolsmeasurementmodified` events
+ *
+ * @param {string} toolName
+ * @param {*} annotation
+ * @param {*} handle
+ * @param {*} options
+ * @param {string} interactionType
+ * @param {*} evt
+ *
+ * @returns {void}
  */
 function _moveHandler(
   toolName,
@@ -168,6 +180,7 @@ function _moveHandler(
   const eventType = EVENTS.MEASUREMENT_MODIFIED;
   const modifiedEventData = {
     toolName,
+    toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
     element,
     measurementData: annotation,
   };
@@ -280,7 +293,10 @@ function _moveEndHandler(
     interactionType,
     options,
     element,
-    { moveHandler, moveEndHandler },
+    {
+      moveHandler,
+      moveEndHandler,
+    },
     doneMovingCallback,
     true
   );
@@ -304,7 +320,10 @@ function _cancelEventHandler(
     interactionType,
     options,
     element,
-    { moveHandler, moveEndHandler },
+    {
+      moveHandler,
+      moveEndHandler,
+    },
     doneMovingCallback,
     false
   );

--- a/src/stackTools/playClip.js
+++ b/src/stackTools/playClip.js
@@ -4,7 +4,7 @@ import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import triggerEvent from '../util/triggerEvent.js';
 
-const toolType = 'playClip';
+const toolName = 'playClip';
 
 /**
  * [private] Turns a Frame Time Vector (0018,1065) array into a normalized array of timeouts. Each element
@@ -129,7 +129,7 @@ function playClip(element, framesPerSecond) {
 
   const stackData = stackToolData.data[0];
 
-  const playClipToolData = getToolState(element, toolType);
+  const playClipToolData = getToolState(element, toolName);
 
   if (
     !playClipToolData ||
@@ -148,7 +148,7 @@ function playClip(element, framesPerSecond) {
       reverse: false,
       loop: true,
     };
-    addToolState(element, toolType, playClipData);
+    addToolState(element, toolName, playClipData);
   } else {
     playClipData = playClipToolData.data[0];
     // Make sure the specified clip is not running before any property update
@@ -287,7 +287,7 @@ function playClip(element, framesPerSecond) {
  * @returns {void}
  */
 function stopClip(element) {
-  const playClipToolData = getToolState(element, toolType);
+  const playClipToolData = getToolState(element, toolName);
 
   if (
     !playClipToolData ||

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -9,7 +9,7 @@ import EVENTS from '../events.js';
 
 const logger = getLogger('stackTools:stackPrefetch');
 
-const toolType = 'stackPrefetch';
+const toolName = 'stackPrefetch';
 const requestType = 'prefetch';
 
 let configuration = {
@@ -79,7 +79,7 @@ function prefetch(element) {
   const stack = stackData.data[0];
 
   // Get the stackPrefetch tool data
-  const stackPrefetchData = getToolState(element, toolType);
+  const stackPrefetchData = getToolState(element, toolName);
 
   if (!stackPrefetchData) {
     return;
@@ -278,7 +278,7 @@ function getPromiseRemovedHandler(element) {
       return;
     }
 
-    const stackPrefetchData = getToolState(element, toolType);
+    const stackPrefetchData = getToolState(element, toolName);
 
     if (
       !stackPrefetchData ||
@@ -311,7 +311,7 @@ function onImageUpdated(e) {
 
 function enable(element) {
   // Clear old prefetch data. Skipping this can cause problems when changing the series inside an element
-  const stackPrefetchDataArray = getToolState(element, toolType);
+  const stackPrefetchDataArray = getToolState(element, toolName);
 
   stackPrefetchDataArray.data = [];
 
@@ -347,7 +347,7 @@ function enable(element) {
 
   stackPrefetchData.indicesToRequest.splice(indexOfCurrentImage, 1);
 
-  addToolState(element, toolType, stackPrefetchData);
+  addToolState(element, toolName, stackPrefetchData);
 
   prefetch(element);
 
@@ -386,7 +386,7 @@ function disable(element) {
     promiseRemovedHandler
   );
 
-  const stackPrefetchData = getToolState(element, toolType);
+  const stackPrefetchData = getToolState(element, toolName);
   // If there is actually something to disable, disable it
 
   if (stackPrefetchData && stackPrefetchData.data.length) {

--- a/src/stateManagement/frameOfReferenceStateManager.js
+++ b/src/stateManagement/frameOfReferenceStateManager.js
@@ -15,7 +15,7 @@ function newFrameOfReferenceSpecificToolStateManager() {
   // As modules that restore saved state
   function addFrameOfReferenceSpecificToolState(
     frameOfReference,
-    toolType,
+    toolName,
     data
   ) {
     // If we don't have any tool state for this frameOfReference, add an empty object
@@ -26,13 +26,13 @@ function newFrameOfReferenceSpecificToolStateManager() {
     const frameOfReferenceToolState = toolState[frameOfReference];
 
     // If we don't have tool state for this type of tool, add an empty object
-    if (frameOfReferenceToolState.hasOwnProperty(toolType) === false) {
-      frameOfReferenceToolState[toolType] = {
+    if (frameOfReferenceToolState.hasOwnProperty(toolName) === false) {
+      frameOfReferenceToolState[toolName] = {
         data: [],
       };
     }
 
-    const toolData = frameOfReferenceToolState[toolType];
+    const toolData = frameOfReferenceToolState[toolName];
 
     // Finally, add this new tool to the state
     toolData.data.push(data);
@@ -40,7 +40,7 @@ function newFrameOfReferenceSpecificToolStateManager() {
 
   // Here you can get state - used by tools as well as modules
   // That save state persistently
-  function getFrameOfReferenceSpecificToolState(frameOfReference, toolType) {
+  function getFrameOfReferenceSpecificToolState(frameOfReference, toolName) {
     // If we don't have any tool state for this frame of reference, return undefined
     if (toolState.hasOwnProperty(frameOfReference) === false) {
       return;
@@ -49,18 +49,18 @@ function newFrameOfReferenceSpecificToolStateManager() {
     const frameOfReferenceToolState = toolState[frameOfReference];
 
     // If we don't have tool state for this type of tool, return undefined
-    if (frameOfReferenceToolState.hasOwnProperty(toolType) === false) {
+    if (frameOfReferenceToolState.hasOwnProperty(toolName) === false) {
       return;
     }
 
-    const toolData = frameOfReferenceToolState[toolType];
+    const toolData = frameOfReferenceToolState[toolName];
 
     return toolData;
   }
 
   function removeFrameOfReferenceSpecificToolState(
     frameOfReference,
-    toolType,
+    toolName,
     data
   ) {
     // If we don't have any tool state for this frame of reference, return undefined
@@ -71,11 +71,11 @@ function newFrameOfReferenceSpecificToolStateManager() {
     const frameOfReferenceToolState = toolState[frameOfReference];
 
     // If we don't have tool state for this type of tool, return undefined
-    if (frameOfReferenceToolState.hasOwnProperty(toolType) === false) {
+    if (frameOfReferenceToolState.hasOwnProperty(toolName) === false) {
       return;
     }
 
-    const toolData = frameOfReferenceToolState[toolType];
+    const toolData = frameOfReferenceToolState[toolName];
     // Find this tool data
     let indexOfData = -1;
 

--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -34,17 +34,17 @@ function newImageIdSpecificToolStateManager() {
 
   // Here we add tool state, this is done by tools as well
   // As modules that restore saved state
-  function addElementToolState(element, toolType, data) {
+  function addElementToolState(element, toolName, data) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
     // If we don't have an image for this element exit early
     if (!enabledElement.image) {
       return;
     }
-    addImageIdToolState(enabledElement.image.imageId, toolType, data);
+    addImageIdToolState(enabledElement.image.imageId, toolName, data);
   }
 
-  function addImageIdToolState(imageId, toolType, data) {
+  function addImageIdToolState(imageId, toolName, data) {
     // If we don't have any tool state for this imageId, add an empty object
     if (toolState.hasOwnProperty(imageId) === false) {
       toolState[imageId] = {};
@@ -52,20 +52,20 @@ function newImageIdSpecificToolStateManager() {
 
     const imageIdToolState = toolState[imageId];
 
-    // If we don't have tool state for this type of tool, add an empty object
-    if (imageIdToolState.hasOwnProperty(toolType) === false) {
-      imageIdToolState[toolType] = {
+    // If we don't have tool state for this tool name, add an empty object
+    if (imageIdToolState.hasOwnProperty(toolName) === false) {
+      imageIdToolState[toolName] = {
         data: [],
       };
     }
 
-    const toolData = imageIdToolState[toolType];
+    const toolData = imageIdToolState[toolName];
 
     // Finally, add this new tool to the state
     toolData.data.push(data);
   }
 
-  function getElementToolState(element, toolType) {
+  function getElementToolState(element, toolName) {
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
     // If the element does not have an image return undefined.
@@ -73,12 +73,12 @@ function newImageIdSpecificToolStateManager() {
       return;
     }
 
-    return getImageIdToolState(enabledElement.image.imageId, toolType);
+    return getImageIdToolState(enabledElement.image.imageId, toolName);
   }
 
   // Here you can get state - used by tools as well as modules
   // That save state persistently
-  function getImageIdToolState(imageId, toolType) {
+  function getImageIdToolState(imageId, toolName) {
     // If we don't have any tool state for this imageId, return undefined
     if (toolState.hasOwnProperty(imageId) === false) {
       return;
@@ -86,12 +86,12 @@ function newImageIdSpecificToolStateManager() {
 
     const imageIdToolState = toolState[imageId];
 
-    // If we don't have tool state for this type of tool, return undefined
-    if (imageIdToolState.hasOwnProperty(toolType) === false) {
+    // If we don't have tool state for this tool name, return undefined
+    if (imageIdToolState.hasOwnProperty(toolName) === false) {
       return;
     }
 
-    return imageIdToolState[toolType];
+    return imageIdToolState[toolName];
   }
 
   // Clears all tool data from this toolStateManager.

--- a/src/stateManagement/imageIdSpecificStateManager.test.js
+++ b/src/stateManagement/imageIdSpecificStateManager.test.js
@@ -6,7 +6,7 @@ jest.mock('./../externalModules.js');
 describe('imageIdSpecificStateManager.add', () => {
   it('creates the toolState and adds the data', () => {
     const stateManager = newImageIdSpecificToolStateManager();
-    const toolType = 'TestTool';
+    const toolName = 'TestTool';
     const imageId = 'abc123';
     const testElement = {
       image: {
@@ -17,16 +17,16 @@ describe('imageIdSpecificStateManager.add', () => {
     externalModules.cornerstone.getEnabledElement.mockImplementationOnce(
       () => testElement
     );
-    stateManager.add(testElement, toolType, 'data1');
+    stateManager.add(testElement, toolName, 'data1');
 
     const allToolState = stateManager.saveToolState();
 
-    expect(allToolState[imageId][toolType].data).toContain('data1');
+    expect(allToolState[imageId][toolName].data).toContain('data1');
   });
 
   it('adds data to the existing toolState', () => {
     const stateManager = newImageIdSpecificToolStateManager();
-    const toolType = 'TestTool';
+    const toolName = 'TestTool';
     const imageId = 'abc123';
     const testElement = {
       image: {
@@ -40,15 +40,15 @@ describe('imageIdSpecificStateManager.add', () => {
 
     // Setup with some intial data
     stateManager.restoreImageIdToolState(imageId, {
-      [toolType]: { data: ['initialData'] },
+      [toolName]: { data: ['initialData'] },
     });
     // Add more data
-    stateManager.add(testElement, toolType, 'addedData');
+    stateManager.add(testElement, toolName, 'addedData');
 
     // Check the results
     const allToolState = stateManager.saveToolState();
 
-    expect(allToolState[imageId][toolType].data).toEqual(
+    expect(allToolState[imageId][toolName].data).toEqual(
       expect.arrayContaining(['initialData', 'addedData'])
     );
   });
@@ -56,7 +56,7 @@ describe('imageIdSpecificStateManager.add', () => {
   describe('when the image is not yet defined', () => {
     it('returns without adding the data', () => {
       const stateManager = newImageIdSpecificToolStateManager();
-      const toolType = 'TestTool';
+      const toolName = 'TestTool';
       const imageId = 'abc123';
       const testElement = {
         image: undefined,
@@ -67,7 +67,7 @@ describe('imageIdSpecificStateManager.add', () => {
       );
 
       // Add more data
-      stateManager.add(testElement, toolType, 'testData');
+      stateManager.add(testElement, toolName, 'testData');
 
       // Check the results
       const allToolState = stateManager.saveToolState();

--- a/src/stateManagement/stackSpecificStateManager.js
+++ b/src/stateManagement/stackSpecificStateManager.js
@@ -11,8 +11,8 @@ import {
  * @constructor newStackSpecificToolStateManager
  * @memberof StateManagement
  *
- * @param  {string[]} toolNames       The tool names to apply to the stack.
- * @param  {Object} oldStateManager The imageIdSpecificStateManager.
+ * @param {string[]} toolNames     List of tools that should have state shared across a stack (a display set) of images
+ * @param {Object} oldStateManager The imageIdSpecificStateManager.
  * @returns {Object} A stackSpecificToolStateManager instance.
  */
 function newStackSpecificToolStateManager(toolNames, oldStateManager) {

--- a/src/stateManagement/stackSpecificStateManager.js
+++ b/src/stateManagement/stackSpecificStateManager.js
@@ -11,11 +11,11 @@ import {
  * @constructor newStackSpecificToolStateManager
  * @memberof StateManagement
  *
- * @param  {string[]} toolTypes       The tool types to apply to the stack.
+ * @param  {string[]} toolNames       The tool names to apply to the stack.
  * @param  {Object} oldStateManager The imageIdSpecificStateManager.
  * @returns {Object} A stackSpecificToolStateManager instance.
  */
-function newStackSpecificToolStateManager(toolTypes, oldStateManager) {
+function newStackSpecificToolStateManager(toolNames, oldStateManager) {
   let toolState = {};
 
   function saveToolState() {
@@ -28,43 +28,43 @@ function newStackSpecificToolStateManager(toolTypes, oldStateManager) {
 
   // Here we add tool state, this is done by tools as well
   // As modules that restore saved state
-  function addStackSpecificToolState(element, toolType, data) {
+  function addStackSpecificToolState(element, toolName, data) {
     // If this is a tool type to apply to the stack, do so
-    if (toolTypes.indexOf(toolType) >= 0) {
-      // If we don't have tool state for this type of tool, add an empty object
-      if (toolState.hasOwnProperty(toolType) === false) {
-        toolState[toolType] = {
+    if (toolNames.indexOf(toolName) >= 0) {
+      // If we don't have tool state for this tool name, add an empty object
+      if (toolState.hasOwnProperty(toolName) === false) {
+        toolState[toolName] = {
           data: [],
         };
       }
 
-      const toolData = toolState[toolType];
+      const toolData = toolState[toolName];
 
       // Finally, add this new tool to the state
       toolData.data.push(data);
     } else {
       // Call the imageId specific tool state manager
-      return oldStateManager.add(element, toolType, data);
+      return oldStateManager.add(element, toolName, data);
     }
   }
 
   // Here you can get state - used by tools as well as modules
   // That save state persistently
-  function getStackSpecificToolState(element, toolType) {
+  function getStackSpecificToolState(element, toolName) {
     // If this is a tool type to apply to the stack, do so
-    if (toolTypes.indexOf(toolType) >= 0) {
-      // If we don't have tool state for this type of tool, add an empty object
-      if (toolState.hasOwnProperty(toolType) === false) {
-        toolState[toolType] = {
+    if (toolNames.indexOf(toolName) >= 0) {
+      // If we don't have tool state for this tool name, add an empty object
+      if (toolState.hasOwnProperty(toolName) === false) {
+        toolState[toolName] = {
           data: [],
         };
       }
 
-      return toolState[toolType];
+      return toolState[toolName];
     }
 
     // Call the imageId specific tool state manager
-    return oldStateManager.get(element, toolType);
+    return oldStateManager.get(element, toolName);
   }
 
   const stackSpecificToolStateManager = {

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -31,19 +31,20 @@ function getElementToolStateManager(element) {
  * @method addToolState
  *
  * @param  {HTMLElement} element  The element.
- * @param  {string} toolType      The toolType of the state.
+ * @param  {string} toolName      The name of the tool the state belongs to.
  * @param  {Object} measurementData The data to store in the state.
  * @returns {undefined}
  */
-function addToolState(element, toolType, measurementData) {
+function addToolState(element, toolName, measurementData) {
   const toolStateManager = getElementToolStateManager(element);
 
   measurementData.uuid = measurementData.uuid || uuidv4();
-  toolStateManager.add(element, toolType, measurementData);
+  toolStateManager.add(element, toolName, measurementData);
 
   const eventType = EVENTS.MEASUREMENT_ADDED;
   const eventData = {
-    toolType,
+    toolName,
+    toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
     element,
     measurementData,
   };
@@ -60,13 +61,13 @@ function addToolState(element, toolType, measurementData) {
  * @name getToolState
  *
  * @param  {HTMLElement} element The element.
- * @param  {string} toolType The toolType of the state.
- * @returns {Object}          The element's state for the given toolType.
+ * @param  {string} toolName The name of the tool the state belongs to.
+ * @returns {Object}          The element's state for the given toolName.
  */
-function getToolState(element, toolType) {
+function getToolState(element, toolName) {
   const toolStateManager = getElementToolStateManager(element);
 
-  return toolStateManager.get(element, toolType);
+  return toolStateManager.get(element, toolName);
 }
 
 /**
@@ -75,13 +76,13 @@ function getToolState(element, toolType) {
  * @method removeToolState
  *
  * @param  {HTMLElement} element  The element.
- * @param  {string} toolType      The toolType of the state.
+ * @param  {string} toolName      The name of the tool the state belongs to.
  * @param  {Object} data          The data to remove from the toolStateManager.
  * @returns {undefined}
  */
-function removeToolState(element, toolType, data) {
+function removeToolState(element, toolName, data) {
   const toolStateManager = getElementToolStateManager(element);
-  const toolData = toolStateManager.get(element, toolType);
+  const toolData = toolStateManager.get(element, toolName);
 
   if (!toolData || !toolData.data || !toolData.data.length) {
     return;
@@ -101,7 +102,8 @@ function removeToolState(element, toolType, data) {
 
     const eventType = EVENTS.MEASUREMENT_REMOVED;
     const eventData = {
-      toolType,
+      toolName,
+      toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData: data,
     };
@@ -112,17 +114,17 @@ function removeToolState(element, toolType, data) {
 
 /**
  * Removes all toolState from the toolStateManager corresponding to
- * the toolType and element.
+ * the toolName and element.
  * @public
  * @method clearToolState
  *
  * @param  {HTMLElement} element  The element.
- * @param  {string} toolType      The toolType of the state.
+ * @param  {string} toolName      The name of the tool the state belongs to.
  * @returns {undefined}
  */
-function clearToolState(element, toolType) {
+function clearToolState(element, toolName) {
   const toolStateManager = getElementToolStateManager(element);
-  const toolData = toolStateManager.get(element, toolType);
+  const toolData = toolStateManager.get(element, toolName);
 
   // If any toolData actually exists, clear it
   if (toolData !== undefined) {

--- a/src/store/setToolMode.js
+++ b/src/store/setToolMode.js
@@ -266,6 +266,7 @@ function setToolModeForElement(mode, changeEvent, element, toolName, options) {
     const statusChangeEventData = {
       options,
       toolName,
+      toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
       type: changeEvent,
     };
 

--- a/src/store/setToolMode.test.js
+++ b/src/store/setToolMode.test.js
@@ -75,6 +75,7 @@ describe('setToolModeForElement', () => {
     expect(triggerEvent).toBeCalledWith(element, changeEvent, {
       options,
       toolName,
+      toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
       type: changeEvent,
     });
   });

--- a/src/toolOptions.js
+++ b/src/toolOptions.js
@@ -1,23 +1,23 @@
 const elementToolOptions = {};
 
 /**
- * Retrieve the options object associated with a particular toolType and element
+ * Retrieve the options object associated with a particular toolName and element
  * @export
  * @public
  * @method
  * @name getToolOptions
  *
- * @param {string} toolType Tool type identifier of the target options object
+ * @param {string} toolName Tool name identifier of the target options object
  * @param {HTMLElement} element Element of the target options object
  *
  * @returns {Object} Target options object (empty if not yet set)
  */
-function getToolOptions(toolType, element) {
-  if (!elementToolOptions[toolType]) {
+function getToolOptions(toolName, element) {
+  if (!elementToolOptions[toolName]) {
     return {};
   }
 
-  const toolOptions = elementToolOptions[toolType];
+  const toolOptions = elementToolOptions[toolName];
   const optionsObject = toolOptions.find(
     toolOptionObject => toolOptionObject.element === element
   );
@@ -30,20 +30,20 @@ function getToolOptions(toolType, element) {
 }
 
 /**
- * Set the options object associated with a particular toolType and element.
+ * Set the options object associated with a particular toolName and element.
  * @export
  * @public
  * @method
  * @name setToolOptions
  *
- * @param {string} toolType Tool type identifier of the target options object.
+ * @param {string} toolName Tool name identifier of the target options object.
  * @param {HTMLElement} element Element of the target options object.
  * @param {Object} options Options object to store at target.
  * @returns {void}
  */
-function setToolOptions(toolType, element, options) {
-  if (!elementToolOptions[toolType]) {
-    elementToolOptions[toolType] = [
+function setToolOptions(toolName, element, options) {
+  if (!elementToolOptions[toolName]) {
+    elementToolOptions[toolName] = [
       {
         element,
         options,
@@ -53,20 +53,20 @@ function setToolOptions(toolType, element, options) {
     return;
   }
 
-  const toolOptions = elementToolOptions[toolType];
+  const toolOptions = elementToolOptions[toolName];
   const index = toolOptions.findIndex(
     toolOptionObject => toolOptionObject.element === element
   );
 
   if (index === -1) {
-    elementToolOptions[toolType].push({
+    elementToolOptions[toolName].push({
       element,
       options,
     });
   } else {
-    const elementOptions = elementToolOptions[toolType][index].options || {};
+    const elementOptions = elementToolOptions[toolName][index].options || {};
 
-    elementToolOptions[toolType][index].options = Object.assign(
+    elementToolOptions[toolName][index].options = Object.assign(
       elementOptions,
       options
     );
@@ -74,21 +74,21 @@ function setToolOptions(toolType, element, options) {
 }
 
 /**
- * Clear the options object associated with a particular toolType and element.
+ * Clear the options object associated with a particular toolName and element.
  * @export
  * @public
  * @method
  * @name clearToolOptions
  *
- * @param {string} toolType Tool type identifier of the target options object.
+ * @param {string} toolName Tool name identifier of the target options object.
  * @param {HTMLElement} element Element of the target options object.
  * @returns {void}
  */
-function clearToolOptions(toolType, element) {
-  const toolOptions = elementToolOptions[toolType];
+function clearToolOptions(toolName, element) {
+  const toolOptions = elementToolOptions[toolName];
 
   if (toolOptions) {
-    elementToolOptions[toolType] = toolOptions.filter(
+    elementToolOptions[toolName] = toolOptions.filter(
       toolOptionObject => toolOptionObject.element !== element
     );
   }
@@ -96,6 +96,10 @@ function clearToolOptions(toolType, element) {
 
 /**
  * Clear the options objects associated with a particular toolType.
+ *
+ * Deprecation notice: use clearToolOptionsByToolName instead
+ * @deprecated
+ *
  * @export
  * @public
  * @method
@@ -105,7 +109,21 @@ function clearToolOptions(toolType, element) {
  * @returns {void}
  */
 function clearToolOptionsByToolType(toolType) {
-  delete elementToolOptions[toolType];
+  return clearToolOptionsByToolName(toolType);
+}
+
+/**
+ * Clear the options objects associated with a particular toolName.
+ * @export
+ * @public
+ * @method
+ * @name clearToolOptionsByToolName
+ *
+ * @param {string} toolName Tool name identifier of the target options objects.
+ * @returns {void}
+ */
+function clearToolOptionsByToolName(toolName) {
+  delete elementToolOptions[toolName];
 }
 
 /**
@@ -119,8 +137,8 @@ function clearToolOptionsByToolType(toolType) {
  * @returns {void}
  */
 function clearToolOptionsByElement(element) {
-  for (const toolType in elementToolOptions) {
-    elementToolOptions[toolType] = elementToolOptions[toolType].filter(
+  for (const toolName in elementToolOptions) {
+    elementToolOptions[toolName] = elementToolOptions[toolName].filter(
       toolOptionObject => toolOptionObject.element !== element
     );
   }
@@ -131,5 +149,6 @@ export {
   setToolOptions,
   clearToolOptions,
   clearToolOptionsByToolType,
+  clearToolOptionsByToolName,
   clearToolOptionsByElement,
 };

--- a/src/toolOptions.test.js
+++ b/src/toolOptions.test.js
@@ -4,7 +4,7 @@ import * as toolOptions from './toolOptions.js';
  * Mirrors the API of toolOptions, but stores the options in an inefficient yet
  * simple way. Mirrored calls modify the model's internal state, make the
  * corresponding call to toolOptions, and then ensures that the model's internal
- * state matches the global toolOptions state at every toolType and element.
+ * state matches the global toolOptions state at every toolName and element.
  */
 class ToolOptionsModel {
   constructor() {
@@ -19,20 +19,20 @@ class ToolOptionsModel {
     this.check();
   }
 
-  toolTypeName(i) {
-    return `toolType${i}`;
+  toolNameValue(i) {
+    return `toolName${i}`;
   }
 
-  ixOf(toolType, element) {
-    return toolType * 10 + element;
+  ixOf(toolName, element) {
+    return toolName * 10 + element;
   }
 
   check() {
-    for (let toolType = 0; toolType < 10; toolType++) {
+    for (let toolName = 0; toolName < 10; toolName++) {
       for (let element = 0; element < 10; element++) {
-        expect(this.options[this.ixOf(toolType, element)]).toEqual(
+        expect(this.options[this.ixOf(toolName, element)]).toEqual(
           toolOptions.getToolOptions(
-            this.toolTypeName(toolType),
+            this.toolNameValue(toolName),
             this.elements[element]
           )
         );
@@ -40,12 +40,12 @@ class ToolOptionsModel {
     }
   }
 
-  getToolOptions(toolType, element) {
-    const ret = this.options[this.ixOf(toolType, element)];
+  getToolOptions(toolName, element) {
+    const ret = this.options[this.ixOf(toolName, element)];
 
     expect(ret).toEqual(
       toolOptions.getToolOptions(
-        this.toolTypeName(toolType),
+        this.toolNameValue(toolName),
         this.elements[element]
       )
     );
@@ -54,37 +54,37 @@ class ToolOptionsModel {
     return ret;
   }
 
-  setToolOptions(toolType, element, options) {
+  setToolOptions(toolName, element, options) {
     toolOptions.setToolOptions(
-      this.toolTypeName(toolType),
+      this.toolNameValue(toolName),
       this.elements[element],
       options
     );
-    this.options[this.ixOf(toolType, element)] = options;
+    this.options[this.ixOf(toolName, element)] = options;
     this.check();
   }
 
-  clearToolOptions(toolType, element) {
+  clearToolOptions(toolName, element) {
     toolOptions.clearToolOptions(
-      this.toolTypeName(toolType),
+      this.toolNameValue(toolName),
       this.elements[element]
     );
-    this.options[this.ixOf(toolType, element)] = {};
+    this.options[this.ixOf(toolName, element)] = {};
     this.check();
   }
 
-  clearToolOptionsByToolType(toolType) {
-    toolOptions.clearToolOptionsByToolType(this.toolTypeName(toolType));
+  clearToolOptionsByToolName(toolName) {
+    toolOptions.clearToolOptionsByToolName(this.toolNameValue(toolName));
     for (let element = 0; element < 10; element++) {
-      this.options[this.ixOf(toolType, element)] = {};
+      this.options[this.ixOf(toolName, element)] = {};
     }
     this.check();
   }
 
   clearToolOptionsByElement(element) {
     toolOptions.clearToolOptionsByElement(this.elements[element]);
-    for (let toolType = 0; toolType < 10; toolType++) {
-      this.options[this.ixOf(toolType, element)] = {};
+    for (let toolName = 0; toolName < 10; toolName++) {
+      this.options[this.ixOf(toolName, element)] = {};
     }
     this.check();
   }
@@ -123,9 +123,9 @@ describe('toolOptions manipulation', function() {
     model.clearToolOptions(1, 2);
     expect(model.getToolOptions(1, 2)).toEqual({});
     model.clearToolOptionsByElement(2);
-    model.clearToolOptionsByToolType(1);
+    model.clearToolOptionsByToolName(1);
     model.getToolOptions(1, 6);
-    model.clearToolOptionsByToolType(4);
+    model.clearToolOptionsByToolName(4);
     model.getToolOptions(4, 4);
   });
 });

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -339,10 +339,12 @@ export default class AngleTool extends BaseAnnotationTool {
             external.cornerstone.updateImage(element);
 
             const modifiedEventData = {
-              toolType: this.name,
+              toolName: this.name,
+              toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
               element,
               measurementData,
             };
+
             triggerEvent(
               element,
               EVENTS.MEASUREMENT_COMPLETED,

--- a/src/tools/annotation/ArrowAnnotateTool.js
+++ b/src/tools/annotation/ArrowAnnotateTool.js
@@ -266,7 +266,8 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
               external.cornerstone.updateImage(element);
 
               triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
-                toolType: this.name,
+                toolName: this.name,
+                toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
                 element,
                 measurementData,
               });
@@ -279,10 +280,12 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
         external.cornerstone.updateImage(element);
 
         const modifiedEventData = {
-          toolType: this.name,
+          toolName: this.name,
+          toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
           element,
           measurementData,
         };
+
         triggerEvent(element, EVENTS.MEASUREMENT_COMPLETED, modifiedEventData);
       }
     );
@@ -342,7 +345,8 @@ export default class ArrowAnnotateTool extends BaseAnnotationTool {
     external.cornerstone.updateImage(element);
 
     triggerEvent(element, EVENTS.MEASUREMENT_MODIFIED, {
-      toolType: this.name,
+      toolName: this.name,
+      toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData,
     });

--- a/src/tools/annotation/BidirectionalTool.js
+++ b/src/tools/annotation/BidirectionalTool.js
@@ -59,7 +59,7 @@ export default class BidirectionalTool extends BaseAnnotationTool {
 
   updateCachedStats(image, element, data) {
     // Prevent updating other tools' data
-    if (data.toolType !== this.name) {
+    if (data.toolName !== this.name) {
       return;
     }
 

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -272,7 +272,7 @@ export default class CobbAngleTool extends BaseAnnotationTool {
     let measurementData;
     let toMoveHandle;
     let doneMovingCallback = success => {
-      // doneMovingCallback for first measurement.
+      // DoneMovingCallback for first measurement.
       if (!success) {
         removeToolState(element, this.name, measurementData);
 
@@ -304,7 +304,7 @@ export default class CobbAngleTool extends BaseAnnotationTool {
       toMoveHandle = measurementData.handles.end2;
       this.hasIncomplete = false;
       doneMovingCallback = success => {
-        // doneMovingCallback for second measurement
+        // DoneMovingCallback for second measurement
         if (!success) {
           removeToolState(element, this.name, measurementData);
 
@@ -313,7 +313,8 @@ export default class CobbAngleTool extends BaseAnnotationTool {
 
         const eventType = EVENTS.MEASUREMENT_COMPLETED;
         const eventData = {
-          toolType: this.name,
+          toolName: this.name,
+          toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
           element,
           measurementData,
         };

--- a/src/tools/annotation/FreehandRoiTool.js
+++ b/src/tools/annotation/FreehandRoiTool.js
@@ -1637,6 +1637,7 @@ export default class FreehandRoiTool extends BaseAnnotationTool {
     const eventType = EVENTS.MEASUREMENT_MODIFIED;
     const eventData = {
       toolName: this.name,
+      toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData,
     };
@@ -1648,6 +1649,7 @@ export default class FreehandRoiTool extends BaseAnnotationTool {
     const eventType = EVENTS.MEASUREMENT_COMPLETED;
     const eventData = {
       toolName: this.name,
+      toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData,
     };

--- a/src/tools/annotation/bidirectionalTool/addNewMeasurement.js
+++ b/src/tools/annotation/bidirectionalTool/addNewMeasurement.js
@@ -78,7 +78,8 @@ export default function(evt, interactionType) {
       }
 
       const modifiedEventData = {
-        toolType: this.name,
+        toolName: this.name,
+        toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
         element,
         measurementData,
       };

--- a/src/tools/annotation/bidirectionalTool/createNewMeasurement.js
+++ b/src/tools/annotation/bidirectionalTool/createNewMeasurement.js
@@ -16,7 +16,8 @@ export default function(mouseEventData) {
   const { x, y } = mouseEventData.currentPoints.image;
   // Create the measurement data for this tool with the end handle activated
   const measurementData = {
-    toolType: this.name,
+    toolName: this.name,
+    toolType: this.name, // Deprecation notice: toolType will be replaced by toolName
     isCreating: true,
     visible: true,
     active: true,

--- a/src/tools/annotation/bidirectionalTool/moveHandle/moveHandle.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/moveHandle.js
@@ -7,7 +7,7 @@ import BaseAnnotationTool from '../../../base/BaseAnnotationTool';
 
 export default function(
   mouseEventData,
-  toolType,
+  toolName,
   data,
   handle,
   doneMovingCallback,
@@ -50,7 +50,8 @@ export default function(
     }
 
     const modifiedEventData = {
-      toolType,
+      toolName,
+      toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData: data,
     };

--- a/src/tools/annotation/bidirectionalTool/moveHandle/touchMoveHandle.js
+++ b/src/tools/annotation/bidirectionalTool/moveHandle/touchMoveHandle.js
@@ -15,7 +15,7 @@ const touchEndEvents = [
 
 export default function(
   mouseEventData,
-  toolType,
+  toolName,
   data,
   handle,
   doneMovingCallback,
@@ -58,7 +58,8 @@ export default function(
     }
 
     const modifiedEventData = {
-      toolType,
+      toolName,
+      toolType: toolName, // Deprecation notice: toolType will be replaced by toolName
       element,
       measurementData: data,
     };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * Bug fix with divergent `toolType`/`toolName` being added to event data.
  * Updated documentation with `toolName` as being the new attribute to be used.
  * Added comments to the code with deprecation notice of `toolType` attribute.



* **What is the current behavior?** (You can also link to an open issue here)
  * Some tools/manipulators were triggering events with `toolType` attribute and others with `toolName` attribute.


* **What is the new behavior (if this is a feature change)?**
  * Until the `toolType` attribute is removed, all the event data are including both `toolType` and `toolName` attributes.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  * No, but it introduce a deprecation notice for the usage of `toolType` attribute.
  * It will be a breaking change when `toolType` is removed for good.



* **Other information**:
  * `toolType` naming is now going to be used to categorize types of tools (e.g. `general`, `annotation`, `stack`, `segmentation`, etc.)