### PR TITLE
Add default value 1 for the rowPixelSpacing and columnPixelSpacing

### DIFF
--- a/src/util/getPixelSpacing.js
+++ b/src/util/getPixelSpacing.js
@@ -9,14 +9,14 @@ export default function getPixelSpacing(image) {
   if (imagePlane) {
     return {
       rowPixelSpacing:
-        imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing,
+        imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing || 1,
       colPixelSpacing:
-        imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing,
+        imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing || 1,
     };
   }
 
   return {
-    rowPixelSpacing: image.rowPixelSpacing,
-    colPixelSpacing: image.columnPixelSpacing,
+    rowPixelSpacing: image.rowPixelSpacing || 1,
+    colPixelSpacing: image.columnPixelSpacing || 1,
   };
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When there are no pixel spacing data of the image, the values of the angle measurements are not able to be calculated, since the getPixelSpacing function returns null for the rowPixelSpacing and columnPixelSpacing values. 


* **What is the new behavior (if this is a feature change)?**
getPixelSpacing function returns default 1 if there is no pixel spacing data.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Default value 1 is added since in the past every tool had it, but due to some refactoring (in which the getPixelSpacing function was created), this scenario was left out. 