### PR TITLE
Angle and CobbAngle tool: set default 1 for rowPixelSpacing and columnPixelSpacing

### DIFF
--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -115,18 +115,20 @@ export default class AngleTool extends BaseAnnotationTool {
     const { rowPixelSpacing, colPixelSpacing } = getPixelSpacing(image);
 
     const sideA = {
-      x: (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y: (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1)
+      x:
+        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
+      y:
+        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideB = {
       x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1)
+      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
     };
 
     const sideC = {
       x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1)
+      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideALength = length(sideA);

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -116,19 +116,29 @@ export default class AngleTool extends BaseAnnotationTool {
 
     const sideA = {
       x:
-        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
+        (data.handles.middle.x - data.handles.start.x) *
+        (colPixelSpacing || 1),
       y:
-        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
+        (data.handles.middle.y - data.handles.start.y) *
+        (rowPixelSpacing || 1)
     };
 
     const sideB = {
-      x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
+      x:
+        (data.handles.end.x - data.handles.middle.x) *
+        (colPixelSpacing || 1),
+      y:
+        (data.handles.end.y - data.handles.middle.y) *
+        (rowPixelSpacing || 1)
     };
 
     const sideC = {
-      x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
+      x:
+        (data.handles.end.x - data.handles.start.x) *
+        (colPixelSpacing || 1),
+      y:
+        (data.handles.end.y - data.handles.start.y) *
+        (rowPixelSpacing || 1)
     };
 
     const sideALength = length(sideA);
@@ -174,7 +184,7 @@ export default class AngleTool extends BaseAnnotationTool {
         continue;
       }
 
-      draw(context, context => {
+      draw(context, (context) => {
         setShadow(context, this.configuration);
 
         // Differentiate the color of activation tool
@@ -306,7 +316,7 @@ export default class AngleTool extends BaseAnnotationTool {
       measurementData.handles.middle,
       this.options,
       interactionType,
-      success => {
+      (success) => {
         measurementData.active = false;
 
         if (!success) {
@@ -329,7 +339,7 @@ export default class AngleTool extends BaseAnnotationTool {
           measurementData.handles.end,
           this.options,
           interactionType,
-          success => {
+          (success) => {
             if (success) {
               measurementData.active = false;
               external.cornerstone.updateImage(element);

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -112,24 +112,9 @@ export default class AngleTool extends BaseAnnotationTool {
   }
 
   updateCachedStats(image, element, data) {
-    const { rowPixelSpacing, colPixelSpacing } = getPixelSpacing(image);
-
-    const sideA = {
-      x:
-        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y:
-        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
-    };
-
-    const sideB = {
-      x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
-    };
-
-    const sideC = {
-      x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
-    };
+    const sideA = getSide(image, data.handles.middle, data.handles.start);
+    const sideB = getSide(image, data.handles.end, data.handles.middle);
+    const sideC = getSide(image, data.handles.end, data.handles.middle);
 
     const sideALength = length(sideA);
     const sideBLength = length(sideB);
@@ -361,4 +346,13 @@ export default class AngleTool extends BaseAnnotationTool {
 
 function length(vector) {
   return Math.sqrt(Math.pow(vector.x, 2) + Math.pow(vector.y, 2));
+}
+
+function getSide(image, handleEnd, handleStart) {
+  const { rowPixelSpacing, colPixelSpacing } = getPixelSpacing(image);
+
+  return {
+    x: (handleEnd.x - handleStart.x) * (colPixelSpacing || 1),
+    y: (handleEnd.y - handleStart.y) * (rowPixelSpacing || 1),
+  };
 }

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -115,18 +115,20 @@ export default class AngleTool extends BaseAnnotationTool {
     const { rowPixelSpacing, colPixelSpacing } = getPixelSpacing(image);
 
     const sideA = {
-      x: (data.handles.middle.x - data.handles.start.x) * colPixelSpacing,
-      y: (data.handles.middle.y - data.handles.start.y) * rowPixelSpacing,
+      x:
+        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
+      y:
+        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideB = {
-      x: (data.handles.end.x - data.handles.middle.x) * colPixelSpacing,
-      y: (data.handles.end.y - data.handles.middle.y) * rowPixelSpacing,
+      x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
     };
 
     const sideC = {
-      x: (data.handles.end.x - data.handles.start.x) * colPixelSpacing,
-      y: (data.handles.end.y - data.handles.start.y) * rowPixelSpacing,
+      x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideALength = length(sideA);

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -116,29 +116,19 @@ export default class AngleTool extends BaseAnnotationTool {
 
     const sideA = {
       x:
-        (data.handles.middle.x - data.handles.start.x) *
-        (colPixelSpacing || 1),
+        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
       y:
-        (data.handles.middle.y - data.handles.start.y) *
-        (rowPixelSpacing || 1)
+        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideB = {
-      x:
-        (data.handles.end.x - data.handles.middle.x) *
-        (colPixelSpacing || 1),
-      y:
-        (data.handles.end.y - data.handles.middle.y) *
-        (rowPixelSpacing || 1)
+      x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
     };
 
     const sideC = {
-      x:
-        (data.handles.end.x - data.handles.start.x) *
-        (colPixelSpacing || 1),
-      y:
-        (data.handles.end.y - data.handles.start.y) *
-        (rowPixelSpacing || 1)
+      x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
     };
 
     const sideALength = length(sideA);
@@ -184,7 +174,7 @@ export default class AngleTool extends BaseAnnotationTool {
         continue;
       }
 
-      draw(context, (context) => {
+      draw(context, context => {
         setShadow(context, this.configuration);
 
         // Differentiate the color of activation tool
@@ -316,7 +306,7 @@ export default class AngleTool extends BaseAnnotationTool {
       measurementData.handles.middle,
       this.options,
       interactionType,
-      (success) => {
+      success => {
         measurementData.active = false;
 
         if (!success) {
@@ -339,7 +329,7 @@ export default class AngleTool extends BaseAnnotationTool {
           measurementData.handles.end,
           this.options,
           interactionType,
-          (success) => {
+          success => {
             if (success) {
               measurementData.active = false;
               external.cornerstone.updateImage(element);

--- a/src/tools/annotation/AngleTool.js
+++ b/src/tools/annotation/AngleTool.js
@@ -115,20 +115,18 @@ export default class AngleTool extends BaseAnnotationTool {
     const { rowPixelSpacing, colPixelSpacing } = getPixelSpacing(image);
 
     const sideA = {
-      x:
-        (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y:
-        (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1),
+      x: (data.handles.middle.x - data.handles.start.x) * (colPixelSpacing || 1),
+      y: (data.handles.middle.y - data.handles.start.y) * (rowPixelSpacing || 1)
     };
 
     const sideB = {
       x: (data.handles.end.x - data.handles.middle.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.middle.y) * (rowPixelSpacing || 1)
     };
 
     const sideC = {
       x: (data.handles.end.x - data.handles.start.x) * (colPixelSpacing || 1),
-      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1),
+      y: (data.handles.end.y - data.handles.start.y) * (rowPixelSpacing || 1)
     };
 
     const sideALength = length(sideA);

--- a/src/tools/annotation/AngleTool.test.js
+++ b/src/tools/annotation/AngleTool.test.js
@@ -1,0 +1,173 @@
+import AngleTool from './AngleTool.js';
+import { getToolState } from './../../stateManagement/toolState.js';
+
+jest.mock('./../../stateManagement/toolState.js', () => ({
+  getToolState: jest.fn(),
+}));
+
+jest.mock('./../../importInternal.js', () => ({
+  default: jest.fn(),
+}));
+
+jest.mock('./../../externalModules.js', () => ({
+  cornerstone: {
+    metaData: {
+      get: jest.fn(),
+    },
+  },
+}));
+
+const goodMouseEventData = {
+  currentPoints: {
+    image: {
+      x: 0,
+      y: 0,
+    },
+  },
+};
+
+const image = {
+  rowPixelSpacing: 0.8984375,
+  columnPixelSpacing: 0.8984375,
+};
+
+describe('AngleTool.js', () => {
+  describe('default values', () => {
+    it('has a default name of "Angle"', () => {
+      const defaultName = 'Angle';
+      const instantiatedTool = new AngleTool();
+
+      expect(instantiatedTool.name).toEqual(defaultName);
+    });
+
+    it('can be created with a custom tool name', () => {
+      const customToolName = { name: 'customToolName' };
+      const instantiatedTool = new AngleTool(customToolName);
+
+      expect(instantiatedTool.name).toEqual(customToolName.name);
+    });
+  });
+
+  describe('createNewMeasurement', () => {
+    it('returns an angle tool object', () => {
+      const instantiatedTool = new AngleTool('Angle');
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+
+      expect(typeof toolMeasurement).toBe(typeof {});
+    });
+
+    it("returns a measurement with a start, middle and end handle at the eventData's x and y", () => {
+      const instantiatedTool = new AngleTool('toolName');
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+      const startHandle = {
+        x: toolMeasurement.handles.start.x,
+        y: toolMeasurement.handles.start.y,
+      };
+      const middleHandle = {
+        x: toolMeasurement.handles.middle.x,
+        y: toolMeasurement.handles.middle.y,
+      };
+      const endHandle = {
+        x: toolMeasurement.handles.end.x,
+        y: toolMeasurement.handles.end.y,
+      };
+
+      expect(startHandle.x).toBe(goodMouseEventData.currentPoints.image.x);
+      expect(startHandle.y).toBe(goodMouseEventData.currentPoints.image.y);
+      expect(middleHandle.x).toBe(goodMouseEventData.currentPoints.image.x);
+      expect(middleHandle.y).toBe(goodMouseEventData.currentPoints.image.y);
+      expect(endHandle.x).toBe(goodMouseEventData.currentPoints.image.x);
+      expect(endHandle.y).toBe(goodMouseEventData.currentPoints.image.y);
+    });
+
+    it('returns a measurement with a textBox handle', () => {
+      const instantiatedTool = new AngleTool('toolName');
+
+      const toolMeasurement = instantiatedTool.createNewMeasurement(
+        goodMouseEventData
+      );
+
+      expect(typeof toolMeasurement.handles.textBox).toBe(typeof {});
+    });
+  });
+
+  describe('pointNearTool', () => {
+    let element, coords;
+
+    beforeEach(() => {
+      element = jest.fn();
+      coords = jest.fn();
+    });
+
+    it('returns false when measurement data is not visible', () => {
+      const instantiatedTool = new AngleTool('AngleTool');
+      const notVisibleMeasurementData = {
+        visible: false,
+      };
+
+      const isPointNearTool = instantiatedTool.pointNearTool(
+        element,
+        notVisibleMeasurementData,
+        coords
+      );
+
+      expect(isPointNearTool).toBe(false);
+    });
+  });
+
+  describe('updateCachedStats', () => {
+    let element;
+
+    beforeEach(() => {
+      element = jest.fn();
+    });
+
+    it('should calculate and update annotation value', () => {
+      const instantiatedTool = new AngleTool('AngleTool');
+
+      const data = {
+        handles: {
+          start: {
+            x: 166,
+            y: 90,
+          },
+          middle: {
+            x: 120,
+            y: 113,
+          },
+          end: {
+            x: 145,
+            y: 143,
+          },
+        },
+      };
+
+      instantiatedTool.updateCachedStats(image, element, data);
+      expect(data.rAngle).toBe(48.82);
+      expect(data.invalidated).toBe(false);
+    });
+  });
+
+  describe('renderToolData', () => {
+    it('returns undefined when no toolData exists for the tool', () => {
+      const instantiatedTool = new AngleTool('AngleTool');
+      const mockEvent = {
+        detail: {
+          enabledElement: undefined,
+        },
+      };
+
+      getToolState.mockReturnValueOnce(undefined);
+
+      const renderResult = instantiatedTool.renderToolData(mockEvent);
+
+      expect(renderResult).toBe(undefined);
+    });
+  });
+});

--- a/src/tools/annotation/CobbAngleTool.js
+++ b/src/tools/annotation/CobbAngleTool.js
@@ -133,16 +133,16 @@ export default class CobbAngleTool extends BaseAnnotationTool {
 
     const dx1 =
       (Math.ceil(data.handles.start.x) - Math.ceil(data.handles.end.x)) *
-      colPixelSpacing;
+      (colPixelSpacing || 1);
     const dy1 =
       (Math.ceil(data.handles.start.y) - Math.ceil(data.handles.end.y)) *
-      rowPixelSpacing;
+      (rowPixelSpacing || 1);
     const dx2 =
       (Math.ceil(data.handles.start2.x) - Math.ceil(data.handles.end2.x)) *
-      colPixelSpacing;
+      (colPixelSpacing || 1);
     const dy2 =
       (Math.ceil(data.handles.start2.y) - Math.ceil(data.handles.end2.y)) *
-      rowPixelSpacing;
+      (rowPixelSpacing || 1);
 
     let angle = Math.acos(
       Math.abs(


### PR DESCRIPTION
Only added in the Angle and CobbAngle tool: rowPixelSpacing and columnPixelSpacing default to 1

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When there are no pixel spacing data of the image, the values of the angle measurements are not able to be calculated, since the getPixelSpacing function returns null for the rowPixelSpacing and columnPixelSpacing values.


* **What is the new behavior (if this is a feature change)?**
Value 1 is used in the angle value calculation if the rowPixelSpacing and/or columnPixelSpacing values are null.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Default value 1 is added since in the past every tool had it, but due to some refactoring (in which the getPixelSpacing function was created), this scenario was left out.