### PR TITLE
Magnify fix

### DIFF
--- a/src/store/internals/removeEnabledElement.js
+++ b/src/store/internals/removeEnabledElement.js
@@ -12,6 +12,7 @@ import {
 import store, { getModule } from '../index.js';
 import { getLogger } from '../../util/logger.js';
 import loadHandlerManager from '../../stateManagement/loadHandlerManager.js';
+import { setToolDisabledForElement } from '../setToolMode';
 
 const logger = getLogger('internals:removeEnabledElement');
 
@@ -71,8 +72,12 @@ export default function(elementDisabledEvt) {
  * @returns  {void}
  */
 const _removeAllToolsForElement = function(enabledElement) {
-  // Note: We may want to `setToolDisabled` before removing from store
-  // Or take other action to remove any lingering eventListeners/state
+  store.state.tools.forEach(tool => {
+    if (tool.element === enabledElement) {
+      setToolDisabledForElement(tool.element, tool.name);
+    }
+  });
+
   store.state.tools = store.state.tools.filter(
     tool => tool.element !== enabledElement
   );

--- a/src/store/internals/removeEnabledElement.js
+++ b/src/store/internals/removeEnabledElement.js
@@ -77,7 +77,6 @@ const _removeAllToolsForElement = function(enabledElement) {
       setToolDisabledForElement(tool.element, tool.name);
     }
   });
-
   store.state.tools = store.state.tools.filter(
     tool => tool.element !== enabledElement
   );

--- a/src/tools/MagnifyTool.js
+++ b/src/tools/MagnifyTool.js
@@ -3,6 +3,7 @@ import { getNewContext } from '../drawing/index.js';
 import BaseTool from './base/BaseTool.js';
 import { hideToolCursor, setToolCursor } from '../store/setToolCursor.js';
 import { magnifyCursor } from './cursors/index.js';
+import { isDebuggerStatement } from '@babel/types';
 
 /**
  * @public
@@ -228,7 +229,7 @@ export default class MagnifyTool extends BaseTool {
    */
   _removeZoomElement() {
     if (this.zoomElement !== undefined) {
-      external.cornerstone.disable(this.zoomCanvas);
+      external.cornerstone.disable(this.zoomElement);
       this.zoomElement = undefined;
       this.zoomCanvas = undefined;
     }

--- a/src/tools/MagnifyTool.js
+++ b/src/tools/MagnifyTool.js
@@ -3,7 +3,6 @@ import { getNewContext } from '../drawing/index.js';
 import BaseTool from './base/BaseTool.js';
 import { hideToolCursor, setToolCursor } from '../store/setToolCursor.js';
 import { magnifyCursor } from './cursors/index.js';
-import { isDebuggerStatement } from '@babel/types';
 
 /**
  * @public


### PR DESCRIPTION
- Fix cleanup of tools on disabling of magnify element.
- Prevent magnify orphans from being formed when an element is removed without tools being disabled.

This appears to fix the following issues:

RE: #1172 
RE: https://github.com/OHIF/Viewers/issues/1518