### PR TITLE
Fixing textStyle API inconsistency between font size and font style

### DIFF
--- a/src/stateManagement/textStyle.js
+++ b/src/stateManagement/textStyle.js
@@ -1,38 +1,56 @@
-let defaultFontSize = 15,
-  defaultFont = `${defaultFontSize}px Arial`,
-  defaultBackgroundColor = 'transparent';
+const textStyle = {
+  fontSize: 15,
+  fontFamily: 'Arial',
+  backgroundColor: 'transparent',
+};
 
+// Deprecate
 function setFont(font) {
-  defaultFont = font;
+  const split = font.split('px ');
+
+  if (split.length === 2) {
+    setFontSize(split[0]);
+    setFontFamily(split[1]);
+  }
 }
 
 function getFont() {
-  return defaultFont;
+  return `${textStyle.fontSize}px ${textStyle.fontFamily}`;
+}
+
+function setFontFamily(fontFamily) {
+  textStyle.fontFamily = fontFamily;
+}
+
+function getFontFamily() {
+  return textStyle.fontFamily;
 }
 
 function setFontSize(fontSize) {
-  defaultFontSize = fontSize;
+  textStyle.fontSize = parseFloat(fontSize);
 }
 
 function getFontSize() {
-  return defaultFontSize;
+  return textStyle.fontSize;
 }
 
 function setBackgroundColor(backgroundColor) {
-  defaultBackgroundColor = backgroundColor;
+  textStyle.backgroundColor = backgroundColor;
 }
 
 function getBackgroundColor() {
-  return defaultBackgroundColor;
+  return textStyle.backgroundColor;
 }
 
-const textStyle = {
+const textStyleApi = {
   setFont,
   getFont,
   setFontSize,
   getFontSize,
+  setFontFamily,
+  getFontFamily,
   setBackgroundColor,
   getBackgroundColor,
 };
 
-export default textStyle;
+export default textStyleApi;


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Fixes https://github.com/cornerstonejs/cornerstoneTools/issues/1279

* **What is the current behavior?**
https://github.com/cornerstonejs/cornerstoneTools/issues/1279

* **What is the new behavior?**
 * A new `textStyle` object was created to control the styling.
 * New `setFontFamily` and `getFontFamily` methods were implemented.
 * Method `getFontSize` was changed to consider both `fontSize` and `fontFamily` attributes.
 * Method `setFontSize` was changed to consider both attributes as well but must be deprecated.

* **Does this PR introduce a breaking change?**
No, it will fix an existing issue.
