### PR TITLE
Adding bounding box's translator option for drawing text boxes

### DIFF
--- a/src/drawing/drawTextBox.js
+++ b/src/drawing/drawTextBox.js
@@ -44,7 +44,7 @@ export function textBoxWidth(context, text, padding) {
  * @param  {Object} options     Options for the textBox.
  * @returns {Object} {top, left, width, height} - Bounding box; can be used for pointNearTool
  */
-export default function(context, textLines, x, y, color, options) {
+export default function(context, textLines, x, y, color, options = {}) {
   if (Object.prototype.toString.call(textLines) !== '[object Array]') {
     textLines = [textLines];
   }
@@ -74,21 +74,26 @@ export default function(context, textLines, x, y, color, options) {
     context.strokeStyle = color;
 
     // Draw the background box with padding
-    if (options && options.centering && options.centering.x === true) {
-      x -= boundingBox.width / 2;
-    }
+    if (options.centering) {
+      // Draw the background box with padding
+      if (options.centering.x === true) {
+        x -= boundingBox.width / 2;
+      }
 
-    if (options && options.centering && options.centering.y === true) {
-      y -= boundingBox.height / 2;
+      if (options.centering.y === true) {
+        y -= boundingBox.height / 2;
+      }
     }
 
     boundingBox.left = x;
     boundingBox.top = y;
 
-    const fillStyle =
-      options && options.debug === true ? '#FF0000' : backgroundColor;
+    // Check if a translator function was provided
+    if (typeof options.translator === 'function') {
+      options.translator(boundingBox);
+    }
 
-    fillBox(context, boundingBox, fillStyle);
+    fillBox(context, boundingBox, backgroundColor);
 
     // Draw each of the text lines on top of the background box
     fillTextLines(context, boundingBox, textLines, color, padding);


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Fixes https://github.com/cornerstonejs/cornerstoneTools/issues/1281

* **What is the current behavior?**
https://github.com/cornerstonejs/cornerstoneTools/issues/1281

* **What is the new behavior?**
A `translator` attribute was added to the `textBox`'s drawing options and it's being called when we have the final position and dimensions for the bounding box, just before rendering.

* **Does this PR introduce a breaking change?**
No, it will only add a new feature to control `textBox` positioning before its rendering.

* **Other information**:
 * The logic for centering was improved, removing duplicates boolean checks.
 * The `debug` attribute was removed as it was not being used inside the codebase and its hardcoded behavior (apply red background to the bounding box) can be achieved using browser's developer tools.