### PR TITLE
Adding global option to control touch offset for handles

### DIFF
--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -130,23 +130,21 @@ export default function(
   // ==========================
   // ========  TOUCH ==========
   // ==========================
-  if (interactionType === 'touch') {
+  const touchOffset = state.handleTouchOffset;
+
+  if (interactionType === 'touch' && (touchOffset.x || touchOffset.y)) {
     runAnimation.value = true;
     const enabledElement = external.cornerstone.getEnabledElement(element);
 
-    // Average pixel width of index finger is 45-57 pixels
-    // https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/
-    const fingerDistance = -57;
-
-    const aboveFinger = {
-      x: evtDetail.currentPoints.page.x,
-      y: evtDetail.currentPoints.page.y + fingerDistance,
+    const positionWithOffset = {
+      x: evtDetail.currentPoints.page.x + touchOffset.x,
+      y: evtDetail.currentPoints.page.y + touchOffset.y,
     };
 
     const targetLocation = external.cornerstone.pageToPixel(
       element,
-      aboveFinger.x,
-      aboveFinger.y
+      positionWithOffset.x,
+      positionWithOffset.y
     );
 
     _animate(handle, runAnimation, enabledElement, targetLocation);
@@ -163,11 +161,11 @@ function _dragHandler(
 ) {
   const { image, currentPoints, element, buttons } = evt.detail;
   const page = currentPoints.page;
-  const fingerOffset = -57;
+  const touchOffset = state.handleTouchOffset;
   const targetLocation = external.cornerstone.pageToPixel(
     element,
-    page.x,
-    interactionType === 'touch' ? page.y + fingerOffset : page.y
+    interactionType === 'touch' ? page.x + touchOffset.x : page.x,
+    interactionType === 'touch' ? page.y + touchOffset.y : page.y
   );
 
   runAnimation.value = false;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,9 +24,9 @@ export const state = {
   handleRadius: 6,
   deleteIfHandleOutsideImage: true,
   preventHandleOutsideImage: false,
+  handleTouchOffset: { x: 0, y: -57 },
   // Cursor
   svgCursorUrl: null,
-  //
 };
 
 export const getters = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Fixes https://github.com/cornerstonejs/cornerstoneTools/issues/1286

* **What is the current behavior?**
https://github.com/cornerstonejs/cornerstoneTools/issues/1286

* **What is the new behavior?**
A `handleTouchOffset ` attribute was added to global state and can be changed to configure both horizontal and vertical offset of the handles being moved by touch input.

* **Does this PR introduce a breaking change?**
It will have no impact over the community as the default value for the created option will not change the original behavior.