### PR TITLE
Update convertToVector3 - handle similar objects

### DIFF
--- a/src/util/convertToVector3.js
+++ b/src/util/convertToVector3.js
@@ -14,8 +14,10 @@ export default function convertToVector3(arrayOrVector3) {
   if (arrayOrVector3 instanceof cornerstoneMath.Vector3) {
     return arrayOrVector3;
   }
-  const keys = Object.keys(arrayOrVector3)
-  if(keys.includes('x') && keys.includes('y') && keys.includes('z')){
+
+  const keys = Object.keys(arrayOrVector3);
+
+  if (keys.includes('x') && keys.includes('y') && keys.includes('z')) {
     return new cornerstoneMath.Vector3(
       arrayOrVector3.x,
       arrayOrVector3.y,

--- a/src/util/convertToVector3.js
+++ b/src/util/convertToVector3.js
@@ -14,6 +14,14 @@ export default function convertToVector3(arrayOrVector3) {
   if (arrayOrVector3 instanceof cornerstoneMath.Vector3) {
     return arrayOrVector3;
   }
+  const keys = Object.keys(arrayOrVector3)
+  if(keys.includes('x') && keys.includes('y') && keys.includes('z')){
+    return new cornerstoneMath.Vector3(
+      arrayOrVector3.x,
+      arrayOrVector3.y,
+      arrayOrVector3.z
+    );
+  }
 
   return new cornerstoneMath.Vector3(
     arrayOrVector3[0],

--- a/src/util/convertToVector3.test.js
+++ b/src/util/convertToVector3.test.js
@@ -1,0 +1,43 @@
+import convertToVector3 from './convertToVector3.js';
+import external from '../externalModules.js';
+
+jest.mock('../externalModules.js', () => {
+  const cornerstoneMath = require('cornerstone-math');
+  return {
+    cornerstoneMath: {
+      Vector3: cornerstoneMath.Vector3,
+    },
+  };
+});
+
+describe('util/convertToVector3.js', function() {
+  const exampleVec3 = new external.cornerstoneMath.Vector3(1, 2, 3);
+
+  it('should return the same object if a Vector3 is passed in', function() {
+    const converted = convertToVector3(exampleVec3);
+
+    expect(converted).toBe(exampleVec3);
+  });
+
+  it('should return an similar Vector3 if a Vector3-like object is passed in', function() {
+    const { x, y, z } = exampleVec3;
+    const vec3LikeObject = { x, y, z };
+    const converted = convertToVector3(vec3LikeObject);
+
+    expect(vec3LikeObject).not.toBe(converted);
+    expect(vec3LikeObject.x).toEqual(converted.x);
+    expect(vec3LikeObject.y).toEqual(converted.y);
+    expect(vec3LikeObject.z).toEqual(converted.z);
+  });
+
+  it('should return an similar Vector3 if an Array is passed in', function() {
+    const { x, y, z } = exampleVec3;
+    const array = [x, y, z];
+    const converted = convertToVector3(array);
+
+    expect(array).not.toBe(converted);
+    expect(array[0]).toEqual(converted.x);
+    expect(array[1]).toEqual(converted.y);
+    expect(array[2]).toEqual(converted.z);
+  });
+});


### PR DESCRIPTION
In case the Vector3 `instanceof` doesn't match, but the object still has `{x,y,z}` values

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) 
No doc change needed


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Kind of a bugfix/code hardening


* **What is the current behavior?** (You can also link to an open issue here)
If an object fails the `instanceof` check(which is currently happening for me, likely a webpack issue), it attempts to grab array values that don't exist, passing undefined to the constructor giving you a Vector3 of [0,0,0].


* **What is the new behavior (if this is a feature change)?**
passing in a Vector3-like object will be properly converted to a Vector3


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It is technically breaking if you were using it wrong, but no behavior change for the expected inputs.

