### PR TITLE
fix: 🐛 Fix SUV calculation if fractional seconds not present

### DIFF
--- a/src/util/calculateSUV.js
+++ b/src/util/calculateSUV.js
@@ -67,7 +67,7 @@ export default function(image, storedPixelValue, skipRescale = false) {
     seriesAcquisitionTime.minutes * 60 +
     seriesAcquisitionTime.hours * 60 * 60;
   const injectionStartTimeInSeconds =
-    fracToDec(startTime.fractionalSeconds) +
+    fracToDec(startTime.fractionalSeconds || 0) +
     startTime.seconds +
     startTime.minutes * 60 +
     startTime.hours * 60 * 60;


### PR DESCRIPTION
`radiopharmaceuticalStartTime.fractionalSeconds` was not being checked in the `injectionStartTimeInSeconds` calculation. The fractional seconds are optional, and if not present, would cause a NaN and the SUV calculation would fail.