### PR TITLE
feat: Add stats formatting to ProbeTool as a configuration option

### DIFF
--- a/src/tools/annotation/ProbeTool.js
+++ b/src/tools/annotation/ProbeTool.js
@@ -28,6 +28,24 @@ const logger = getLogger('tools:annotation:ProbeTool');
  */
 export default class ProbeTool extends BaseAnnotationTool {
   constructor(props = {}) {
+    function defaultBuildStatsStr(storedPixels, sp, mo, suv, image) {
+      let str;
+
+      if (image.color) {
+        str = `R: ${storedPixels[0]} G: ${storedPixels[1]} B: ${
+          storedPixels[2]
+        }`;
+      } else {
+        // Draw text
+        str = `SP: ${sp} MO: ${parseFloat(mo.toFixed(3))}`;
+        if (suv) {
+          str += ` SUV: ${parseFloat(suv.toFixed(3))}`;
+        }
+      }
+
+      return str;
+    }
+
     const defaultProps = {
       name: 'Probe',
       supportedInteractionTypes: ['Mouse', 'Touch'],
@@ -35,6 +53,7 @@ export default class ProbeTool extends BaseAnnotationTool {
       configuration: {
         drawHandles: true,
         renderDashed: false,
+        buildStatsStr: defaultBuildStatsStr,
       },
     };
 
@@ -145,6 +164,7 @@ export default class ProbeTool extends BaseAnnotationTool {
     const { image, element } = eventData;
     const fontHeight = textStyle.getFontSize();
     const lineDash = getModule('globalConfiguration').configuration.lineDash;
+    const buildStatsStr = this.configuration.buildStatsStr;
 
     for (let i = 0; i < toolData.data.length; i++) {
       const data = toolData.data[i];
@@ -182,18 +202,7 @@ export default class ProbeTool extends BaseAnnotationTool {
 
         if (x >= 0 && y >= 0 && x < image.columns && y < image.rows) {
           text = `${x}, ${y}`;
-
-          if (image.color) {
-            str = `R: ${storedPixels[0]} G: ${storedPixels[1]} B: ${
-              storedPixels[2]
-            }`;
-          } else {
-            // Draw text
-            str = `SP: ${sp} MO: ${parseFloat(mo.toFixed(3))}`;
-            if (suv) {
-              str += ` SUV: ${parseFloat(suv.toFixed(3))}`;
-            }
-          }
+          str = buildStatsStr(storedPixels, sp, mo, suv, image);
 
           // Coords for text
           const coords = {

--- a/src/tools/annotation/ProbeTool.test.js
+++ b/src/tools/annotation/ProbeTool.test.js
@@ -55,6 +55,13 @@ describe('ProbeTool.js', () => {
 
       expect(instantiatedTool.name).toEqual(customToolName.name);
     });
+
+    it('can be created with a custom buildStatsStr callback', () => {
+      const customToolName = { configuration: { buildStatsStr: () => 'TEST' } };
+      const instantiatedTool = new ProbeTool(customToolName);
+
+      expect(instantiatedTool.configuration.buildStatsStr()).toEqual('TEST');
+    });
   });
 
   describe('createNewMeasurement', () => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
It's the fix of #1285 for ProbeTool

* **What is the new behavior (if this is a feature change)?**
It introduces an configuration option `buildStatsStr` for ProbeTool which allows for customization of a text displayed by the tool.

Example usage:
```
function buildStatsStr(storedPixels, sp, mo, suv, image) {
  return image.color
    ? `Red: ${storedPixels[0]} Green: ${storedPixels[1]} Blue: ${storedPixels[2]}`
    : `Raw pixel value: ${sp}`;
}

cornerstoneTools.addToolForElement(element, cornerstoneTools['ProbeTool'], { name: 'Probe', configuration: { buildStatsStr } });
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
