### PR TITLE
feat(Synchronizer): Change Scope of Event handlers

### DIFF
--- a/src/synchronization/Synchronizer.js
+++ b/src/synchronization/Synchronizer.js
@@ -156,7 +156,7 @@ function Synchronizer(event, handler) {
    * @param {Object} eventData - The data object for the source event
    * @returns {void}
    */
-  function fireEvent(sourceElement, eventData) {
+  this.fireEvent = function(sourceElement, eventData) {
     const isDisabled = !that.enabled;
     const noElements = !sourceElements.length || !targetElements.length;
 
@@ -199,7 +199,7 @@ function Synchronizer(event, handler) {
       );
     });
     ignoreFiredEvents = false;
-  }
+  };
 
   /**
    * Call fireEvent if not ignoring events, and pass along event data
@@ -208,15 +208,15 @@ function Synchronizer(event, handler) {
    * @param {Event} e - The source event object
    * @returns {void}
    */
-  function onEvent(e) {
+  this.onEvent = function(e) {
     const eventData = e.detail;
 
     if (ignoreFiredEvents === true) {
       return;
     }
 
-    fireEvent(e.currentTarget, eventData);
-  }
+    that.fireEvent(e.currentTarget, eventData);
+  };
 
   /**
    * Add a source element to this synchronizer
@@ -237,7 +237,7 @@ function Synchronizer(event, handler) {
 
     // Subscribe to the event
     event.split(' ').forEach(oneEvent => {
-      element.addEventListener(oneEvent, onEvent);
+      element.addEventListener(oneEvent, that.onEvent);
     });
 
     // Update the initial distances between elements
@@ -302,14 +302,14 @@ function Synchronizer(event, handler) {
 
     // Stop listening for the event
     event.split(' ').forEach(oneEvent => {
-      element.removeEventListener(oneEvent, onEvent);
+      element.removeEventListener(oneEvent, that.onEvent);
     });
 
     // Update the initial distances between elements
     that.getDistances();
 
     // Update everyone listening for events
-    fireEvent(element);
+    that.fireEvent(element);
     that.updateDisableHandlers();
   };
 


### PR DESCRIPTION
Set fireEvent and onEvent functions from anonymous inner functions to object keys, to allow consumers to monkeypatch the functions of need be.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor feature


* **What is the current behavior?** (You can also link to an open issue here)
Anonymous inner functions in the Synchronizer class cannot be accessed or changed.


* **What is the new behavior (if this is a feature change)?**
The changes allow for consumers to modify/extend Synchronizer behavior without having to create a whole new class


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

