### PR TITLE
fix(drawing/drawRect.js): Fixes the fillStyle feature of drawRect.js

### DIFF
--- a/src/drawing/drawRect.js
+++ b/src/drawing/drawRect.js
@@ -85,11 +85,8 @@ export default function(
   path(context, options, context => {
     context.moveTo(corner1.x, corner1.y);
     context.lineTo(corner3.x, corner3.y);
-    context.moveTo(corner3.x, corner3.y);
     context.lineTo(corner2.x, corner2.y);
-    context.moveTo(corner2.x, corner2.y);
     context.lineTo(corner4.x, corner4.y);
-    context.moveTo(corner4.x, corner4.y);
     context.lineTo(corner1.x, corner1.y);
   });
 }


### PR DESCRIPTION
`drawRect` was using a `moveTo` command between each `lineTo` which meant there was no polygon to fill. Removing the extra `moveTo` calls fixes `fillStyle`

Fixes #1299

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Fix the `fillStyle` option on `drawRect`.
For details see #1299 

## Visual tests using the RectangleROI tool example

> Note that if you look closely, the corners are not connected in the before version

**Before:**

![Screen Shot 2020-08-27 at 10 00 37 am](https://user-images.githubusercontent.com/814227/91368763-42427980-e84d-11ea-900e-7f715627a5ea.png)

**After:**

![Screen Shot 2020-08-27 at 9 59 31 am](https://user-images.githubusercontent.com/814227/91368770-45d60080-e84d-11ea-9023-1d81bb9a85b7.png)

## Visual tests using a the example in #1299 

**Before:**
![Screen Shot 2020-08-27 at 10 12 31 am](https://user-images.githubusercontent.com/814227/91369061-0fe54c00-e84e-11ea-973b-fa255a355e83.png)

**After:**
![Screen Shot 2020-08-27 at 10 12 44 am](https://user-images.githubusercontent.com/814227/91369068-170c5a00-e84e-11ea-863e-a5bd919fdec7.png)

[![Edit hungry-mcclintock-ebt3s](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/hungry-mcclintock-ebt3s?fontsize=14&hidenavigation=1&theme=dark)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
