### PR TITLE
feat(RotateTool): Add rounded/integer angles option

### DIFF
--- a/src/synchronization/Synchronizer.js
+++ b/src/synchronization/Synchronizer.js
@@ -156,7 +156,7 @@ function Synchronizer(event, handler) {
    * @param {Object} eventData - The data object for the source event
    * @returns {void}
    */
-  function fireEvent(sourceElement, eventData) {
+  this.fireEvent = function(sourceElement, eventData) {
     const isDisabled = !that.enabled;
     const noElements = !sourceElements.length || !targetElements.length;
 
@@ -199,7 +199,7 @@ function Synchronizer(event, handler) {
       );
     });
     ignoreFiredEvents = false;
-  }
+  };
 
   /**
    * Call fireEvent if not ignoring events, and pass along event data
@@ -208,15 +208,15 @@ function Synchronizer(event, handler) {
    * @param {Event} e - The source event object
    * @returns {void}
    */
-  function onEvent(e) {
+  this.onEvent = function(e) {
     const eventData = e.detail;
 
     if (ignoreFiredEvents === true) {
       return;
     }
 
-    fireEvent(e.currentTarget, eventData);
-  }
+    that.fireEvent(e.currentTarget, eventData);
+  };
 
   /**
    * Add a source element to this synchronizer
@@ -237,7 +237,7 @@ function Synchronizer(event, handler) {
 
     // Subscribe to the event
     event.split(' ').forEach(oneEvent => {
-      element.addEventListener(oneEvent, onEvent);
+      element.addEventListener(oneEvent, that.onEvent);
     });
 
     // Update the initial distances between elements
@@ -302,14 +302,14 @@ function Synchronizer(event, handler) {
 
     // Stop listening for the event
     event.split(' ').forEach(oneEvent => {
-      element.removeEventListener(oneEvent, onEvent);
+      element.removeEventListener(oneEvent, that.onEvent);
     });
 
     // Update the initial distances between elements
     that.getDistances();
 
     // Update everyone listening for events
-    fireEvent(element);
+    that.fireEvent(element);
     that.updateDisableHandlers();
   };
 

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -82,7 +82,7 @@ function defaultStrategy(evt) {
   );
 
   if (roundAngles) {
-    angleInfo.angle = Math.round(angleInfo.angle);
+    angleInfo.angle = Math.ceil(angleInfo.angle);
   }
   if (angleInfo.direction < 0) {
     angleInfo.angle = -angleInfo.angle;
@@ -99,7 +99,7 @@ const horizontalStrategy = evt => {
   let angle = deltaPoints.page.x / viewport.scale;
 
   if (roundAngles) {
-    angle = Math.round(angle);
+    angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
   }
 
   viewport.rotation += angle;
@@ -113,7 +113,7 @@ const verticalStrategy = evt => {
   let angle = deltaPoints.page.y / viewport.scale;
 
   if (roundAngles) {
-    angle = Math.round(angle);
+    angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
   }
 
   viewport.rotation += angle;

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -22,6 +22,9 @@ export default class RotateTool extends BaseTool {
       },
       defaultStrategy: 'default',
       supportedInteractionTypes: ['Mouse', 'Touch'],
+      configuration: {
+        roundAngles: false,
+      },
       svgCursor: rotateCursor,
     };
 
@@ -48,6 +51,7 @@ export default class RotateTool extends BaseTool {
 }
 
 function defaultStrategy(evt) {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { element, viewport } = eventData;
   const initialRotation = viewport.initialRotation;
@@ -77,6 +81,9 @@ function defaultStrategy(evt) {
     currentPoints
   );
 
+  if (roundAngles) {
+    angleInfo.angle = Math.round(angleInfo.angle);
+  }
   if (angleInfo.direction < 0) {
     angleInfo.angle = -angleInfo.angle;
   }
@@ -85,15 +92,29 @@ function defaultStrategy(evt) {
 }
 
 const horizontalStrategy = evt => {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
-  viewport.rotation += deltaPoints.page.x / viewport.scale;
+  let angle = deltaPoints.page.x / viewport.scale;
+
+  if (roundAngles) {
+    angle = Math.round(angle);
+  }
+
+  viewport.rotation += angle;
 };
 
 const verticalStrategy = evt => {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
-  viewport.rotation += deltaPoints.page.y / viewport.scale;
+  let angle = deltaPoints.page.y / viewport.scale;
+
+  if (roundAngles) {
+    angle = Math.round(angle);
+  }
+
+  viewport.rotation += angle;
 };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a rounding option to the RotateTool that rounds to integer numbers when configured.


* **What is the current behavior?** (You can also link to an open issue here)
No integer rounding is applied, and the scale/angle values create tiny fractional angles, which do not display well. We could round the display of these numbers, but other logic in a vtkView uses whole integer angles.
![image](https://user-images.githubusercontent.com/1474137/94213061-c6a70d00-fe8a-11ea-89ec-42890491e752.png)


* **What is the new behavior (if this is a feature change)?**
Optional config for the `RotateTool` allows for rotating at whole integer increments, rounding up to the nearest angle.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
#hacktober!
