### PR TITLE
feat(RotateTool): Add rounded/integer angles option

### DIFF
--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -93,7 +93,7 @@ function defaultStrategy(evt) {
   viewport.rotation = initialRotation + angleInfo.angle;
 }
 
-const horizontalStrategy = evt => {
+function horizontalStrategy(evt) {
   const { roundAngles, flipHorizontal } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
@@ -108,9 +108,9 @@ const horizontalStrategy = evt => {
   }
 
   viewport.rotation += angle;
-};
+}
 
-const verticalStrategy = evt => {
+function verticalStrategy(evt) {
   const { roundAngles, flipVertical } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
@@ -125,4 +125,4 @@ const verticalStrategy = evt => {
   }
 
   viewport.rotation += angle;
-};
+}

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -82,7 +82,7 @@ function defaultStrategy(evt) {
   );
 
   if (roundAngles) {
-    angleInfo.angle = Math.round(angleInfo.angle);
+    angleInfo.angle = Math.ceil(angleInfo.angle);
   }
   if (angleInfo.direction < 0) {
     angleInfo.angle = -angleInfo.angle;
@@ -99,7 +99,7 @@ const horizontalStrategy = evt => {
   let angle = deltaPoints.page.x / viewport.scale;
 
   if (roundAngles) {
-    angle = Math.round(angle);
+    angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
   }
 
   viewport.rotation += angle;
@@ -113,7 +113,7 @@ const verticalStrategy = evt => {
   let angle = deltaPoints.page.y / viewport.scale;
 
   if (roundAngles) {
-    angle = Math.round(angle);
+    angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
   }
 
   viewport.rotation += angle;

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -22,6 +22,9 @@ export default class RotateTool extends BaseTool {
       },
       defaultStrategy: 'default',
       supportedInteractionTypes: ['Mouse', 'Touch'],
+      configuration: {
+        roundAngles: false,
+      },
       svgCursor: rotateCursor,
     };
 
@@ -48,6 +51,7 @@ export default class RotateTool extends BaseTool {
 }
 
 function defaultStrategy(evt) {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { element, viewport } = eventData;
   const initialRotation = viewport.initialRotation;
@@ -77,6 +81,9 @@ function defaultStrategy(evt) {
     currentPoints
   );
 
+  if (roundAngles) {
+    angleInfo.angle = Math.round(angleInfo.angle);
+  }
   if (angleInfo.direction < 0) {
     angleInfo.angle = -angleInfo.angle;
   }
@@ -85,15 +92,29 @@ function defaultStrategy(evt) {
 }
 
 const horizontalStrategy = evt => {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
-  viewport.rotation += deltaPoints.page.x / viewport.scale;
+  let angle = deltaPoints.page.x / viewport.scale;
+
+  if (roundAngles) {
+    angle = Math.round(angle);
+  }
+
+  viewport.rotation += angle;
 };
 
 const verticalStrategy = evt => {
+  const { roundAngles } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
-  viewport.rotation += deltaPoints.page.y / viewport.scale;
+  let angle = deltaPoints.page.y / viewport.scale;
+
+  if (roundAngles) {
+    angle = Math.round(angle);
+  }
+
+  viewport.rotation += angle;
 };

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -24,6 +24,8 @@ export default class RotateTool extends BaseTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         roundAngles: false,
+        flipHorizontal: false,
+        flipVertical: false,
       },
       svgCursor: rotateCursor,
     };
@@ -92,7 +94,7 @@ function defaultStrategy(evt) {
 }
 
 const horizontalStrategy = evt => {
-  const { roundAngles } = this.configuration;
+  const { roundAngles, flipHorizontal } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
@@ -101,12 +103,15 @@ const horizontalStrategy = evt => {
   if (roundAngles) {
     angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
   }
+  if (flipHorizontal) {
+    angle = -angle;
+  }
 
   viewport.rotation += angle;
 };
 
 const verticalStrategy = evt => {
-  const { roundAngles } = this.configuration;
+  const { roundAngles, flipVertical } = this.configuration;
   const eventData = evt.detail;
   const { viewport, deltaPoints } = eventData;
 
@@ -114,6 +119,9 @@ const verticalStrategy = evt => {
 
   if (roundAngles) {
     angle = Math[angle > 0 ? 'ceil' : 'floor'](angle);
+  }
+  if (flipVertical) {
+    angle = -angle;
   }
 
   viewport.rotation += angle;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a rounding option to the RotateTool that rounds to integer numbers when configured.
Adds flipping direction option to change the CW/CCW direction that the mouse movement affects when using vertical/horizontal strategies


* **What is the current behavior?** (You can also link to an open issue here)
No integer rounding is applied, and the scale/angle values create tiny fractional angles, which do not display well. We could round the display of these numbers, but other logic in a vtkView uses whole integer angles.
![image](https://user-images.githubusercontent.com/1474137/94213061-c6a70d00-fe8a-11ea-89ec-42890491e752.png)
Vertical strategy, down mousemovement is CW, and up is CCW.

* **What is the new behavior (if this is a feature change)?**
Optional config for the `RotateTool` allows for rotating at whole integer increments, rounding up to the nearest angle.
Vertical/horizontal strategy users can choose the rotation direction relative to the mouse. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
#hacktober! (boo I'm too early)
