### PR TITLE
Request pool manager options

### DIFF
--- a/src/requestPool/requestPoolManager.js
+++ b/src/requestPool/requestPoolManager.js
@@ -30,7 +30,7 @@ function addRequest(
   doneCallback,
   failCallback,
   addToBeginning,
-  options
+  options = {}
 ) {
   if (!requestPool.hasOwnProperty(type)) {
     throw new Error(

--- a/src/requestPool/requestPoolManager.js
+++ b/src/requestPool/requestPoolManager.js
@@ -152,8 +152,6 @@ function sendRequest(requestDetails) {
 
   const priority = requestTypeToLoadPriority(requestDetails);
 
-  let loader;
-
   const options = Object.assign(
     {},
     {
@@ -162,6 +160,8 @@ function sendRequest(requestDetails) {
     },
     requestDetails.options
   );
+
+  let loader;
 
   if (requestDetails.preventCache === true) {
     loader = cornerstone.loadImage(imageId, options);

--- a/src/requestPool/requestPoolManager.js
+++ b/src/requestPool/requestPoolManager.js
@@ -152,14 +152,10 @@ function sendRequest(requestDetails) {
 
   const priority = requestTypeToLoadPriority(requestDetails);
 
-  const options = Object.assign(
-    {},
-    {
-      priority,
-      type: requestDetails.type,
-    },
-    requestDetails.options
-  );
+  const options = Object.assign({}, requestDetails.options, {
+    priority,
+    type: requestDetails.type,
+  });
 
   let loader;
 

--- a/src/requestPool/requestPoolManager.js
+++ b/src/requestPool/requestPoolManager.js
@@ -29,7 +29,8 @@ function addRequest(
   preventCache,
   doneCallback,
   failCallback,
-  addToBeginning
+  addToBeginning,
+  options
 ) {
   if (!requestPool.hasOwnProperty(type)) {
     throw new Error(
@@ -48,6 +49,7 @@ function addRequest(
     preventCache,
     doneCallback,
     failCallback,
+    options,
   };
 
   // If this imageId is in the cache, resolve it immediately
@@ -152,16 +154,19 @@ function sendRequest(requestDetails) {
 
   let loader;
 
+  const options = Object.assign(
+    {},
+    {
+      priority,
+      type: requestDetails.type,
+    },
+    requestDetails.options
+  );
+
   if (requestDetails.preventCache === true) {
-    loader = cornerstone.loadImage(imageId, {
-      priority,
-      type: requestDetails.type,
-    });
+    loader = cornerstone.loadImage(imageId, options);
   } else {
-    loader = cornerstone.loadAndCacheImage(imageId, {
-      priority,
-      type: requestDetails.type,
-    });
+    loader = cornerstone.loadAndCacheImage(imageId, options);
   }
 
   // Load and cache the image


### PR DESCRIPTION
Cornerstone imageLoaders registered to cornerstone can take options which may specific to the loader themselves.

This PR adds an argument to the request pool manager to pass options down options to its managed `cornerstone.loadImage` and `cornerstone.loadAndCacheImage` calls.

These options are merged with the default options request pool manager provides.