### PR TITLE
Fix segmentsOnLabelmap recalculation on undo and redo

### DIFF
--- a/src/store/modules/segmentationModule/history.test.js
+++ b/src/store/modules/segmentationModule/history.test.js
@@ -13,6 +13,7 @@ jest.mock('./getLabelmaps3D', () => ({
 jest.mock('../../../externalModules.js', () => ({
   cornerstone: {
     updateImage: jest.fn(),
+    triggerEvent: jest.fn(),
   },
 }));
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

1. Recalculation of segmentsOnLabelmap when triggering a undo or redo
2. Trigger labelmapmodified event on undo and redo

See: [https://github.com/cornerstonejs/cornerstoneTools/issues/1333](url)

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
never contributed to an opensource project before ^_^, hope i don't break anything
