### PR TITLE
Improvement Volume statistics: Delay get of ImagePlane metadata

### DIFF
--- a/src/store/modules/segmentationModule/getLabelmapStats.js
+++ b/src/store/modules/segmentationModule/getLabelmapStats.js
@@ -43,15 +43,6 @@ export default function getLabelmapStats(
       resolve(null);
     }
 
-    const { sufficientMetadata, imagePlanes } = _getImagePlanes(imageIds);
-
-    if (!sufficientMetadata) {
-      logger.warn(
-        'Insufficient imagePlaneModule information to calculate volume statistics.'
-      );
-      resolve(null);
-    }
-
     labelmapIndex =
       labelmapIndex === undefined
         ? brushStackState.activeLabelmapIndex
@@ -66,13 +57,21 @@ export default function getLabelmapStats(
     }
 
     Promise.all(imagePromises).then(images => {
-      const stats = _calculateLabelmapStats(
-        labelmap3D,
-        images,
-        imagePlanes,
-        segmentIndex
-      );
+      let stats;
+      const { sufficientMetadata, imagePlanes } = _getImagePlanes(imageIds);
 
+      if (sufficientMetadata) {
+        stats = _calculateLabelmapStats(
+          labelmap3D,
+          images,
+          imagePlanes,
+          segmentIndex
+        );
+      } else {
+        logger.warn(
+          'Insufficient imagePlaneModule information to calculate volume statistics.'
+        );
+      }
       resolve(stats);
     });
   });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** Improvement / Bug fix

The volume statistics calculation gets the imagePlanes metadata before prefetching all the images of a stack. This can result in an error, if you did not prefetch all your images beforehand


* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/cornerstonejs/cornerstoneTools/issues/1335


* **What is the new behavior (if this is a feature change)?**

The behavior remains the same, it will just introduce less bugs in applications that don't prefetch their complete stack


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**:
