### PR TITLE
Remove any orphaned event listeners on disable (#1337)

### DIFF
--- a/src/eventListeners/mouseEventListeners.js
+++ b/src/eventListeners/mouseEventListeners.js
@@ -10,6 +10,8 @@ let isClickEvent = true;
 let preventClickTimeout;
 const clickDelay = 200;
 
+const addedListeners = new Map();
+
 function getEventButtons(event) {
   if (typeof event.buttons === 'number') {
     return event.buttons;
@@ -264,6 +266,8 @@ function mouseDown(e) {
 
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
+    addedListeners.delete(onMouseMove);
+    addedListeners.delete(onMouseUp);
 
     element.addEventListener('mousemove', mouseMove);
 
@@ -272,6 +276,8 @@ function mouseDown(e) {
 
   document.addEventListener('mousemove', onMouseMove);
   document.addEventListener('mouseup', onMouseUp);
+  addedListeners.set(onMouseMove, 'mousemove');
+  addedListeners.set(onMouseUp, 'mouseup');
 }
 
 function mouseMove(e) {
@@ -356,6 +362,11 @@ function disable(element) {
   element.removeEventListener('mousedown', mouseDown);
   element.removeEventListener('mousemove', mouseMove);
   element.removeEventListener('dblclick', mouseDoubleClick);
+  // make sure we have removed any listeners that were added within the above listeners (#1337)
+  addedListeners.forEach((listener, event) => {
+    document.removeEventListener(event, listener);
+  });
+  addedListeners.clear();
 }
 
 function enable(element) {

--- a/src/eventListeners/mouseEventListeners.js
+++ b/src/eventListeners/mouseEventListeners.js
@@ -362,7 +362,7 @@ function disable(element) {
   element.removeEventListener('mousedown', mouseDown);
   element.removeEventListener('mousemove', mouseMove);
   element.removeEventListener('dblclick', mouseDoubleClick);
-  // make sure we have removed any listeners that were added within the above listeners (#1337)
+  // Make sure we have removed any listeners that were added within the above listeners (#1337)
   addedListeners.forEach((listener, event) => {
     document.removeEventListener(event, listener);
   });

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -236,6 +236,7 @@ function _moveEndHandler(
 ) {
   const eventData = evt.detail;
   const { element, currentPoints } = eventData;
+  let moveNewHandleSuccessful = true;
 
   if (options.hasMoved === false) {
     return;
@@ -289,6 +290,7 @@ function _moveEndHandler(
     anyHandlesOutsideImage(evt.detail, annotation.handles)
   ) {
     annotation.cancelled = true;
+    moveNewHandleSuccessful = false;
     removeToolState(element, toolName, annotation);
   }
 
@@ -301,7 +303,7 @@ function _moveEndHandler(
       moveEndHandler,
     },
     doneMovingCallback,
-    true
+    moveNewHandleSuccessful
   );
 }
 


### PR DESCRIPTION
This fixes #1337.  No breaking changes.  Just mitigating exceptions.

Currently, if you disable an element while a mouse button is held down, the two `onMouseMove` and `onMouseUp` listeners that are added _by_ the `mousedown` handler are not removed, causing an endless stream of exceptions.

To fix this, I've added a `Map` called `addedListeners` in the parent scope.  When `mousedown` is invoked, its `onMouseMove` and `onMouseUp` listeners get added to that Map.  If the problem scenario occurs, we now have a handle to all the generated listeners so we can remove them in the `disable` function.

I used the listener functions themselves as the keys in the Map because it is possible to have multiple `mousedown` and `mousemove` listeners when you have more than one mouse button pressed.