### PR TITLE
fix(EllipticalRoiTool): Push stdDev to separate line for non-SUV modalities

### DIFF
--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -397,7 +397,8 @@ function _createTextBoxContent(
       otherLines.push(`${meanString}${meanSuvString}`);
       otherLines.push(`${stdDevString}     ${stdDevSuvString}`);
     } else {
-      otherLines.push(`${meanString}     ${stdDevString}`);
+      otherLines.push(`${meanString}`);
+      otherLines.push(`${stdDevString}`);
     }
 
     if (showMinMax) {


### PR DESCRIPTION
This is the same fix with #1320 for Elliptical ROI