### PR TITLE
fix: addNewMeasurement of touch event move handle bug, when meatureme…

### DIFF
--- a/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/touchEventHandlers/addNewMeasurement.js
@@ -2,7 +2,7 @@ import EVENTS from '../../events.js';
 import external from '../../externalModules.js';
 import { state } from '../../store/index.js';
 import anyHandlesOutsideImage from './../../manipulators/anyHandlesOutsideImage.js';
-import { moveNewHandle } from '../../manipulators/index.js';
+import { moveHandle, moveNewHandle } from '../../manipulators/index.js';
 import {
   addToolState,
   removeToolState,
@@ -58,7 +58,12 @@ export default function(evt, tool) {
 
   external.cornerstone.updateImage(element);
 
-  moveNewHandle(
+  const handleMover =
+    Object.keys(measurementData.handles).length === 1
+      ? moveHandle
+      : moveNewHandle;
+
+  handleMover(
     touchEventData,
     tool.name,
     measurementData,


### PR DESCRIPTION
…ntData.handle only one.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix: addNewMeasurement of touch event move handle bug, when meaturementData.handle only one

when i use TextMarker with my mobile, i meet a problem createMeasurement.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
