### PR TITLE
Fix - RotateTool for mobile devices

### DIFF
--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -57,14 +57,9 @@ function defaultStrategy(evt) {
   const { roundAngles, rotateScale } = this.configuration;
   const { element, viewport, startPoints, currentPoints } = evt.detail;
 
-  let prevInitialRotation;
-
-  if (viewport.initialRotation) {
-    prevInitialRotation = viewport.initialRotation;
-  } else {
-    prevInitialRotation = viewport.rotation;
-  }
-  const initialRotation = prevInitialRotation;
+  const initialRotation = viewport.initialRotation
+    ? viewport.initialRotation
+    : viewport.rotation;
 
   // Calculate the center of the image
   const rect = element.getBoundingClientRect(element);

--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -56,7 +56,15 @@ export default class RotateTool extends BaseTool {
 function defaultStrategy(evt) {
   const { roundAngles, rotateScale } = this.configuration;
   const { element, viewport, startPoints, currentPoints } = evt.detail;
-  const initialRotation = viewport.initialRotation;
+
+  let prevInitialRotation;
+
+  if (viewport.initialRotation) {
+    prevInitialRotation = viewport.initialRotation;
+  } else {
+    prevInitialRotation = viewport.rotation;
+  }
+  const initialRotation = prevInitialRotation;
 
   // Calculate the center of the image
   const rect = element.getBoundingClientRect(element);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Bug fix: The RotateTool does not work on mobile device.

* **What is the current behavior?** (You can also link to an open issue here)
    - The RotateTool does not work on mobile devices. viewport.initialRotation is undefined


* **What is the new behavior (if this is a feature change)?**
    - The RotateTool works fine on mobile devices.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
I modified function defaultStrategy(evt) in RotateTool.js.