### PR TITLE
Update deep merge to resolve target prototype

### DIFF
--- a/src/util/deepmerge.js
+++ b/src/util/deepmerge.js
@@ -68,7 +68,13 @@ const deepmerge = (target = {}, source = {}, optionsArgument) => {
       : cloneIfNecessary(source, optionsArgument);
   }
 
-  return mergeObject(target, source, optionsArgument);
+  const mergedObject = mergeObject(target, source, optionsArgument);
+
+  if (Object.getPrototypeOf(target) !== Object.prototype) {
+    Object.setPrototypeOf(mergedObject, Object.getPrototypeOf(target));
+  }
+
+  return mergedObject;
 };
 
 export default deepmerge;


### PR DESCRIPTION
- When using the tool option svgCursor, one has to use the MouseCursor to instantiate the cursor object: 
```
import csTools from 'cornerstone-tools';
const MouseCursor = csTools.importInternal('tools/cursors/MouseCursor');

const cursor = new MouseCursor(
  `
    <g fill="ACTIVE_COLOR" stroke="ACTIVE_COLOR">
      ...
    </g>
  `,
  {
    viewBox: {
      x: 100,
      y: 100,
    },
  }
);

cornerstoneTools.addTool(cornerstoneTools.AngleTool, {
    svgCursor: cursor,
  });
```
The problem is that when passing the cursor object (instance of MouseCursor) as an option to the tool constructor, the deep merge that happens in the base tool just ignores the target's prototype: https://github.com/cornerstonejs/cornerstoneTools/blob/4e77512b79edd6d271fd249f841a80f71bee7ef0/src/tools/base/BaseTool.js#L35

This causes errors because the methods used by cornerstone-tools to get the SVG just vanished.