### PR TITLE
fix(RotateTool.js): evaluation of initialRotation

### DIFF
--- a/src/tools/RotateTool.js
+++ b/src/tools/RotateTool.js
@@ -57,9 +57,7 @@ function defaultStrategy(evt) {
   const { roundAngles, rotateScale } = this.configuration;
   const { element, viewport, startPoints, currentPoints } = evt.detail;
 
-  const initialRotation = viewport.initialRotation
-    ? viewport.initialRotation
-    : viewport.rotation;
+  const initialRotation = viewport.initialRotation;
 
   // Calculate the center of the image
   const rect = element.getBoundingClientRect(element);


### PR DESCRIPTION
fix: RotateTool rotate too quick when viewport.initialRotation is 0

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
RotateTool rotate too quick when viewport.initialRotation is 0


* **What is the new behavior (if this is a feature change)?**
rotate normally


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
