### PR TITLE
Fixed deltaPoints always 0 bug

### DIFF
--- a/src/eventListeners/mouseEventListeners.js
+++ b/src/eventListeners/mouseEventListeners.js
@@ -304,7 +304,25 @@ function mouseMove(e) {
     startPoints.image
   );
 
-  let lastPoints = copyPoints(startPoints);
+ let lastPoints = {
+    page: { x: e.pageX - e.movementX, y: e.pageY - e.movementY },
+    image: external.cornerstone.pageToPixel(
+      element,
+      e.pageX - e.movementX,
+      e.pageY - e.movementY
+    ),
+    client: {
+      x: e.clientX - e.movementX,
+      y: e.clientY - e.movementY,
+    },
+  };
+
+  lastPoints.canvas = external.cornerstone.pixelToCanvas(
+    element,
+    lastPoints.image
+  );
+
+
 
   // Calculate our current points in page and image coordinates
   const currentPoints = {


### PR DESCRIPTION
Fixed deltaPoints always 0 bug

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

[I don't think currentPoints and lastPoints will be different when the mouse moves. I get deltaPoints. Image always {x:0,y:0}.](https://github.com/cornerstonejs/cornerstoneTools/issues/1470#issue-1205273979)

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Such as:
```
constructor(props = {}) {
...
this.updateOnMouseMove = true;
...
}

// When I move the mouse quickly, I need to decide whether to hide when I reach the boundary.
mouseMoveCallback(evt) {
//
const { element, currentPoints, image, deltaPoints } = evt.detail;
const borderDistance = 30;
const imageRect = {
left: 0 + borderDistance - deltaPoints.image.x * 2,
top: 0 + borderDistance - deltaPoints.image.y * 2,
width: image.width - borderDistance * 2 - deltaPoints.image.x * 2,
height: image.height - borderDistance * 2 - deltaPoints.image.y * 2,
};
...

const outside = cornerstoneMath.point.insideRect(data.handles.end, imageRect) === false;

data.visible = ! outside;
...
}

```
* **Other information**:
