### PR TITLE
fix(moveNewHandler): Avoid ghost annotations on fast mouse events

### DIFF
--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -46,7 +46,10 @@ export default function(evt, tool) {
         return;
       }
 
-      const isTooFast = new Date().getTime() - timestamp < 150;
+      const isTooFast =
+        tool.configuration && tool.configuration.ignoreFastEvents === true
+          ? new Date().getTime() - timestamp < 150
+          : false;
 
       if (success && isTooFast === false) {
         const eventType = EVENTS.MEASUREMENT_COMPLETED;

--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -46,10 +46,16 @@ export default function(evt, tool) {
         return;
       }
 
-      const isTooFast =
-        tool.configuration && tool.configuration.ignoreFastEvents === true
-          ? new Date().getTime() - timestamp < 150
-          : false;
+      const hasThreshold =
+        tool.configuration &&
+        Object(tool.configuration).hasOwnProperty(
+          'measurementCreationThreshold'
+        );
+
+      const isTooFast = hasThreshold
+        ? new Date().getTime() - timestamp <
+          tool.configuration.measurementCreationThreshold
+        : false;
 
       if (success && isTooFast === false) {
         const eventType = EVENTS.MEASUREMENT_COMPLETED;

--- a/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
+++ b/src/eventDispatchers/mouseEventHandlers/addNewMeasurement.js
@@ -32,6 +32,8 @@ export default function(evt, tool) {
       ? moveHandle
       : moveNewHandle;
 
+  const timestamp = new Date().getTime();
+
   handleMover(
     eventData,
     tool.name,
@@ -44,7 +46,9 @@ export default function(evt, tool) {
         return;
       }
 
-      if (success) {
+      const isTooFast = new Date().getTime() - timestamp < 150;
+
+      if (success && isTooFast === false) {
         const eventType = EVENTS.MEASUREMENT_COMPLETED;
         const eventData = {
           toolName: tool.name,


### PR DESCRIPTION
Issue: #1464 