### PR TITLE
playClip works better when timer fires slowly

### DIFF
--- a/src/stackTools/playClip.js
+++ b/src/stackTools/playClip.js
@@ -139,7 +139,7 @@ function playClip(element, framesPerSecond) {
     playClipData = {
       intervalId: undefined,
       framesPerSecond: 30,
-      lastFrameTimeStamp: undefined,
+      lastFrameTimeStamp: new Date().getTime(),
       frameRate: 0,
       frameTimeVector: undefined,
       ignoreFrameTimeVector: false,
@@ -182,15 +182,19 @@ function playClip(element, framesPerSecond) {
       startLoadingHandler,
       endLoadingHandler,
       errorLoadingHandler,
+      newlastFrameTimeStamp = new Date().getTime(),
+      deltatime = newlastFrameTimeStamp - playClipData.lastFrameTimeStamp,
+      frames = Math.round((playClipData.framesPerSecond / 1000) * deltatime),
       newImageIdIndex = stackData.currentImageIdIndex;
 
     const imageCount = stackData.imageIds.length;
 
     if (playClipData.reverse) {
-      newImageIdIndex--;
+      newImageIdIndex -= frames;
     } else {
-      newImageIdIndex++;
+      newImageIdIndex += frames;
     }
+    playClipData.lastFrameTimeStamp = newlastFrameTimeStamp;
 
     if (
       !playClipData.loop &&


### PR DESCRIPTION
### Video  Demo
https://youtu.be/C6jsGZfL82s

### Description

This change makes playClip playback keep real time by dropping missed frames if the computer cannot keep up with the requested framerate.  Without this change, providers perceive playback to "slow down."  With this change, the playback is always kept to "real time" at the expense of dropping frames that must be skipped.