### PR TITLE
[bugfix] give default values for cachedStats values to avoid undefined error

### DIFF
--- a/src/tools/annotation/EllipticalRoiTool.js
+++ b/src/tools/annotation/EllipticalRoiTool.js
@@ -355,7 +355,14 @@ function _getUnit(modality, showHounsfieldUnits) {
 function _createTextBoxContent(
   context,
   isColorImage,
-  { area, mean, stdDev, min, max, meanStdDevSUV } = {},
+  {
+    area = 0,
+    mean = 0,
+    stdDev = 0,
+    min = 0,
+    max = 0,
+    meanStdDevSUV = 0,
+  } = {},
   modality,
   hasPixelSpacing,
   options = {}

--- a/src/tools/annotation/RectangleRoiTool.js
+++ b/src/tools/annotation/RectangleRoiTool.js
@@ -478,7 +478,14 @@ function _getUnit(modality, showHounsfieldUnits) {
 function _createTextBoxContent(
   context,
   isColorImage,
-  { area, mean, stdDev, min, max, meanStdDevSUV },
+  {
+    area = 0,
+    mean = 0,
+    stdDev = 0,
+    min = 0,
+    max = 0,
+    meanStdDevSUV = 0,
+  } = {},
   modality,
   hasPixelSpacing,
   options = {}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix:
_createTextBoxContent() function call during rendering sometimes causes undefined error.

Current Behavior:
Ideal flow should be, first calculate all values of `cachedStats` and then call the `_createTextBoxContent()` function.
But in reality, particularly for the initial load, the `_createTextBoxContent()` function is called before the `cachedStats` values are calculated.

New behavior:
Gave default value: 0, for the `cachedStats` values that are being used by `_createTextBoxContent()`.
This will prevent `undefined` error until they are correctly caculcated.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
